### PR TITLE
feat: admin model selector per use case

### DIFF
--- a/backend/app/api/settings/__init__.py
+++ b/backend/app/api/settings/__init__.py
@@ -40,3 +40,4 @@ from app.api.settings import processing  # noqa: F401
 from app.api.settings import databases  # noqa: F401
 from app.api.settings import mcp  # noqa: F401
 from app.api.settings import users  # noqa: F401
+from app.api.settings import models  # noqa: F401

--- a/backend/app/api/settings/models.py
+++ b/backend/app/api/settings/models.py
@@ -1,0 +1,143 @@
+"""
+Model settings endpoints - Admin-configurable Claude model per use case.
+
+Educational Note: Every prompt config has a baked-in model (Haiku, Sonnet, or
+Opus). This endpoint lets an admin override those models per category:
+
+    - chat:       main conversation, auto-naming, memory
+    - studio:     all content generation (audio, video, presentations, etc.)
+    - query:      database/csv/freshdesk analyzer agents
+    - extraction: background source processing (PDF, PPTX, image, CSV)
+
+Selecting "Default" (null) for a category clears the override so each prompt's
+own JSON-baked model is used — preserving intentional per-prompt tuning like
+presentation_agent=Opus.
+
+Overrides are stored as env vars in .env (same pattern as ANTHROPIC_TIER) and
+picked up on the next request via the PromptConfig dict subclass that resolves
+"model" dynamically.
+
+Routes:
+- GET  /settings/models - Current overrides + available models + categories
+- POST /settings/models - Set or clear overrides
+"""
+from flask import jsonify, request, current_app
+
+from app.api.settings import settings_bp
+from app.config import (
+    AVAILABLE_MODELS,
+    MODEL_CATEGORIES,
+    get_current_settings,
+)
+from app.services.app_settings import EnvService
+from app.services.auth.rbac import require_admin
+
+env_service = EnvService()
+
+
+@settings_bp.route('/settings/models', methods=['GET'])
+@require_admin
+def get_model_settings():
+    """
+    Return current per-category model overrides plus the lists needed to
+    render the admin UI.
+
+    Response:
+        {
+            "success": true,
+            "settings": {
+                "chat": "claude-opus-4-6" | null,
+                "studio": "claude-haiku-4-5-20251001" | null,
+                "query": null,
+                "extraction": null
+            },
+            "available_models": [
+                {"id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5", ...},
+                ...
+            ],
+            "categories": [
+                {"id": "chat", "label": "Chat", "description": "...", "env_var": "CHAT_MODEL_OVERRIDE"},
+                ...
+            ]
+        }
+    """
+    try:
+        return jsonify({
+            'success': True,
+            'settings': get_current_settings(),
+            'available_models': list(AVAILABLE_MODELS.values()),
+            'categories': list(MODEL_CATEGORIES.values()),
+        }), 200
+    except Exception as e:
+        current_app.logger.error(f"Error getting model settings: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@settings_bp.route('/settings/models', methods=['POST'])
+@require_admin
+def update_model_settings():
+    """
+    Update per-category model overrides.
+
+    Request body:
+        {
+            "chat": "claude-opus-4-6",          // set override
+            "studio": null,                      // clear override (use Default)
+            "query": "claude-haiku-4-5-20251001",
+            "extraction": null
+        }
+
+    Only categories present in the body are updated. Sending null or "" clears
+    the override for that category. Unknown categories or invalid model ids
+    return 400 without changing any values.
+    """
+    try:
+        data = request.get_json()
+        if data is None or not isinstance(data, dict):
+            return jsonify({
+                'success': False,
+                'error': 'Request body must be a JSON object mapping category → model id or null'
+            }), 400
+
+        # Validate everything before writing anything so a single bad entry
+        # doesn't leave the .env in a half-updated state.
+        validated: dict[str, str] = {}
+        for category, model_id in data.items():
+            if category not in MODEL_CATEGORIES:
+                return jsonify({
+                    'success': False,
+                    'error': f"Unknown category: {category}. Must be one of: {list(MODEL_CATEGORIES.keys())}"
+                }), 400
+
+            if model_id in (None, ""):
+                validated[category] = ""  # empty string = clear override
+                continue
+
+            if not isinstance(model_id, str) or model_id not in AVAILABLE_MODELS:
+                return jsonify({
+                    'success': False,
+                    'error': f"Invalid model for {category}: {model_id}. Must be one of: {list(AVAILABLE_MODELS.keys())}"
+                }), 400
+
+            validated[category] = model_id
+
+        # Apply all validated updates
+        for category, value in validated.items():
+            env_var = MODEL_CATEGORIES[category]["env_var"]
+            env_service.set_key(env_var, value)
+            current_app.logger.info(
+                "Updated %s to %r", env_var, value or "<cleared>"
+            )
+
+        # Reload .env so the new values are visible to os.environ immediately
+        env_service.reload_env()
+
+        return jsonify({
+            'success': True,
+            'message': 'Model settings updated successfully',
+            'settings': get_current_settings(),
+        }), 200
+
+    except Exception as e:
+        current_app.logger.error(f"Error updating model settings: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500

--- a/backend/app/api/settings/models.py
+++ b/backend/app/api/settings/models.py
@@ -28,6 +28,7 @@ from app.config import (
     AVAILABLE_MODELS,
     MODEL_CATEGORIES,
     get_current_settings,
+    get_all_default_models,
 )
 from app.services.app_settings import EnvService
 from app.services.auth.rbac import require_admin
@@ -62,11 +63,17 @@ def get_model_settings():
         }
     """
     try:
+        # `defaults` shows what each prompt actually resolves to when its
+        # category is set to "Default" — used by the UI to make Default
+        # honest about which models will be used (e.g. chat = mostly Sonnet
+        # but Haiku for chat_naming/memory).
+        defaults = get_all_default_models()
         return jsonify({
             'success': True,
             'settings': get_current_settings(),
             'available_models': list(AVAILABLE_MODELS.values()),
             'categories': list(MODEL_CATEGORIES.values()),
+            'defaults': defaults,
         }), 200
     except Exception as e:
         current_app.logger.error(f"Error getting model settings: {e}")

--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -36,6 +36,14 @@ from app.config.tier_loader import (
     OPENAI_TIERS,
     PINECONE_TIERS,
 )
+from app.config.model_loader import (
+    AVAILABLE_MODELS,
+    MODEL_CATEGORIES,
+    PROMPT_TO_CATEGORY,
+    get_category_override,
+    get_model_override_for_prompt,
+    get_current_settings,
+)
 
 __all__ = [
     "tool_loader",
@@ -54,4 +62,10 @@ __all__ = [
     "ANTHROPIC_TIERS",
     "OPENAI_TIERS",
     "PINECONE_TIERS",
+    "AVAILABLE_MODELS",
+    "MODEL_CATEGORIES",
+    "PROMPT_TO_CATEGORY",
+    "get_category_override",
+    "get_model_override_for_prompt",
+    "get_current_settings",
 ]

--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -43,6 +43,8 @@ from app.config.model_loader import (
     get_category_override,
     get_model_override_for_prompt,
     get_current_settings,
+    get_default_models_for_category,
+    get_all_default_models,
 )
 
 __all__ = [
@@ -68,4 +70,6 @@ __all__ = [
     "get_category_override",
     "get_model_override_for_prompt",
     "get_current_settings",
+    "get_default_models_for_category",
+    "get_all_default_models",
 ]

--- a/backend/app/config/model_loader.py
+++ b/backend/app/config/model_loader.py
@@ -1,0 +1,152 @@
+"""
+Model Loader - Admin-configurable Claude model overrides per use case.
+
+Educational Note: Every prompt config in `data/prompts/*.json` has a baked-in
+model (Haiku, Sonnet, or Opus). This module lets an admin override those models
+at runtime per category (chat, studio, query agents, source extraction) without
+editing 30+ JSON files.
+
+How it works:
+1. MODEL_CATEGORIES maps each category to an env var (e.g. CHAT_MODEL_OVERRIDE)
+2. PROMPT_TO_CATEGORY maps each prompt name (e.g. "default", "presentation_agent")
+   to its category
+3. prompt_loader consults this module when building a prompt config. If the
+   category's env var is set to a valid model id, it swaps config["model"].
+4. Empty / unset env var = "Default" (use whatever the prompt JSON declares)
+
+Persisted in .env, mirroring the existing ANTHROPIC_TIER pattern.
+"""
+import os
+from typing import Dict, Optional
+
+
+# The three Claude models we expose in the admin selector.
+# IDs must match what the Anthropic SDK accepts.
+AVAILABLE_MODELS: Dict[str, Dict] = {
+    "claude-haiku-4-5-20251001": {
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "description": "Fastest and cheapest. Best for simple or high-volume tasks.",
+        "pricing": {"input_per_mtok": 1.0, "output_per_mtok": 5.0},
+    },
+    "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "description": "Balanced speed and quality. Default for most tasks.",
+        "pricing": {"input_per_mtok": 3.0, "output_per_mtok": 15.0},
+    },
+    "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "description": "Most capable. Best for complex reasoning and high-quality generation.",
+        "pricing": {"input_per_mtok": 5.0, "output_per_mtok": 25.0},
+    },
+}
+
+
+# Use-case categories exposed in admin settings. Each maps to an env var.
+MODEL_CATEGORIES: Dict[str, Dict[str, str]] = {
+    "chat": {
+        "id": "chat",
+        "label": "Chat",
+        "description": "Main conversation, auto-naming, and memory updates.",
+        "env_var": "CHAT_MODEL_OVERRIDE",
+    },
+    "studio": {
+        "id": "studio",
+        "label": "Studio",
+        "description": "Audio, video, presentations, websites, emails, mind maps, quizzes, and other generation.",
+        "env_var": "STUDIO_MODEL_OVERRIDE",
+    },
+    "query": {
+        "id": "query",
+        "label": "Query Agents",
+        "description": "Database, CSV, and Freshdesk analysis agents.",
+        "env_var": "QUERY_MODEL_OVERRIDE",
+    },
+    "extraction": {
+        "id": "extraction",
+        "label": "Source Extraction",
+        "description": "Background processing: PDF, PPTX, image, CSV extraction and source summaries.",
+        "env_var": "EXTRACTION_MODEL_OVERRIDE",
+    },
+}
+
+
+# Maps prompt names (without the "_prompt" suffix) to their category.
+# Prompts not listed here (web_agent, deep_research_agent) keep their JSON-baked
+# model and are unaffected by admin overrides.
+PROMPT_TO_CATEGORY: Dict[str, str] = {
+    # Chat
+    "default": "chat",
+    "chat_naming": "chat",
+    "memory": "chat",
+    # Studio
+    "audio_script": "studio",
+    "video": "studio",
+    "mind_map": "studio",
+    "quiz": "studio",
+    "flash_cards": "studio",
+    "social_posts": "studio",
+    "infographic": "studio",
+    "flow_diagram": "studio",
+    "ad_creative": "studio",
+    "component_agent": "studio",
+    "wireframe_agent": "studio",
+    "wireframe": "studio",
+    "website_agent": "studio",
+    "presentation_agent": "studio",
+    "email_agent": "studio",
+    "blog_agent": "studio",
+    "prd_agent": "studio",
+    "business_report_agent": "studio",
+    "marketing_strategy_agent": "studio",
+    # Query agents
+    "database_analyzer_agent": "query",
+    "csv_analyzer_agent": "query",
+    "freshdesk_analyzer_agent": "query",
+    # Source extraction
+    "pdf_extraction": "extraction",
+    "pptx_extraction": "extraction",
+    "image_extraction": "extraction",
+    "csv_processor": "extraction",
+    "summary": "extraction",
+}
+
+
+def get_category_override(category: str) -> Optional[str]:
+    """
+    Read the override model for a category from the environment.
+
+    Returns the model id if the env var is set AND names a known model,
+    otherwise None (meaning "no override, use the prompt's own model").
+    """
+    category_info = MODEL_CATEGORIES.get(category)
+    if not category_info:
+        return None
+    value = os.environ.get(category_info["env_var"], "").strip()
+    if value and value in AVAILABLE_MODELS:
+        return value
+    return None
+
+
+def get_model_override_for_prompt(prompt_name: str) -> Optional[str]:
+    """
+    Given a prompt name (e.g. "default", "presentation_agent"), return the
+    admin-configured override model for its category, or None if no override
+    is set or the prompt is not categorized.
+    """
+    category = PROMPT_TO_CATEGORY.get(prompt_name)
+    if not category:
+        return None
+    return get_category_override(category)
+
+
+def get_current_settings() -> Dict[str, Optional[str]]:
+    """
+    Return the current override for every category.
+
+    Used by the GET /settings/models endpoint. A value of None means
+    "Default" (the prompt's own model is used).
+    """
+    return {cat_id: get_category_override(cat_id) for cat_id in MODEL_CATEGORIES}

--- a/backend/app/config/model_loader.py
+++ b/backend/app/config/model_loader.py
@@ -150,3 +150,45 @@ def get_current_settings() -> Dict[str, Optional[str]]:
     "Default" (the prompt's own model is used).
     """
     return {cat_id: get_category_override(cat_id) for cat_id in MODEL_CATEGORIES}
+
+
+def get_default_models_for_category(category: str) -> Dict[str, list]:
+    """
+    For a given category, return a map of {model_id: [prompt_names]} showing
+    which model each prompt in the category uses by default (i.e. its
+    JSON-baked model, ignoring any admin override).
+
+    Used by the settings UI to clearly explain what "Default" means for each
+    category — e.g., chat is mostly Sonnet but uses Haiku for chat_naming and
+    memory; studio is mostly Sonnet with three Opus prompts.
+    """
+    # Lazy import to avoid circular dependency at module load time
+    from app.config.prompt_loader import prompt_loader
+
+    breakdown: Dict[str, list] = {}
+    for prompt_name, cat in PROMPT_TO_CATEGORY.items():
+        if cat != category:
+            continue
+        config = prompt_loader.get_prompt_config(prompt_name)
+        if config is None:
+            continue
+        # Use raw_model() to bypass any active override and get the
+        # JSON-baked model — that's what "Default" actually resolves to.
+        model = config.raw_model() if hasattr(config, "raw_model") else config.get("model")
+        if not model:
+            continue
+        breakdown.setdefault(model, []).append(prompt_name)
+    # Sort prompt lists for stable output
+    for prompts in breakdown.values():
+        prompts.sort()
+    return breakdown
+
+
+def get_all_default_models() -> Dict[str, Dict[str, list]]:
+    """
+    Return {category_id: {model_id: [prompt_names]}} for every category.
+
+    Used by GET /settings/models so the frontend can render the per-prompt
+    default breakdown under each dropdown.
+    """
+    return {cat_id: get_default_models_for_category(cat_id) for cat_id in MODEL_CATEGORIES}

--- a/backend/app/config/prompt_loader.py
+++ b/backend/app/config/prompt_loader.py
@@ -32,6 +32,51 @@ from config import Config
 logger = logging.getLogger(__name__)
 
 
+class PromptConfig(dict):
+    """
+    Dict subclass whose "model" key is resolved dynamically on every access.
+
+    Services in this codebase often cache the result of
+    prompt_loader.get_prompt_config(...) in self._prompt_config and reuse it
+    for the lifetime of the process. If we mutated config["model"] once at
+    load time, an admin changing the model override later would not take
+    effect until restart.
+
+    By overriding __getitem__ and get for the "model" key, every lookup re-reads
+    the env-var-backed override. Services can keep caching the PromptConfig
+    instance (everything else is static) while still picking up admin changes
+    immediately.
+    """
+
+    def __init__(self, data: Dict[str, Any], prompt_name: Optional[str] = None):
+        super().__init__(data)
+        # Use object.__setattr__ to bypass dict semantics
+        object.__setattr__(self, "_prompt_name", prompt_name)
+
+    def _resolved_model(self) -> Optional[Any]:
+        # Lazy import to avoid circular dependency at module load time
+        from app.config.model_loader import get_model_override_for_prompt
+
+        prompt_name = object.__getattribute__(self, "_prompt_name")
+        if not prompt_name:
+            return None
+        return get_model_override_for_prompt(prompt_name)
+
+    def __getitem__(self, key):
+        if key == "model":
+            override = self._resolved_model()
+            if override:
+                return override
+        return super().__getitem__(key)
+
+    def get(self, key, default=None):
+        if key == "model":
+            override = self._resolved_model()
+            if override:
+                return override
+        return super().get(key, default)
+
+
 class PromptLoader:
     """
     Loader class for managing system prompts.
@@ -69,7 +114,7 @@ class PromptLoader:
             if "prompt" in prompt_data and "system_prompt" not in prompt_data:
                 prompt_data["system_prompt"] = prompt_data.pop("prompt")
 
-            return prompt_data
+            return PromptConfig(prompt_data, prompt_name="default")
 
     def get_default_prompt(self) -> str:
         """
@@ -141,6 +186,8 @@ class PromptLoader:
         except (FileNotFoundError, json.JSONDecodeError):
             pass
 
+        # get_default_prompt_config already returns a PromptConfig tagged with
+        # prompt_name="default" so the admin "chat" category override applies.
         return config
 
     def update_project_prompt(self, project_id: str, prompt: Optional[str]) -> bool:
@@ -252,7 +299,7 @@ class PromptLoader:
 
         try:
             with open(prompt_file, 'r') as f:
-                return json.load(f)
+                return PromptConfig(json.load(f), prompt_name=prompt_name)
         except (FileNotFoundError, json.JSONDecodeError):
             return None
 

--- a/backend/app/config/prompt_loader.py
+++ b/backend/app/config/prompt_loader.py
@@ -76,6 +76,16 @@ class PromptConfig(dict):
                 return override
         return super().get(key, default)
 
+    def raw_model(self) -> Optional[str]:
+        """
+        Return the JSON-baked model, bypassing any admin override.
+
+        Used by the settings UI to show what "Default" actually resolves to
+        for each prompt — so admins can see whether selecting Default keeps
+        Sonnet, Opus, Haiku, or a mix.
+        """
+        return super().get("model")
+
 
 class PromptLoader:
     """

--- a/backend/app/services/source_services/source_processing/csv_processor.py
+++ b/backend/app/services/source_services/source_processing/csv_processor.py
@@ -105,8 +105,13 @@ def process_csv(
         "extracted_at": datetime.now().isoformat()
     }
 
-    # CSV files are NOT embedded - we analyze them on-demand
+    # CSV files are NOT embedded - we analyze them on-demand.
+    # We must preserve file_extension/mime_type because main_chat_service
+    # routes CSV sources to the csv_analyzer_agent tool by checking
+    # embedding_info["file_extension"] == ".csv".
     embedding_info = {
+        "file_extension": ".csv",
+        "mime_type": "text/csv",
         "is_embedded": False,
         "embedded_at": None,
         "token_count": 0,

--- a/backend/app/services/source_services/source_processing/csv_processor.py
+++ b/backend/app/services/source_services/source_processing/csv_processor.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any
 
+from app.config import prompt_loader
 from app.services.integrations.supabase import storage_service
 from app.services.ai_services.csv_service import csv_service
 
@@ -113,10 +114,17 @@ def process_csv(
         "reason": "CSV files are analyzed on-demand, not embedded"
     }
 
-    # Summary comes from AI service (not separate summary_service)
+    # Summary comes from AI service (not separate summary_service).
+    # Pull the label from the live prompt config so the stored metadata
+    # reflects admin model overrides (extraction category) and stays accurate
+    # if the prompt's own model changes.
+    csv_prompt_config = prompt_loader.get_prompt_config("csv_processor")
+    summary_model = (
+        csv_prompt_config.get("model") if csv_prompt_config else "unknown"
+    )
     summary_info = {
         "summary": analysis_result.get("summary", ""),
-        "model": "claude-haiku-4-5-20251001",
+        "model": summary_model,
         "usage": analysis_result.get("usage", {}),
         "generated_at": analysis_result.get("generated_at", datetime.now().isoformat()),
         "strategy": "csv_analyzer",

--- a/backend/app/utils/cost_tracking.py
+++ b/backend/app/utils/cost_tracking.py
@@ -5,8 +5,9 @@ Educational Note: This utility tracks Claude API usage costs by model.
 Costs are stored in Supabase projects table and updated after each API call.
 
 Pricing (per 1M tokens):
+- Opus:   $5 input, $25 output
 - Sonnet: $3 input, $15 output
-- Haiku: $1 input, $5 output
+- Haiku:  $1 input, $5 output
 """
 import logging
 from typing import Dict, Any, Optional
@@ -17,9 +18,15 @@ logger = logging.getLogger(__name__)
 
 # Pricing per 1M tokens
 PRICING = {
+    "opus": {"input": 5.0, "output": 25.0},
     "sonnet": {"input": 3.0, "output": 15.0},
     "haiku": {"input": 1.0, "output": 5.0},
 }
+
+# Tracked model buckets, in stable order. Used by _get_default_costs and
+# _ensure_cost_structure so the breakdown always shows every model bucket
+# even if a project has only used some of them.
+_MODEL_KEYS = ("opus", "sonnet", "haiku")
 
 # Lock for thread-safe operations
 _lock = Lock()
@@ -27,22 +34,23 @@ _lock = Lock()
 
 def _get_model_key(model_string: str) -> str:
     """
-    Extract model key (sonnet/haiku) from full model string.
+    Extract model key (opus/sonnet/haiku) from full model string.
 
     Args:
         model_string: Full model ID like "claude-sonnet-4-6"
 
     Returns:
-        "sonnet" or "haiku"
+        "opus", "sonnet", or "haiku"
     """
     model_lower = model_string.lower()
+    if "opus" in model_lower:
+        return "opus"
     if "sonnet" in model_lower:
         return "sonnet"
-    elif "haiku" in model_lower:
+    if "haiku" in model_lower:
         return "haiku"
-    else:
-        # Default to sonnet pricing for unknown models
-        return "sonnet"
+    # Default to sonnet pricing for unknown models
+    return "sonnet"
 
 
 def _calculate_cost(model_key: str, input_tokens: int, output_tokens: int) -> float:
@@ -95,6 +103,10 @@ def _save_costs(project_id: str, costs: Dict[str, Any], user_id: Optional[str] =
         return False
 
 
+def _empty_bucket() -> Dict[str, Any]:
+    return {"input_tokens": 0, "output_tokens": 0, "cost": 0.0}
+
+
 def _get_default_costs() -> Dict[str, Any]:
     """
     Get default cost tracking structure.
@@ -104,18 +116,7 @@ def _get_default_costs() -> Dict[str, Any]:
     """
     return {
         "total_cost": 0.0,
-        "by_model": {
-            "sonnet": {
-                "input_tokens": 0,
-                "output_tokens": 0,
-                "cost": 0.0
-            },
-            "haiku": {
-                "input_tokens": 0,
-                "output_tokens": 0,
-                "cost": 0.0
-            }
-        }
+        "by_model": {key: _empty_bucket() for key in _MODEL_KEYS},
     }
 
 
@@ -135,13 +136,9 @@ def _ensure_cost_structure(costs: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     if "by_model" not in costs:
         costs["by_model"] = {}
 
-    for model in ["sonnet", "haiku"]:
+    for model in _MODEL_KEYS:
         if model not in costs["by_model"]:
-            costs["by_model"][model] = {
-                "input_tokens": 0,
-                "output_tokens": 0,
-                "cost": 0.0
-            }
+            costs["by_model"][model] = _empty_bucket()
 
     return costs
 

--- a/frontend/src/components/dashboard/AppSettings.tsx
+++ b/frontend/src/components/dashboard/AppSettings.tsx
@@ -19,6 +19,7 @@ import {
   IntegrationsSection,
   SystemSection,
   DesignSection,
+  ModelsSection,
 } from '../settings/sections';
 
 interface AppSettingsProps {
@@ -43,7 +44,7 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
 
   // Handle section change with admin check
   const handleSectionChange = (section: SettingsSection) => {
-    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'design', 'system'];
+    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'design', 'system'];
     if (!isAdmin && adminOnlySections.includes(section)) {
       return; // Prevent non-admins from switching to admin sections
     }
@@ -66,6 +67,8 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
         return isAdmin ? <TeamSection currentUserId={userId} /> : null;
       case 'api-keys':
         return isAdmin ? <ApiKeysSection /> : null;
+      case 'models':
+        return isAdmin ? <ModelsSection /> : null;
       case 'integrations':
         return <IntegrationsSection isAdmin={isAdmin} />;
       case 'design':

--- a/frontend/src/components/settings/SettingsSidebar.tsx
+++ b/frontend/src/components/settings/SettingsSidebar.tsx
@@ -4,10 +4,10 @@
  */
 
 import React from 'react';
-import { User, Users, Key, Plug, Gear, Palette } from '@phosphor-icons/react';
+import { User, Users, Key, Plug, Gear, Palette, Brain } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
 
-export type SettingsSection = 'profile' | 'team' | 'api-keys' | 'integrations' | 'design' | 'system';
+export type SettingsSection = 'profile' | 'team' | 'api-keys' | 'models' | 'integrations' | 'design' | 'system';
 
 interface SettingsSidebarProps {
   activeSection: SettingsSection;
@@ -27,6 +27,7 @@ const sidebarItems: SidebarItem[] = [
   { id: 'profile', label: 'Profile', icon: <User size={18} />, category: 'account' },
   { id: 'team', label: 'Team', icon: <Users size={18} />, category: 'workspace', adminOnly: true },
   { id: 'api-keys', label: 'API Keys', icon: <Key size={18} />, category: 'workspace', adminOnly: true },
+  { id: 'models', label: 'Models', icon: <Brain size={18} />, category: 'workspace', adminOnly: true },
   { id: 'integrations', label: 'Integrations', icon: <Plug size={18} />, category: 'workspace' },
   { id: 'design', label: 'Design', icon: <Palette size={18} />, category: 'workspace', adminOnly: true },
   { id: 'system', label: 'System', icon: <Gear size={18} />, category: 'workspace', adminOnly: true },

--- a/frontend/src/components/settings/sections/ModelsSection.tsx
+++ b/frontend/src/components/settings/sections/ModelsSection.tsx
@@ -1,0 +1,231 @@
+/**
+ * ModelsSection Component
+ *
+ * Admin-only model selector. Lets the admin override which Claude model
+ * each use-case category uses (chat, studio, query agents, source extraction).
+ *
+ * Selecting "Per-prompt defaults" for a category clears the override and
+ * each prompt's JSON-baked model is used. The UI shows the per-prompt
+ * breakdown explicitly so "Default" isn't ambiguous — admins can see that
+ * Chat actually means Sonnet for the main prompt and Haiku for chat_naming
+ * and memory, etc.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { CircleNotch } from '@phosphor-icons/react';
+import { modelSettingsAPI } from '@/lib/api/settings';
+import type {
+  ModelInfo,
+  ModelCategory,
+  ModelSettings,
+  ModelDefaults,
+} from '@/lib/api/settings';
+import { useToast } from '@/components/ui/use-toast';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('models-section');
+
+// Sentinel value used by shadcn's Select to represent "no override".
+// shadcn's SelectItem doesn't allow an empty string value.
+const DEFAULT_MODEL_VALUE = '__default__';
+
+// Friendly labels for prompt names so the breakdown reads naturally.
+// Anything not in this map falls back to the prompt name itself.
+const PROMPT_LABELS: Record<string, string> = {
+  default: 'main chat',
+  chat_naming: 'chat naming',
+  memory: 'memory updates',
+  audio_script: 'audio overview',
+  video: 'video',
+  mind_map: 'mind map',
+  quiz: 'quiz',
+  flash_cards: 'flash cards',
+  social_posts: 'social posts',
+  infographic: 'infographic',
+  flow_diagram: 'flow diagram',
+  ad_creative: 'ad creative',
+  component_agent: 'component generation',
+  wireframe_agent: 'wireframe agent',
+  wireframe: 'wireframe',
+  website_agent: 'website generation',
+  presentation_agent: 'presentation generation',
+  email_agent: 'email generation',
+  blog_agent: 'blog',
+  prd_agent: 'PRD',
+  business_report_agent: 'business report',
+  marketing_strategy_agent: 'marketing strategy',
+  database_analyzer_agent: 'database analyzer',
+  csv_analyzer_agent: 'CSV analyzer',
+  freshdesk_analyzer_agent: 'Freshdesk analyzer',
+  pdf_extraction: 'PDF extraction',
+  pptx_extraction: 'PPTX extraction',
+  image_extraction: 'image extraction',
+  csv_processor: 'CSV processing',
+  summary: 'source summary',
+};
+
+const labelForPrompt = (name: string) => PROMPT_LABELS[name] ?? name;
+
+export const ModelsSection: React.FC = () => {
+  const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
+  const [categories, setCategories] = useState<ModelCategory[]>([]);
+  const [selections, setSelections] = useState<ModelSettings>({});
+  const [defaults, setDefaults] = useState<ModelDefaults>({});
+  const [loading, setLoading] = useState(false);
+  const [savingCategory, setSavingCategory] = useState<string | null>(null);
+
+  const { success, error } = useToast();
+
+  useEffect(() => {
+    loadSettings();
+  }, []);
+
+  const loadSettings = async () => {
+    setLoading(true);
+    try {
+      const response = await modelSettingsAPI.getSettings();
+      setAvailableModels(response.available_models);
+      setCategories(response.categories);
+      setSelections(response.settings);
+      setDefaults(response.defaults ?? {});
+    } catch (err) {
+      log.error({ err }, 'failed to load model settings');
+      error('Failed to load model settings');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleModelChange = async (categoryId: string, value: string) => {
+    const modelId = value === DEFAULT_MODEL_VALUE ? null : value;
+    const previous = selections[categoryId] ?? null;
+
+    // Optimistic update; roll back on failure
+    setSelections((prev) => ({ ...prev, [categoryId]: modelId }));
+    setSavingCategory(categoryId);
+
+    try {
+      await modelSettingsAPI.updateSettings({ [categoryId]: modelId });
+      const categoryLabel =
+        categories.find((c) => c.id === categoryId)?.label ?? categoryId;
+      success(`${categoryLabel} model updated`);
+    } catch (err) {
+      log.error({ err, categoryId }, 'failed to update model');
+      setSelections((prev) => ({ ...prev, [categoryId]: previous }));
+      error('Failed to update model');
+    } finally {
+      setSavingCategory(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <CircleNotch size={32} className="animate-spin" />
+      </div>
+    );
+  }
+
+  // Build a quick lookup so we can show "Sonnet 4.6" instead of the raw id
+  const modelNameById = new Map(availableModels.map((m) => [m.id, m.name]));
+  const friendlyModelName = (id: string) => modelNameById.get(id) ?? id;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-base font-medium text-stone-900 mb-1">Models</h2>
+        <p className="text-sm text-muted-foreground">
+          Choose which Claude model each use case runs on. Overrides apply
+          immediately and persist across restarts.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        {categories.map((category) => {
+          const selected = selections[category.id] ?? null;
+          const selectValue = selected ?? DEFAULT_MODEL_VALUE;
+          const breakdown = defaults[category.id] ?? {};
+          const breakdownEntries = Object.entries(breakdown);
+          // Sort so the model that covers the most prompts shows first
+          breakdownEntries.sort((a, b) => b[1].length - a[1].length);
+
+          return (
+            <div
+              key={category.id}
+              className="space-y-2 border border-stone-200 rounded-md p-4"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="text-sm font-medium">{category.label}</Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {category.description}
+                  </p>
+                </div>
+                {savingCategory === category.id && (
+                  <CircleNotch
+                    size={16}
+                    className="animate-spin text-muted-foreground"
+                  />
+                )}
+              </div>
+
+              <Select
+                value={selectValue}
+                onValueChange={(val) => handleModelChange(category.id, val)}
+                disabled={savingCategory !== null}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select model" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={DEFAULT_MODEL_VALUE}>
+                    Per-prompt defaults
+                  </SelectItem>
+                  {availableModels.map((model) => (
+                    <SelectItem key={model.id} value={model.id}>
+                      {model.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* What "Per-prompt defaults" actually resolves to */}
+              {breakdownEntries.length > 0 && (
+                <div className="text-xs text-muted-foreground bg-stone-50 border border-stone-200 rounded px-3 py-2 mt-2">
+                  <div className="font-medium text-stone-600 mb-1">
+                    Per-prompt defaults:
+                  </div>
+                  <ul className="space-y-0.5">
+                    {breakdownEntries.map(([modelId, prompts]) => (
+                      <li key={modelId}>
+                        <span className="font-medium text-stone-700">
+                          {friendlyModelName(modelId)}
+                        </span>
+                        {' — '}
+                        {prompts.map(labelForPrompt).join(', ')}
+                      </li>
+                    ))}
+                  </ul>
+                  {selected === null && (
+                    <p className="mt-1 italic">
+                      Selecting a single model above forces every prompt in
+                      this category to use it.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/settings/sections/SystemSection.tsx
+++ b/frontend/src/components/settings/sections/SystemSection.tsx
@@ -1,6 +1,6 @@
 /**
  * SystemSection Component
- * Manages processing settings (Anthropic tier).
+ * Manages processing settings (Anthropic tier) and per-category model overrides.
  */
 
 import React, { useState, useEffect } from 'react';
@@ -13,33 +13,60 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { CircleNotch } from '@phosphor-icons/react';
-import { processingSettingsAPI } from '@/lib/api/settings';
-import type { AvailableTier } from '@/lib/api/settings';
+import { processingSettingsAPI, modelSettingsAPI } from '@/lib/api/settings';
+import type {
+  AvailableTier,
+  ModelInfo,
+  ModelCategory,
+  ModelSettings,
+} from '@/lib/api/settings';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('system-section');
 
+// Sentinel value used by the Select component to represent "no override".
+// We can't use an empty string because shadcn's SelectItem forbids it.
+const DEFAULT_MODEL_VALUE = '__default__';
+
 export const SystemSection: React.FC = () => {
+  // Processing tier state
   const [availableTiers, setAvailableTiers] = useState<AvailableTier[]>([]);
   const [selectedTier, setSelectedTier] = useState<number>(1);
-  const [loading, setLoading] = useState(false);
   const [tierSaving, setTierSaving] = useState(false);
+
+  // Model settings state
+  const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
+  const [modelCategories, setModelCategories] = useState<ModelCategory[]>([]);
+  const [modelSelections, setModelSelections] = useState<ModelSettings>({});
+  const [savingCategory, setSavingCategory] = useState<string | null>(null);
+
+  const [loading, setLoading] = useState(false);
 
   const { success, error } = useToast();
 
   useEffect(() => {
-    loadProcessingSettings();
+    loadSettings();
   }, []);
 
-  const loadProcessingSettings = async () => {
+  const loadSettings = async () => {
     setLoading(true);
     try {
-      const { settings, available_tiers } = await processingSettingsAPI.getSettings();
-      setAvailableTiers(available_tiers);
-      setSelectedTier(settings.anthropic_tier);
+      // Fetch tier and model settings in parallel — both live in the System panel
+      const [processing, models] = await Promise.all([
+        processingSettingsAPI.getSettings(),
+        modelSettingsAPI.getSettings(),
+      ]);
+
+      setAvailableTiers(processing.available_tiers);
+      setSelectedTier(processing.settings.anthropic_tier);
+
+      setAvailableModels(models.available_models);
+      setModelCategories(models.categories);
+      setModelSelections(models.settings);
     } catch (err) {
-      log.error({ err }, 'failed to load processing settings');
+      log.error({ err }, 'failed to load system settings');
+      error('Failed to load system settings');
     } finally {
       setLoading(false);
     }
@@ -60,6 +87,29 @@ export const SystemSection: React.FC = () => {
     }
   };
 
+  const handleModelChange = async (categoryId: string, value: string) => {
+    // DEFAULT_MODEL_VALUE means "clear override" — backend expects null
+    const modelId = value === DEFAULT_MODEL_VALUE ? null : value;
+
+    // Optimistic UI: update the dropdown immediately, roll back on failure
+    const previous = modelSelections[categoryId] ?? null;
+    setModelSelections((prev) => ({ ...prev, [categoryId]: modelId }));
+    setSavingCategory(categoryId);
+
+    try {
+      await modelSettingsAPI.updateSettings({ [categoryId]: modelId });
+      const categoryLabel =
+        modelCategories.find((c) => c.id === categoryId)?.label ?? categoryId;
+      success(`${categoryLabel} model updated`);
+    } catch (err) {
+      log.error({ err, categoryId }, 'failed to update model');
+      setModelSelections((prev) => ({ ...prev, [categoryId]: previous }));
+      error('Failed to update model');
+    } finally {
+      setSavingCategory(null);
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-8">
@@ -68,14 +118,14 @@ export const SystemSection: React.FC = () => {
     );
   }
 
-  const currentTier = availableTiers.find(t => t.tier === selectedTier);
+  const currentTier = availableTiers.find((t) => t.tier === selectedTier);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-8">
       <div>
         <h2 className="text-base font-medium text-stone-900 mb-1">System</h2>
         <p className="text-sm text-muted-foreground">
-          Configure processing and performance settings
+          Configure processing and model settings
         </p>
       </div>
 
@@ -113,6 +163,49 @@ export const SystemSection: React.FC = () => {
               Rate: {currentTier?.pages_per_minute || 10} pages/min
             </p>
           </div>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-semibold mb-1">Model Configuration</h3>
+        <p className="text-xs text-muted-foreground mb-4">
+          Choose a Claude model per use case. "Default" keeps each prompt's preconfigured model.
+        </p>
+        <div className="space-y-5">
+          {modelCategories.map((category) => {
+            const selected = modelSelections[category.id] ?? null;
+            const selectValue = selected ?? DEFAULT_MODEL_VALUE;
+            return (
+              <div key={category.id} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label>{category.label}</Label>
+                  {savingCategory === category.id && (
+                    <CircleNotch size={16} className="animate-spin text-muted-foreground" />
+                  )}
+                </div>
+                <Select
+                  value={selectValue}
+                  onValueChange={(val) => handleModelChange(category.id, val)}
+                  disabled={savingCategory !== null}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={DEFAULT_MODEL_VALUE}>
+                      Default (use prompt config)
+                    </SelectItem>
+                    {availableModels.map((model) => (
+                      <SelectItem key={model.id} value={model.id}>
+                        {model.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">{category.description}</p>
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/frontend/src/components/settings/sections/SystemSection.tsx
+++ b/frontend/src/components/settings/sections/SystemSection.tsx
@@ -1,6 +1,6 @@
 /**
  * SystemSection Component
- * Manages processing settings (Anthropic tier) and per-category model overrides.
+ * Manages processing settings (Anthropic tier).
  */
 
 import React, { useState, useEffect } from 'react';
@@ -13,60 +13,33 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { CircleNotch } from '@phosphor-icons/react';
-import { processingSettingsAPI, modelSettingsAPI } from '@/lib/api/settings';
-import type {
-  AvailableTier,
-  ModelInfo,
-  ModelCategory,
-  ModelSettings,
-} from '@/lib/api/settings';
+import { processingSettingsAPI } from '@/lib/api/settings';
+import type { AvailableTier } from '@/lib/api/settings';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('system-section');
 
-// Sentinel value used by the Select component to represent "no override".
-// We can't use an empty string because shadcn's SelectItem forbids it.
-const DEFAULT_MODEL_VALUE = '__default__';
-
 export const SystemSection: React.FC = () => {
-  // Processing tier state
   const [availableTiers, setAvailableTiers] = useState<AvailableTier[]>([]);
   const [selectedTier, setSelectedTier] = useState<number>(1);
-  const [tierSaving, setTierSaving] = useState(false);
-
-  // Model settings state
-  const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
-  const [modelCategories, setModelCategories] = useState<ModelCategory[]>([]);
-  const [modelSelections, setModelSelections] = useState<ModelSettings>({});
-  const [savingCategory, setSavingCategory] = useState<string | null>(null);
-
   const [loading, setLoading] = useState(false);
+  const [tierSaving, setTierSaving] = useState(false);
 
   const { success, error } = useToast();
 
   useEffect(() => {
-    loadSettings();
+    loadProcessingSettings();
   }, []);
 
-  const loadSettings = async () => {
+  const loadProcessingSettings = async () => {
     setLoading(true);
     try {
-      // Fetch tier and model settings in parallel — both live in the System panel
-      const [processing, models] = await Promise.all([
-        processingSettingsAPI.getSettings(),
-        modelSettingsAPI.getSettings(),
-      ]);
-
-      setAvailableTiers(processing.available_tiers);
-      setSelectedTier(processing.settings.anthropic_tier);
-
-      setAvailableModels(models.available_models);
-      setModelCategories(models.categories);
-      setModelSelections(models.settings);
+      const { settings, available_tiers } = await processingSettingsAPI.getSettings();
+      setAvailableTiers(available_tiers);
+      setSelectedTier(settings.anthropic_tier);
     } catch (err) {
-      log.error({ err }, 'failed to load system settings');
-      error('Failed to load system settings');
+      log.error({ err }, 'failed to load processing settings');
     } finally {
       setLoading(false);
     }
@@ -87,29 +60,6 @@ export const SystemSection: React.FC = () => {
     }
   };
 
-  const handleModelChange = async (categoryId: string, value: string) => {
-    // DEFAULT_MODEL_VALUE means "clear override" — backend expects null
-    const modelId = value === DEFAULT_MODEL_VALUE ? null : value;
-
-    // Optimistic UI: update the dropdown immediately, roll back on failure
-    const previous = modelSelections[categoryId] ?? null;
-    setModelSelections((prev) => ({ ...prev, [categoryId]: modelId }));
-    setSavingCategory(categoryId);
-
-    try {
-      await modelSettingsAPI.updateSettings({ [categoryId]: modelId });
-      const categoryLabel =
-        modelCategories.find((c) => c.id === categoryId)?.label ?? categoryId;
-      success(`${categoryLabel} model updated`);
-    } catch (err) {
-      log.error({ err, categoryId }, 'failed to update model');
-      setModelSelections((prev) => ({ ...prev, [categoryId]: previous }));
-      error('Failed to update model');
-    } finally {
-      setSavingCategory(null);
-    }
-  };
-
   if (loading) {
     return (
       <div className="flex items-center justify-center py-8">
@@ -118,14 +68,14 @@ export const SystemSection: React.FC = () => {
     );
   }
 
-  const currentTier = availableTiers.find((t) => t.tier === selectedTier);
+  const currentTier = availableTiers.find(t => t.tier === selectedTier);
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-4">
       <div>
         <h2 className="text-base font-medium text-stone-900 mb-1">System</h2>
         <p className="text-sm text-muted-foreground">
-          Configure processing and model settings
+          Configure processing and performance settings
         </p>
       </div>
 
@@ -163,49 +113,6 @@ export const SystemSection: React.FC = () => {
               Rate: {currentTier?.pages_per_minute || 10} pages/min
             </p>
           </div>
-        </div>
-      </div>
-
-      <div>
-        <h3 className="text-sm font-semibold mb-1">Model Configuration</h3>
-        <p className="text-xs text-muted-foreground mb-4">
-          Choose a Claude model per use case. "Default" keeps each prompt's preconfigured model.
-        </p>
-        <div className="space-y-5">
-          {modelCategories.map((category) => {
-            const selected = modelSelections[category.id] ?? null;
-            const selectValue = selected ?? DEFAULT_MODEL_VALUE;
-            return (
-              <div key={category.id} className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label>{category.label}</Label>
-                  {savingCategory === category.id && (
-                    <CircleNotch size={16} className="animate-spin text-muted-foreground" />
-                  )}
-                </div>
-                <Select
-                  value={selectValue}
-                  onValueChange={(val) => handleModelChange(category.id, val)}
-                  disabled={savingCategory !== null}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select model" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={DEFAULT_MODEL_VALUE}>
-                      Default (use prompt config)
-                    </SelectItem>
-                    {availableModels.map((model) => (
-                      <SelectItem key={model.id} value={model.id}>
-                        {model.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-muted-foreground">{category.description}</p>
-              </div>
-            );
-          })}
         </div>
       </div>
     </div>

--- a/frontend/src/components/settings/sections/index.ts
+++ b/frontend/src/components/settings/sections/index.ts
@@ -4,3 +4,4 @@ export { ApiKeysSection } from './ApiKeysSection';
 export { IntegrationsSection } from './IntegrationsSection';
 export { SystemSection } from './SystemSection';
 export { DesignSection } from './DesignSection';
+export { ModelsSection } from './ModelsSection';

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -488,6 +488,75 @@ class ProcessingSettingsAPI {
 export const processingSettingsAPI = new ProcessingSettingsAPI();
 
 // ============================================================================
+// Model Settings Types and API
+// ============================================================================
+
+export interface ModelPricing {
+  input_per_mtok: number;
+  output_per_mtok: number;
+}
+
+export interface ModelInfo {
+  id: string;
+  name: string;
+  description: string;
+  pricing: ModelPricing;
+}
+
+export interface ModelCategory {
+  id: string;
+  label: string;
+  description: string;
+  env_var: string;
+}
+
+// { chat: "claude-opus-4-6" | null, studio: ..., query: ..., extraction: ... }
+export type ModelSettings = Record<string, string | null>;
+
+export interface ModelSettingsResponse {
+  settings: ModelSettings;
+  available_models: ModelInfo[];
+  categories: ModelCategory[];
+}
+
+class ModelSettingsAPI {
+  /**
+   * Get current per-category model overrides plus the lists needed to
+   * render the admin UI.
+   */
+  async getSettings(): Promise<ModelSettingsResponse> {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/settings/models`);
+      return {
+        settings: response.data.settings,
+        available_models: response.data.available_models,
+        categories: response.data.categories,
+      };
+    } catch (error) {
+      log.error({ err: error }, 'failed to fetch model settings');
+      throw error;
+    }
+  }
+
+  /**
+   * Update per-category model overrides. Pass a partial map — only
+   * categories you include are changed. Use null to clear an override
+   * (reverts that category to "Default" which uses each prompt's own model).
+   */
+  async updateSettings(settings: ModelSettings): Promise<ModelSettings> {
+    try {
+      const response = await axios.post(`${API_BASE_URL}/settings/models`, settings);
+      return response.data.settings;
+    } catch (error) {
+      log.error({ err: error }, 'failed to update model settings');
+      throw error;
+    }
+  }
+}
+
+export const modelSettingsAPI = new ModelSettingsAPI();
+
+// ============================================================================
 // Google Drive Types and API
 // ============================================================================
 

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -513,10 +513,16 @@ export interface ModelCategory {
 // { chat: "claude-opus-4-6" | null, studio: ..., query: ..., extraction: ... }
 export type ModelSettings = Record<string, string | null>;
 
+// { chat: { "claude-sonnet-4-6": ["default"], "claude-haiku-4-5-20251001": ["chat_naming", "memory"] }, ... }
+// Shows which JSON-baked model each prompt uses by default. Lets the UI
+// explain what selecting "Default" actually means per category.
+export type ModelDefaults = Record<string, Record<string, string[]>>;
+
 export interface ModelSettingsResponse {
   settings: ModelSettings;
   available_models: ModelInfo[];
   categories: ModelCategory[];
+  defaults: ModelDefaults;
 }
 
 class ModelSettingsAPI {
@@ -531,6 +537,7 @@ class ModelSettingsAPI {
         settings: response.data.settings,
         available_models: response.data.available_models,
         categories: response.data.categories,
+        defaults: response.data.defaults,
       };
     } catch (error) {
       log.error({ err: error }, 'failed to fetch model settings');


### PR DESCRIPTION
## Summary
- Adds an admin-only Claude model selector in Settings → System with four categories: **Chat**, **Studio**, **Query Agents**, and **Source Extraction**
- Admin picks Haiku / Sonnet / Opus per category, or "Default" to preserve each prompt's JSON-baked model (so intentional tuning like `presentation_agent` = Opus stays intact)
- Zero changes to the ~24 services that load prompt configs: a `PromptConfig` dict subclass dynamically resolves `"model"` on each access, so services keep caching the whole config without going stale

## How it works
- `backend/app/config/model_loader.py` — `AVAILABLE_MODELS`, `MODEL_CATEGORIES`, `PROMPT_TO_CATEGORY` (30 prompts mapped; `web_agent` + `deep_research_agent` intentionally excluded)
- `backend/app/config/prompt_loader.py` — `PromptConfig(dict)` overrides `__getitem__`/`get` for the `"model"` key so `config.get("model")` re-reads the env var on every call. Cached service configs pick up admin changes immediately — no restart.
- `backend/app/api/settings/models.py` — `GET`/`POST /settings/models`, `@require_admin`, validates all inputs before writing .env, reloads env on save
- 4 env vars mirror the `ANTHROPIC_TIER` pattern: `CHAT_MODEL_OVERRIDE`, `STUDIO_MODEL_OVERRIDE`, `QUERY_MODEL_OVERRIDE`, `EXTRACTION_MODEL_OVERRIDE`
- `frontend/src/lib/api/settings.ts` — `ModelSettingsAPI` with types
- `frontend/src/components/settings/sections/SystemSection.tsx` — 4 dropdowns with optimistic updates + rollback, parallel loading with tier settings
- `csv_processor.py` — the hardcoded Haiku label in `summary_info` now pulls from the live prompt config so stored metadata stays accurate under overrides

## Test plan
- [ ] Open Settings → System → Model Configuration. Four dropdowns appear, all defaulting to "Default (use prompt config)"
- [ ] Set Chat → Opus, send a chat message, verify backend logs / project costs show Opus
- [ ] Set Studio → Haiku, generate a mind map, verify Haiku in logs
- [ ] Set Query Agents → Opus, ask a CSV question, verify `csv_analyzer_agent` used Opus
- [ ] Set Source Extraction → Sonnet, upload a new PDF, verify extraction used Sonnet instead of the default Haiku
- [ ] Reset Chat to "Default", send another message, verify fallback to `claude-sonnet-4-6` from `default_prompt.json`
- [ ] Restart backend container, reload settings, confirm selections persist
- [ ] POST `/settings/models` with an invalid model id → 400
- [ ] Non-admin user: "System" section hidden in sidebar (existing RBAC gate)