### PR TITLE
feat: per-chat cost tracking + fix Opus visibility

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,15 @@
 # PM-AI Bot Roadmap
 
-| # | Improvement | Notes |
-|---|-------------|-------|
-| 1 | **Haiku movement** | Migrate eligible prompts to Haiku for cost/speed |
-| 2 | **JIRA connection** | JIRA integration for querying tickets as a source |
-| 3 | **Usage credit limit for individual users** | Per-user monthly/daily credit caps |
-| 4 | **STT** | Speech-to-text improvements |
-| 5 | **4XX error fix for number of iterations** | Retry/handle 4XX errors inside agent loops instead of hard-failing |
-| 6 | **Chat download as PDF** | Currently exports markdown — should export as PDF |
-| 7 | **Chat-wise token utilisation** | Show per-chat token usage breakdown |
-| 8 | **Opik logs — thread & unique user info** | Attach thread ID and user identity to every Opik log entry |
-| 9 | **Studio Business & Product section bug** | Clicking one item (e.g. Flow Diagram) generates it, but all other active studio items stop working |
-| 10 | **Ledger DB** | Connect to ledger/accounting database as a source |
-| 11 | **Mixpanel MCP connection** | MCP server integration for Mixpanel analytics |
+| # | Status | Improvement | Notes |
+|---|--------|-------------|-------|
+| 1 | ⬜ | **Haiku movement** | Migrate eligible prompts to Haiku for cost/speed |
+| 2 | ⬜ | **JIRA connection** | JIRA integration for querying tickets as a source |
+| 3 | ⬜ | **Usage credit limit for individual users** | Per-user monthly/daily credit caps |
+| 4 | ⬜ | **STT** | Speech-to-text improvements |
+| 5 | ⬜ | **4XX error fix for number of iterations** | Retry/handle 4XX errors inside agent loops instead of hard-failing |
+| 6 | ✅ | **Chat download as PDF** | Shipped in a7c3fc8 — jspdf + html2canvas export |
+| 7 | ✅ | **Chat-wise token utilisation** | Shipped — per-chat cost badge in ChatHeader + Opus row added to project breakdown |
+| 8 | ✅ | **Opik logs — thread & unique user info** | Shipped — user_id, project_id, chat_id (thread_id), and tags attached to every trace |
+| 9 | ✅ | **Studio Business & Product section bug** | Shipped — fire-and-forget triggerGeneration + DB source fallback + mermaid sanitization |
+| 10 | ⬜ | **Ledger DB** | Connect to ledger/accounting database as a source |
+| 11 | ⬜ | **Mixpanel MCP connection** | MCP server integration for Mixpanel analytics |

--- a/backend/app/api/chats/routes.py
+++ b/backend/app/api/chats/routes.py
@@ -6,11 +6,12 @@ A chat is a container for a conversation - it has metadata (title, timestamps)
 and holds messages, but the actual AI processing happens in the messages blueprint.
 
 Routes:
-- GET    /projects/<id>/chats          - List all chats
-- POST   /projects/<id>/chats          - Create new chat
-- GET    /projects/<id>/chats/<id>     - Get chat with messages
-- PUT    /projects/<id>/chats/<id>     - Update chat (rename)
-- DELETE /projects/<id>/chats/<id>     - Delete chat
+- GET    /projects/<id>/chats              - List all chats
+- POST   /projects/<id>/chats              - Create new chat
+- GET    /projects/<id>/chats/<id>         - Get chat with messages
+- PUT    /projects/<id>/chats/<id>         - Update chat (rename)
+- DELETE /projects/<id>/chats/<id>         - Delete chat
+- GET    /projects/<id>/chats/<id>/costs   - Get per-chat cost/token breakdown
 """
 from flask import jsonify, request, current_app
 from app.api.chats import chats_bp
@@ -174,6 +175,29 @@ def delete_chat(project_id, chat_id):
 
     except Exception as e:
         current_app.logger.error(f"Error deleting chat {chat_id}: {e}")
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+
+@chats_bp.route('/projects/<project_id>/chats/<chat_id>/costs', methods=['GET'])
+def get_chat_costs(project_id, chat_id):
+    """
+    Get per-chat cost and token usage breakdown.
+
+    Educational Note: Mirrors /projects/<id>/costs but scoped to a single
+    chat. Returns the same shape: total_cost and by_model breakdown with
+    input_tokens, output_tokens, and cost for each of opus/sonnet/haiku.
+    """
+    try:
+        costs = chat_service.get_chat_costs(project_id, chat_id)
+        return jsonify({
+            'success': True,
+            'costs': costs
+        }), 200
+    except Exception as e:
+        current_app.logger.error(f"Error getting chat costs {chat_id}: {e}")
         return jsonify({
             'success': False,
             'error': str(e)

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -54,7 +54,7 @@ class ChatService:
         """
         response = (
             self.supabase.table(self.table)
-            .select("id, title, created_at, updated_at")
+            .select("id, title, created_at, updated_at, costs")
             .eq("project_id", project_id)
             .order("updated_at", desc=True)
             .execute()
@@ -418,6 +418,79 @@ class ChatService:
             .execute()
         )
         return bool(existing.data)
+
+    def get_chat_costs(self, project_id: str, chat_id: str) -> Dict[str, Any]:
+        """
+        Get cost tracking data for a specific chat.
+
+        Educational Note: Mirrors project_service.get_project_costs() —
+        returns the costs JSONB column, or a default structure if the chat
+        exists but has no costs yet.
+
+        Args:
+            project_id: The project UUID (for authorization scoping)
+            chat_id: The chat UUID
+
+        Returns:
+            Cost dict with total_cost and by_model breakdown
+        """
+        response = (
+            self.supabase.table(self.table)
+            .select("costs")
+            .eq("id", chat_id)
+            .eq("project_id", project_id)
+            .execute()
+        )
+
+        if not response.data:
+            return {
+                "total_cost": 0.0,
+                "by_model": {
+                    "opus": {"input_tokens": 0, "output_tokens": 0, "cost": 0.0},
+                    "sonnet": {"input_tokens": 0, "output_tokens": 0, "cost": 0.0},
+                    "haiku": {"input_tokens": 0, "output_tokens": 0, "cost": 0.0},
+                },
+            }
+
+        return response.data[0].get("costs") or {
+            "total_cost": 0.0,
+            "by_model": {
+                "opus": {"input_tokens": 0, "output_tokens": 0, "cost": 0.0},
+                "sonnet": {"input_tokens": 0, "output_tokens": 0, "cost": 0.0},
+                "haiku": {"input_tokens": 0, "output_tokens": 0, "cost": 0.0},
+            },
+        }
+
+    def get_chat_costs_raw(self, chat_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Load raw costs JSONB for a chat by chat_id only (no project scoping).
+
+        Used internally by cost_tracking._load_chat_costs. Returns None if
+        the chat doesn't exist — the cost tracker will fall back to defaults.
+        """
+        response = (
+            self.supabase.table(self.table)
+            .select("costs")
+            .eq("id", chat_id)
+            .execute()
+        )
+        if not response.data:
+            return None
+        return response.data[0].get("costs")
+
+    def update_chat_costs(self, chat_id: str, costs: Dict[str, Any]) -> bool:
+        """
+        Persist updated costs JSONB to a chat.
+
+        Used internally by cost_tracking._save_chat_costs.
+        """
+        response = (
+            self.supabase.table(self.table)
+            .update({"costs": costs})
+            .eq("id", chat_id)
+            .execute()
+        )
+        return bool(response.data)
 
 
 # Singleton instance for easy import

--- a/backend/app/services/integrations/claude/claude_service.py
+++ b/backend/app/services/integrations/claude/claude_service.py
@@ -216,13 +216,14 @@ class ClaudeService:
             trace_input=trace_input,
         )
 
-        # Track costs if project_id provided
+        # Track costs if project_id provided (also per-chat if chat_id set)
         if project_id:
             add_cost_usage(
                 project_id=project_id,
                 model=response.model,
                 input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens
+                output_tokens=response.usage.output_tokens,
+                chat_id=chat_id,
             )
 
         # Return raw response data - all parsing happens in claude_parsing_utils
@@ -292,7 +293,8 @@ class ClaudeService:
                 project_id=project_id,
                 model=response.model,
                 input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens
+                output_tokens=response.usage.output_tokens,
+                chat_id=chat_id,
             )
 
         return {

--- a/backend/app/utils/cost_tracking.py
+++ b/backend/app/utils/cost_tracking.py
@@ -77,6 +77,12 @@ def _get_project_service():
     return project_service
 
 
+def _get_chat_service():
+    """Get chat service (lazy import to avoid circular imports)."""
+    from app.services.data_services import chat_service
+    return chat_service
+
+
 def _load_costs(project_id: str, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Load cost tracking data from Supabase."""
     try:
@@ -100,6 +106,26 @@ def _save_costs(project_id: str, costs: Dict[str, Any], user_id: Optional[str] =
         return project_service.update_project_costs(project_id, costs, user_id=owner_id)
     except Exception as e:
         logger.error("Error saving costs for %s: %s", project_id, e)
+        return False
+
+
+def _load_chat_costs(chat_id: str) -> Optional[Dict[str, Any]]:
+    """Load cost tracking data for a chat from Supabase."""
+    try:
+        chat_service = _get_chat_service()
+        return chat_service.get_chat_costs_raw(chat_id)
+    except Exception as e:
+        logger.error("Error loading chat costs for %s: %s", chat_id, e)
+        return None
+
+
+def _save_chat_costs(chat_id: str, costs: Dict[str, Any]) -> bool:
+    """Save cost tracking data for a chat to Supabase."""
+    try:
+        chat_service = _get_chat_service()
+        return chat_service.update_chat_costs(chat_id, costs)
+    except Exception as e:
+        logger.error("Error saving chat costs for %s: %s", chat_id, e)
         return False
 
 
@@ -143,57 +169,82 @@ def _ensure_cost_structure(costs: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     return costs
 
 
+def _apply_usage(
+    costs: Dict[str, Any],
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+) -> Dict[str, Any]:
+    """
+    Mutate a costs dict in place: add this call's tokens + cost to the
+    correct model bucket and bump the total. Returns the same dict.
+
+    Extracted so both project-level and chat-level updates share identical math.
+    """
+    model_key = _get_model_key(model)
+    call_cost = _calculate_cost(model_key, input_tokens, output_tokens)
+
+    bucket = costs["by_model"][model_key]
+    bucket["input_tokens"] += input_tokens
+    bucket["output_tokens"] += output_tokens
+    bucket["cost"] += call_cost
+
+    costs["total_cost"] += call_cost
+    return costs
+
+
 def add_usage(
     project_id: str,
     model: str,
     input_tokens: int,
     output_tokens: int,
     user_id: Optional[str] = None,
+    chat_id: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """
-    Add API usage to project cost tracking.
+    Add API usage to project (and optionally chat) cost tracking.
 
     Educational Note: This function is called after each Claude API call
-    to update the cumulative cost tracking in Supabase.
+    to update the cumulative cost tracking in Supabase. When chat_id is
+    provided, the same usage is also added to chats.costs so per-chat
+    spend can be shown in the chat header. Both updates happen inside a
+    single lock so project and chat totals never drift.
 
     Args:
         project_id: The project UUID
         model: Full model string (e.g., "claude-sonnet-4-6")
         input_tokens: Number of input tokens used
         output_tokens: Number of output tokens used
+        user_id: Optional owner id (falls back to project lookup)
+        chat_id: Optional chat UUID — when set, chat-level costs update too
 
     Returns:
-        Updated cost tracking data or None if failed
+        Updated project cost tracking data or None if project save failed
     """
     with _lock:
-        # Load current costs from Supabase
-        costs = _load_costs(project_id, user_id=user_id)
-        if costs is None:
-            # Project might not exist or no costs yet - use defaults
-            costs = _get_default_costs()
+        # --- Project-level update (unchanged behavior) ---
+        project_costs = _load_costs(project_id, user_id=user_id)
+        if project_costs is None:
+            project_costs = _get_default_costs()
+        project_costs = _ensure_cost_structure(project_costs)
+        _apply_usage(project_costs, model, input_tokens, output_tokens)
 
-        # Ensure structure exists
-        costs = _ensure_cost_structure(costs)
-
-        # Get model key and calculate cost
-        model_key = _get_model_key(model)
-        call_cost = _calculate_cost(model_key, input_tokens, output_tokens)
-
-        # Update model-specific tracking
-        model_tracking = costs["by_model"][model_key]
-        model_tracking["input_tokens"] += input_tokens
-        model_tracking["output_tokens"] += output_tokens
-        model_tracking["cost"] += call_cost
-
-        # Update total cost
-        costs["total_cost"] += call_cost
-
-        # Save updated costs to Supabase
-        if _save_costs(project_id, costs, user_id=user_id):
-            return costs
-        else:
+        if not _save_costs(project_id, project_costs, user_id=user_id):
             logger.warning("Failed to save costs for project %s", project_id)
-            return None
+            project_costs = None
+
+        # --- Chat-level update (only when chat_id provided) ---
+        if chat_id:
+            chat_costs = _load_chat_costs(chat_id)
+            if chat_costs is None:
+                chat_costs = _get_default_costs()
+            chat_costs = _ensure_cost_structure(chat_costs)
+            _apply_usage(chat_costs, model, input_tokens, output_tokens)
+
+            if not _save_chat_costs(chat_id, chat_costs):
+                logger.warning("Failed to save costs for chat %s", chat_id)
+
+        return project_costs
 
 
 def get_project_costs(project_id: str, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:

--- a/backend/supabase/migrations/00018_chat_costs.sql
+++ b/backend/supabase/migrations/00018_chat_costs.sql
@@ -1,0 +1,19 @@
+-- Add cost tracking column to chats table.
+--
+-- Mirrors the `projects.costs` JSONB structure so we can use the same
+-- cost_tracking utility to update both in one locked operation.
+--
+-- Existing chats get the default on first cost write via
+-- _ensure_cost_structure() in app/utils/cost_tracking.py.
+
+ALTER TABLE chats
+  ADD COLUMN IF NOT EXISTS costs JSONB DEFAULT '{
+    "total_cost": 0,
+    "by_model": {
+      "opus": {"input_tokens": 0, "output_tokens": 0, "cost": 0},
+      "sonnet": {"input_tokens": 0, "output_tokens": 0, "cost": 0},
+      "haiku": {"input_tokens": 0, "output_tokens": 0, "cost": 0}
+    }
+  }'::jsonb;
+
+COMMENT ON COLUMN chats.costs IS 'Per-chat cost tracking: total_cost + by_model breakdown (opus/sonnet/haiku)';

--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -12,22 +12,38 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
-import { Sparkle, Plus, ChatCircle, CaretDown, Hash, Books, DownloadSimple, CircleNotch } from '@phosphor-icons/react';
+import { Sparkle, Plus, ChatCircle, CaretDown, Hash, Books, DownloadSimple, CircleNotch, CurrencyDollar } from '@phosphor-icons/react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { Button } from '../ui/button';
 import type { Chat, ChatMetadata } from '../../lib/api/chats';
+import type { CostTracking } from '../../lib/api/projects';
 
 interface ChatHeaderProps {
   activeChat: Chat | null;
   allChats: ChatMetadata[];
   activeSources: number;
   totalSources: number;
+  chatCosts: CostTracking | null;
   onSelectChat: (chatId: string) => void;
   onNewChat: () => void;
   onShowChatList: () => void;
   onExportChat: () => void;
   exportingChat: boolean;
 }
+
+// Cost formatters — mirrors ProjectHeader so the two badges look identical
+const formatCost = (cost: number): string => {
+  if (cost < 0.01) return '<$0.01';
+  return `$${cost.toFixed(2)}`;
+};
+
+const formatCostWithSymbol = (cost: number): string => `$${cost.toFixed(6)}`;
+
+const formatTokens = (count: number): string => {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(2)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+  return count.toString();
+};
 
 /**
  * Memoized to prevent re-renders when typing in ChatInput
@@ -38,6 +54,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
   allChats,
   activeSources,
   totalSources,
+  chatCosts,
   onSelectChat,
   onNewChat,
   onShowChatList,
@@ -115,6 +132,76 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
             <Books size={16} className="text-primary" />
             <span className="text-sm font-medium">{activeSources}/{totalSources}</span>
           </div>
+
+          {/* Per-chat cost badge — shows only when this chat has spent something */}
+          {chatCosts && chatCosts.total_cost > 0 && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex items-center gap-1.5 px-2 py-1 bg-muted/50 rounded-md cursor-default">
+                    <CurrencyDollar size={14} className="text-muted-foreground" />
+                    <span className="text-sm text-muted-foreground font-medium">
+                      {formatCost(chatCosts.total_cost)}
+                    </span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="p-3">
+                  <div className="space-y-2 text-xs">
+                    <p className="font-semibold text-sm mb-2">Chat Usage Breakdown</p>
+
+                    {chatCosts.by_model.opus && (chatCosts.by_model.opus.input_tokens > 0 || chatCosts.by_model.opus.output_tokens > 0) && (
+                      <div className="space-y-1">
+                        <p className="font-medium">Opus</p>
+                        <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-muted-foreground">
+                          <span>Input:</span>
+                          <span>{formatTokens(chatCosts.by_model.opus.input_tokens)} tokens</span>
+                          <span>Output:</span>
+                          <span>{formatTokens(chatCosts.by_model.opus.output_tokens)} tokens</span>
+                          <span>Cost:</span>
+                          <span className="font-medium text-foreground">{formatCostWithSymbol(chatCosts.by_model.opus.cost)}</span>
+                        </div>
+                      </div>
+                    )}
+
+                    {(chatCosts.by_model.sonnet.input_tokens > 0 || chatCosts.by_model.sonnet.output_tokens > 0) && (
+                      <div className="space-y-1">
+                        <p className="font-medium">Sonnet</p>
+                        <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-muted-foreground">
+                          <span>Input:</span>
+                          <span>{formatTokens(chatCosts.by_model.sonnet.input_tokens)} tokens</span>
+                          <span>Output:</span>
+                          <span>{formatTokens(chatCosts.by_model.sonnet.output_tokens)} tokens</span>
+                          <span>Cost:</span>
+                          <span className="font-medium text-foreground">{formatCostWithSymbol(chatCosts.by_model.sonnet.cost)}</span>
+                        </div>
+                      </div>
+                    )}
+
+                    {(chatCosts.by_model.haiku.input_tokens > 0 || chatCosts.by_model.haiku.output_tokens > 0) && (
+                      <div className="space-y-1">
+                        <p className="font-medium">Haiku</p>
+                        <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-muted-foreground">
+                          <span>Input:</span>
+                          <span>{formatTokens(chatCosts.by_model.haiku.input_tokens)} tokens</span>
+                          <span>Output:</span>
+                          <span>{formatTokens(chatCosts.by_model.haiku.output_tokens)} tokens</span>
+                          <span>Cost:</span>
+                          <span className="font-medium text-foreground">{formatCostWithSymbol(chatCosts.by_model.haiku.cost)}</span>
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="border-t pt-2 mt-2">
+                      <div className="flex justify-between font-medium">
+                        <span>Total:</span>
+                        <span>{formatCostWithSymbol(chatCosts.total_cost)}</span>
+                      </div>
+                    </div>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
       </div>
       {/* Description - matches Sources/Studio */}

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -10,6 +10,7 @@ import { Sparkle } from '@phosphor-icons/react';
 import { Skeleton } from '../ui/skeleton';
 import { chatsAPI } from '@/lib/api/chats';
 import type { Chat, ChatMetadata, StudioSignal } from '@/lib/api/chats';
+import type { CostTracking } from '@/lib/api/projects';
 import { sourcesAPI, type Source } from '@/lib/api/sources';
 import { ToastContainer } from '../ui/toast';
 import { useToast } from '../ui/use-toast';
@@ -72,6 +73,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
 
   // Sources state for header display
   const [sources, setSources] = useState<Source[]>([]);
+
+  // Per-chat cost tracking (shown in ChatHeader)
+  const [chatCosts, setChatCosts] = useState<CostTracking | null>(null);
 
   // Active sources count derived from per-chat selection
   const activeSources = selectedSourceIds.length;
@@ -187,6 +191,28 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   }, [activeChat, onSignalsChange]);
 
   /**
+   * Load per-chat cost/token breakdown whenever the active chat changes.
+   * Refreshed again after each message via `loadChatCosts()` in the send flow.
+   */
+  const loadChatCosts = useCallback(async (chatId: string) => {
+    try {
+      const costs = await chatsAPI.getCosts(projectId, chatId);
+      setChatCosts(costs);
+    } catch (err) {
+      log.error({ err }, 'failed to load chat costs');
+      // Silent — costs are not critical for chat function
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    if (activeChat?.id) {
+      loadChatCosts(activeChat.id);
+    } else {
+      setChatCosts(null);
+    }
+  }, [activeChat?.id, loadChatCosts]);
+
+  /**
    * Send a message and get AI response
    * Educational Note: We add the user message optimistically to the UI
    * before the API call, so users see their message immediately.
@@ -225,6 +251,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     const scheduleChatRefreshes = async (chatId: string) => {
       await loadChats();
       onCostsChange?.();
+      loadChatCosts(chatId);
 
       setTimeout(async () => {
         try {
@@ -546,6 +573,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         allChats={allChats}
         activeSources={activeSources}
         totalSources={sources.length}
+        chatCosts={chatCosts}
         onSelectChat={handleSelectChat}
         onNewChat={handleNewChat}
         onShowChatList={() => setShowChatList(true)}

--- a/frontend/src/components/project/ProjectHeader.tsx
+++ b/frontend/src/components/project/ProjectHeader.tsx
@@ -337,6 +337,21 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
                 <div className="space-y-2 text-xs">
                   <p className="font-semibold text-sm mb-2">API Usage Breakdown</p>
 
+                  {/* Opus breakdown */}
+                  {costs.by_model.opus && (costs.by_model.opus.input_tokens > 0 || costs.by_model.opus.output_tokens > 0) && (
+                    <div className="space-y-1">
+                      <p className="font-medium">Opus</p>
+                      <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-muted-foreground">
+                        <span>Input:</span>
+                        <span>{formatTokens(costs.by_model.opus.input_tokens)} tokens</span>
+                        <span>Output:</span>
+                        <span>{formatTokens(costs.by_model.opus.output_tokens)} tokens</span>
+                        <span>Cost:</span>
+                        <span className="font-medium text-foreground">{formatCostWithSymbol(costs.by_model.opus.cost)}</span>
+                      </div>
+                    </div>
+                  )}
+
                   {/* Sonnet breakdown */}
                   {(costs.by_model.sonnet.input_tokens > 0 || costs.by_model.sonnet.output_tokens > 0) && (
                     <div className="space-y-1">

--- a/frontend/src/lib/api/chats.ts
+++ b/frontend/src/lib/api/chats.ts
@@ -10,6 +10,7 @@ import type { StudioSignal } from '../../components/studio/types';
 import { API_BASE_URL } from './client';
 import { createLogger } from '@/lib/logger';
 import { getAccessToken } from '../auth/session';
+import type { CostTracking } from './projects';
 
 const log = createLogger('chats-api');
 
@@ -414,6 +415,22 @@ class ChatsAPI {
       );
     } catch (error) {
       log.error({ err: error }, 'failed to delete chat');
+      throw error;
+    }
+  }
+
+  /**
+   * Get per-chat cost and token breakdown.
+   * Educational Note: Mirrors projectsAPI.getCosts but scoped to a single chat.
+   */
+  async getCosts(projectId: string, chatId: string): Promise<CostTracking> {
+    try {
+      const response = await axios.get(
+        `${API_BASE_URL}/projects/${projectId}/chats/${chatId}/costs`
+      );
+      return response.data.costs;
+    } catch (error) {
+      log.error({ err: error }, 'failed to fetch chat costs');
       throw error;
     }
   }

--- a/frontend/src/lib/api/projects.ts
+++ b/frontend/src/lib/api/projects.ts
@@ -29,6 +29,7 @@ export interface ModelCostBreakdown {
 export interface CostTracking {
   total_cost: number;
   by_model: {
+    opus: ModelCostBreakdown;
     sonnet: ModelCostBreakdown;
     haiku: ModelCostBreakdown;
   };


### PR DESCRIPTION
## Summary

Roadmap item #7 — adds per-chat cost/token breakdown in the chat header, and fixes a long-standing bug where Opus spend was tracked server-side but invisible in the frontend.

## What's new

**Backend**
- Migration `00018_chat_costs` — adds `costs` JSONB column to `chats` table (same shape as `projects.costs`)
- `cost_tracking.add_usage` now accepts optional `chat_id`. When set, it updates both `projects.costs` AND `chats.costs` inside a single lock so they stay in sync. Math extracted into `_apply_usage()`.
- `claude_service.send_message` / `stream_message` forward `chat_id` to cost tracking (plumbing already existed from Opik work)
- `chat_service`: new `get_chat_costs` (project-scoped), `get_chat_costs_raw` (internal), `update_chat_costs`
- New endpoint: `GET /projects/<pid>/chats/<cid>/costs`

**Frontend**
- `CostTracking` type: added `opus` bucket — was silently dropped before, so any Opus spend was invisible in the project header tooltip
- `ProjectHeader`: renders Opus row above Sonnet in cost breakdown
- `chatsAPI.getCosts()`: new method mirroring `projectsAPI.getCosts`
- `ChatPanel`: fetches chat costs on active-chat change and after every send; passes to `ChatHeader`
- `ChatHeader`: new cost badge next to source count with hover tooltip showing Opus/Sonnet/Haiku breakdown

**Out of scope**: analyzer agents (database/csv/freshdesk) don't yet receive `chat_id`, so their costs continue to hit the project bucket only. They still bubble up via project totals.

## Test plan

- [ ] Migration applies cleanly: `docker compose exec db psql -U postgres -c "\d chats"` shows `costs jsonb`
- [ ] Set admin model override: Chat → Opus, send a message → project header tooltip shows Opus row with correct tokens/cost
- [ ] Open a chat, send 3 messages → `GET /api/v1/projects/{pid}/chats/{cid}/costs` returns aggregated cost
- [ ] ChatHeader shows cost badge with per-model breakdown in hover tooltip
- [ ] Old chats (pre-migration) show `$0.00` initially, then start accumulating on next message
- [ ] Upload a PDF → project costs update but active chat's costs do NOT