### PR TITLE
fix: sanitize SVG for XML compatibility on flowchart download

### DIFF
--- a/frontend/src/components/studio/flow-diagrams/FlowDiagramViewer.tsx
+++ b/frontend/src/components/studio/flow-diagrams/FlowDiagramViewer.tsx
@@ -210,17 +210,14 @@ export const FlowDiagramViewer: React.FC<FlowDiagramViewerProps> = ({
 
     // Sanitize HTML void elements to be XML-compatible (self-closing)
     // This fixes: "Opening and ending tag mismatch: br line 1 and p"
+    // Uses negative lookahead (?![^>]*\/>) to skip already self-closing tags
     let sanitizedSvg = svgContent
-      // Convert void elements to self-closing format
-      .replace(/<br\s*>/gi, '<br/>')
-      .replace(/<hr\s*>/gi, '<hr/>')
-      .replace(/<img([^>]*)>/gi, '<img$1/>')
-      .replace(/<input([^>]*)>/gi, '<input$1/>')
-      .replace(/<meta([^>]*)>/gi, '<meta$1/>')
-      .replace(/<link([^>]*)>/gi, '<link$1/>')
-      // Also handle cases where there might be attributes before >
-      .replace(/<br\s+([^/>]*)\s*>/gi, '<br $1/>')
-      .replace(/<hr\s+([^/>]*)\s*>/gi, '<hr $1/>');
+      .replace(/<br(?![^>]*\/>)([^>]*)>/gi, '<br$1/>')
+      .replace(/<hr(?![^>]*\/>)([^>]*)>/gi, '<hr$1/>')
+      .replace(/<img(?![^>]*\/>)([^>]*)>/gi, '<img$1/>')
+      .replace(/<input(?![^>]*\/>)([^>]*)>/gi, '<input$1/>')
+      .replace(/<meta(?![^>]*\/>)([^>]*)>/gi, '<meta$1/>')
+      .replace(/<link(?![^>]*\/>)([^>]*)>/gi, '<link$1/>');
 
     const blob = new Blob([sanitizedSvg], { type: 'image/svg+xml' });
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
Mermaid with htmlLabels:true embeds HTML inside <foreignObject>. HTML void elements like <br> are valid HTML5 but invalid XML/SVG. This fix converts void elements to self-closing format before download.

Fixes: "Opening and ending tag mismatch: br line 1 and p" error

Before:
<img width="1366" height="643" alt="image" src="https://github.com/user-attachments/assets/02870cdc-46b2-4024-80dd-d1490720152a" />

After:
![diagram (2)](https://github.com/user-attachments/assets/bd629be3-028c-4f94-a941-3403c131126a)
