### PR TITLE
perf: fix chat input typing lag with React.memo

### DIFF
--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -25,7 +25,11 @@ interface ChatHeaderProps {
   onShowChatList: () => void;
 }
 
-export const ChatHeader: React.FC<ChatHeaderProps> = ({
+/**
+ * Memoized to prevent re-renders when typing in ChatInput
+ * Only re-renders when its props actually change
+ */
+export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
   activeChat,
   allChats,
   activeSources,
@@ -89,4 +93,4 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
       </p>
     </div>
   );
-};
+});

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -330,7 +330,13 @@ const LoadingIndicator: React.FC = () => (
   </div>
 );
 
-export const ChatMessages: React.FC<ChatMessagesProps> = ({ messages, sending, projectId }) => {
+/**
+ * ChatMessages Component - Memoized to prevent re-renders on parent state changes
+ * Educational Note: Without React.memo, every keystroke in ChatInput would
+ * re-render this entire component (expensive markdown parsing). Memoization
+ * ensures it only re-renders when messages, sending, or projectId actually change.
+ */
+export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({ messages, sending, projectId }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -409,4 +415,4 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({ messages, sending, p
       </div>
     </div>
   );
-};
+});

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -5,7 +5,7 @@
  * and manages chat state and API interactions.
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Sparkle, CircleNotch } from '@phosphor-icons/react';
 import { chatsAPI } from '@/lib/api/chats';
 import type { Chat, ChatMetadata, StudioSignal } from '@/lib/api/chats';
@@ -39,6 +39,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ projectId, projectName, so
 
   // Sources state for header display
   const [sources, setSources] = useState<Source[]>([]);
+
+  // Memoize active sources count to prevent recalculation on every render
+  const activeSources = useMemo(
+    () => sources.filter(s => s.status === 'ready' && s.active).length,
+    [sources]
+  );
 
   // Voice recording hook
   const {
@@ -369,7 +375,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ projectId, projectName, so
       <ChatHeader
         activeChat={activeChat}
         allChats={allChats}
-        activeSources={sources.filter(s => s.status === 'ready' && s.active).length}
+        activeSources={activeSources}
         totalSources={sources.length}
         onSelectChat={handleSelectChat}
         onNewChat={handleNewChat}


### PR DESCRIPTION
Memoize ChatMessages and ChatHeader components to prevent expensive re-renders on every keystroke. Also memoize filtered sources count in ChatPanel.

Before: typing caused full re-render cascade including markdown parsing
After: only ChatInput re-renders, instant character display