### PR TITLE
feat: granular per-user module permissions

### DIFF
--- a/backend/app/api/google/drive.py
+++ b/backend/app/api/google/drive.py
@@ -32,6 +32,7 @@ from flask import jsonify, request, current_app
 from app.api.google import google_bp
 from app.services.integrations.google import google_drive_service
 from app.services.auth.rbac import get_request_identity
+from app.services.auth import require_permission
 from app.services.source_services import source_service
 
 
@@ -99,6 +100,7 @@ def google_list_files():
 
 
 @google_bp.route('/projects/<project_id>/sources/google-import', methods=['POST'])
+@require_permission("document_sources", "google_drive")
 def google_import_file(project_id):
     """
     Import a file from Google Drive to project sources.

--- a/backend/app/api/sources/routes.py
+++ b/backend/app/api/sources/routes.py
@@ -31,12 +31,56 @@ Routes:
 - GET    /projects/<id>/sources/summary  - Aggregate stats
 - GET    /sources/allowed-types          - List allowed extensions
 """
+from pathlib import Path
+from typing import Optional, Tuple
+
 from flask import jsonify, request, current_app, send_file, redirect
 from app.api.sources import sources_bp
 from app.services.source_services import SourceService
+from app.services.auth.rbac import get_request_identity
+from app.services.auth.permissions import user_has_permission
 
 # Initialize service
 source_service = SourceService()
+
+
+# Map file extensions to permission (category, item) tuples.
+# Educational Note: File uploads go through a single endpoint regardless of type,
+# so we check permissions inline based on the uploaded file's extension.
+_EXT_PERMISSION_MAP = {
+    # document_sources
+    ".pdf": ("document_sources", "pdf"),
+    ".docx": ("document_sources", "docx"),
+    ".pptx": ("document_sources", "pptx"),
+    ".txt": ("document_sources", "text"),
+    ".md": ("document_sources", "text"),
+    ".json": ("document_sources", "text"),
+    ".html": ("document_sources", "text"),
+    ".xml": ("document_sources", "text"),
+    # document_sources — images
+    ".png": ("document_sources", "image"),
+    ".jpg": ("document_sources", "image"),
+    ".jpeg": ("document_sources", "image"),
+    ".gif": ("document_sources", "image"),
+    ".webp": ("document_sources", "image"),
+    # document_sources — audio
+    ".mp3": ("document_sources", "audio"),
+    ".wav": ("document_sources", "audio"),
+    ".m4a": ("document_sources", "audio"),
+    ".aac": ("document_sources", "audio"),
+    ".flac": ("document_sources", "audio"),
+    # data_sources
+    ".csv": ("data_sources", "csv"),
+}
+
+
+def _get_upload_permission(filename: str) -> Optional[Tuple[str, str]]:
+    """
+    Return the (category, item) permission tuple for a given filename,
+    or None if no specific permission is required.
+    """
+    ext = Path(filename).suffix.lower()
+    return _EXT_PERMISSION_MAP.get(ext)
 
 
 @sources_bp.route('/projects/<project_id>/sources', methods=['GET'])
@@ -112,6 +156,18 @@ def upload_source(project_id: str):
                 'success': False,
                 'error': 'No file selected'
             }), 400
+
+        # Permission check based on file type
+        # Educational Note: One upload endpoint handles all file types, so we
+        # resolve the permission from the extension and check inline.
+        perm = _get_upload_permission(file.filename)
+        if perm:
+            identity = get_request_identity()
+            if not identity.is_admin and not user_has_permission(identity.user_id, perm[0], perm[1]):
+                return jsonify({
+                    'success': False,
+                    'error': 'This file type is not available for your account. Contact your admin.'
+                }), 403
 
         # Get optional fields from form data
         name = request.form.get('name')

--- a/backend/app/api/sources/uploads.py
+++ b/backend/app/api/sources/uploads.py
@@ -38,12 +38,14 @@ from flask import jsonify, request, current_app
 from app.api.sources import sources_bp
 from app.services.source_services import SourceService
 from app.services.auth.rbac import get_request_identity
+from app.services.auth import require_permission
 
 # Initialize service
 source_service = SourceService()
 
 
 @sources_bp.route('/projects/<project_id>/sources/url', methods=['POST'])
+@require_permission("document_sources", "url_youtube")
 def add_url_source(project_id: str):
     """
     Add a URL source (website or YouTube link) to a project.
@@ -118,6 +120,7 @@ def add_url_source(project_id: str):
 
 
 @sources_bp.route('/projects/<project_id>/sources/text', methods=['POST'])
+@require_permission("document_sources", "text")
 def add_text_source(project_id: str):
     """
     Add a pasted text source to a project.
@@ -281,6 +284,7 @@ def add_research_source(project_id: str):
 
 
 @sources_bp.route('/projects/<project_id>/sources/database', methods=['POST'])
+@require_permission("data_sources", "database")
 def add_database_source(project_id: str):
     """
     Add a database source (Postgres/MySQL) to a project.
@@ -325,6 +329,7 @@ def add_database_source(project_id: str):
 
 
 @sources_bp.route('/projects/<project_id>/sources/freshdesk', methods=['POST'])
+@require_permission("data_sources", "freshdesk")
 def add_freshdesk_source_endpoint(project_id: str):
     """
     Add a Freshdesk ticket source to a project.

--- a/backend/app/api/studio/ads.py
+++ b/backend/app/api/studio/ads.py
@@ -36,9 +36,11 @@ from app.services.studio_services.ad_creative_service import ad_creative_service
 from app.services.integrations.google.imagen_service import imagen_service
 from app.services.integrations.supabase import storage_service
 from app.services.background_services.task_service import task_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/ad-creative', methods=['POST'])
+@require_permission("studio", "ad_creative")
 def generate_ad_creative(project_id: str):
     """
     Start ad creative generation as a background task.

--- a/backend/app/api/studio/audio.py
+++ b/backend/app/api/studio/audio.py
@@ -35,9 +35,11 @@ from app.services.source_services import source_index_service
 from app.services.integrations.elevenlabs import tts_service
 from app.services.integrations.supabase import storage_service  # For downloading previous scripts during edits
 from app.services.background_services.task_service import task_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/audio-overview', methods=['POST'])
+@require_permission("studio", "audio_overview")
 def generate_audio_overview(project_id: str):
     """
     Start audio overview generation or edit as a background task.

--- a/backend/app/api/studio/blogs.py
+++ b/backend/app/api/studio/blogs.py
@@ -36,9 +36,11 @@ from app.services.studio_services import studio_index_service
 from app.services.tool_executors.blog_agent_executor import blog_agent_executor
 from app.services.integrations.supabase import storage_service
 from app.api.studio.logo_utils import resolve_logo
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/blog', methods=['POST'])
+@require_permission("studio", "blogs")
 def generate_blog_post(project_id: str):
     """
     Start blog post generation or edit via blog agent.

--- a/backend/app/api/studio/business_reports.py
+++ b/backend/app/api/studio/business_reports.py
@@ -36,9 +36,11 @@ from app.api.studio import studio_bp
 from app.services.studio_services import studio_index_service
 from app.services.tool_executors.business_report_agent_executor import business_report_agent_executor
 from app.services.integrations.supabase import storage_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/business-report', methods=['POST'])
+@require_permission("studio", "business_reports")
 def generate_business_report(project_id: str):
     """
     Start business report generation via business report agent.

--- a/backend/app/api/studio/components.py
+++ b/backend/app/api/studio/components.py
@@ -32,9 +32,11 @@ from app.api.studio import studio_bp
 from app.services.studio_services import studio_index_service
 from app.services.tool_executors.component_agent_executor import component_agent_executor
 from app.services.integrations.supabase import storage_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/components', methods=['POST'])
+@require_permission("studio", "components")
 def generate_components(project_id: str):
     """
     Start component generation via component agent.

--- a/backend/app/api/studio/emails.py
+++ b/backend/app/api/studio/emails.py
@@ -36,9 +36,11 @@ from app.api.studio import studio_bp
 from app.services.studio_services import studio_index_service
 from app.services.tool_executors.email_agent_executor import email_agent_executor
 from app.services.integrations.supabase import storage_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/email-template', methods=['POST'])
+@require_permission("studio", "emails")
 def generate_email_template(project_id: str):
     """
     Start email template generation or edit via email agent.

--- a/backend/app/api/studio/flash_cards.py
+++ b/backend/app/api/studio/flash_cards.py
@@ -31,9 +31,11 @@ from app.services.studio_services import studio_index_service
 from app.services.studio_services.flash_cards_service import flash_cards_service
 from app.services.source_services import source_index_service
 from app.services.background_services.task_service import task_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/flash-cards', methods=['POST'])
+@require_permission("studio", "flash_cards")
 def generate_flash_cards(project_id: str):
     """
     Start flash card generation or edit as a background task.

--- a/backend/app/api/studio/flow_diagrams.py
+++ b/backend/app/api/studio/flow_diagrams.py
@@ -30,9 +30,11 @@ from app.services.studio_services.flow_diagram_service import flow_diagram_servi
 from app.services.source_services import source_index_service
 from app.services.integrations.supabase import storage_service
 from app.services.background_services.task_service import task_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/flow-diagram', methods=['POST'])
+@require_permission("studio", "flow_diagrams")
 def generate_flow_diagram(project_id: str):
     """
     Start flow diagram generation or edit via background task.

--- a/backend/app/api/studio/infographics.py
+++ b/backend/app/api/studio/infographics.py
@@ -36,9 +36,11 @@ from app.services.integrations.google.imagen_service import imagen_service
 from app.services.integrations.supabase import storage_service
 from app.services.background_services.task_service import task_service
 from app.api.studio.logo_utils import resolve_logo
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/infographic', methods=['POST'])
+@require_permission("studio", "infographics")
 def generate_infographic(project_id: str):
     """
     Start infographic generation as a background task.

--- a/backend/app/api/studio/marketing_strategies.py
+++ b/backend/app/api/studio/marketing_strategies.py
@@ -22,9 +22,11 @@ from flask import jsonify, request, current_app, send_file
 from app.api.studio import studio_bp
 from app.services.studio_services import studio_index_service
 from app.services.integrations.supabase import storage_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/marketing-strategy', methods=['POST'])
+@require_permission("studio", "marketing_strategies")
 def generate_marketing_strategy(project_id: str):
     """
     Start marketing strategy generation (background task).

--- a/backend/app/api/studio/mind_maps.py
+++ b/backend/app/api/studio/mind_maps.py
@@ -32,9 +32,11 @@ from app.services.studio_services import studio_index_service
 from app.services.studio_services.mind_map_service import mind_map_service
 from app.services.source_services import source_index_service
 from app.services.background_services.task_service import task_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/mind-map', methods=['POST'])
+@require_permission("studio", "mind_maps")
 def generate_mind_map(project_id: str):
     """
     Start mind map generation or edit as a background task.

--- a/backend/app/api/studio/prds.py
+++ b/backend/app/api/studio/prds.py
@@ -22,9 +22,11 @@ from flask import jsonify, request, current_app, send_file, Response
 from app.api.studio import studio_bp
 from app.services.studio_services import studio_index_service
 from app.services.integrations.supabase import storage_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/prd', methods=['POST'])
+@require_permission("studio", "prds")
 def generate_prd(project_id: str):
     """
     Start PRD generation (background task).

--- a/backend/app/api/studio/presentations.py
+++ b/backend/app/api/studio/presentations.py
@@ -32,9 +32,11 @@ from flask import jsonify, request, current_app, send_file, Response
 from app.api.studio import studio_bp
 from app.services.studio_services import studio_index_service
 from app.services.integrations.supabase import storage_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/presentation', methods=['POST'])
+@require_permission("studio", "presentations")
 def generate_presentation(project_id: str):
     """
     Start presentation generation or edit (background task).

--- a/backend/app/api/studio/quizzes.py
+++ b/backend/app/api/studio/quizzes.py
@@ -31,9 +31,11 @@ from app.services.studio_services import studio_index_service
 from app.services.studio_services.quiz_service import quiz_service
 from app.services.source_services import source_index_service
 from app.services.background_services.task_service import task_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/quiz', methods=['POST'])
+@require_permission("studio", "quizzes")
 def generate_quiz(project_id: str):
     """
     Start quiz generation or edit as a background task.

--- a/backend/app/api/studio/social_posts.py
+++ b/backend/app/api/studio/social_posts.py
@@ -35,9 +35,11 @@ from app.services.studio_services.social_posts_service import social_posts_servi
 from app.services.integrations.google.imagen_service import imagen_service
 from app.services.integrations.supabase import storage_service
 from app.services.background_services.task_service import task_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/social-posts', methods=['POST'])
+@require_permission("studio", "social_posts")
 def generate_social_posts(project_id: str):
     """
     Start social post generation as a background task.

--- a/backend/app/api/studio/videos.py
+++ b/backend/app/api/studio/videos.py
@@ -31,9 +31,11 @@ from flask import jsonify, request, current_app, send_file
 from app.api.studio import studio_bp
 from app.services.studio_services import studio_index_service
 from app.services.integrations.supabase import storage_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/videos', methods=['POST'])
+@require_permission("studio", "videos")
 def generate_video(project_id: str):
     """
     Start video generation as a background task.

--- a/backend/app/api/studio/websites.py
+++ b/backend/app/api/studio/websites.py
@@ -36,9 +36,11 @@ from flask import jsonify, request, current_app, send_file, Response
 from app.api.studio import studio_bp
 from app.services.studio_services import studio_index_service
 from app.services.integrations.supabase import storage_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route('/projects/<project_id>/studio/website', methods=['POST'])
+@require_permission("studio", "websites")
 def generate_website(project_id: str):
     """
     Start website generation or edit (background task).

--- a/backend/app/api/studio/wireframes.py
+++ b/backend/app/api/studio/wireframes.py
@@ -22,9 +22,11 @@ from app.services.ai_agents.wireframe_agent_service import wireframe_agent_servi
 from app.services.source_services import source_index_service
 from app.services.integrations.supabase import storage_service
 from app.services.background_services.task_service import task_service
+from app.services.auth import require_permission
 
 
 @studio_bp.route("/projects/<project_id>/studio/wireframe", methods=["POST"])
+@require_permission("studio", "wireframes")
 def generate_wireframe(project_id: str):
     """
     Start wireframe generation or edit as a background task.

--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -36,6 +36,7 @@ from flask import has_request_context
 from app.services.auth.rbac import get_request_identity
 from app.services.data_services.project_service import DEFAULT_USER_ID
 from app.utils import claude_parsing_utils
+from app.services.auth.permissions import user_has_permission
 
 
 class ClaudeStreamError(Exception):
@@ -136,22 +137,25 @@ class MainChatService:
         Returns:
             Tuple of (tool definitions list, MCP tool registry dict)
         """
-        # Always include memory and studio_signal tools
-        tools = [
-            self._get_memory_tool(),
-            self._get_studio_signal_tool()
-        ]
+        # Include memory and studio_signal tools only if the user has permission
+        tools = []
+
+        if not user_id or user_has_permission(user_id, "chat_features", "memory"):
+            tools.append(self._get_memory_tool())
+
+        if not user_id or user_has_permission(user_id, "studio"):
+            tools.append(self._get_studio_signal_tool())
 
         if has_active_sources:
             tools.append(self._get_search_tool())
 
-        if has_csv_sources:
+        if has_csv_sources and (not user_id or user_has_permission(user_id, "data_sources", "csv")):
             tools.append(self._get_csv_analyzer_tool())
 
-        if has_database_sources:
+        if has_database_sources and (not user_id or user_has_permission(user_id, "data_sources", "database")):
             tools.append(self._get_database_analyzer_tool())
 
-        if has_freshdesk_sources:
+        if has_freshdesk_sources and (not user_id or user_has_permission(user_id, "data_sources", "freshdesk")):
             tools.append(self._get_freshdesk_analyzer_tool())
 
         # Add all configured knowledge base tools (Jira, Notion, GitHub, etc.)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { projectsAPI } from './lib/api';
 import { AuthPage } from './components/auth/AuthPage';
 import { authAPI } from './lib/api/auth';
 import { createLogger } from '@/lib/logger';
+import { PermissionsProvider } from './contexts/PermissionsContext';
 
 const log = createLogger('app');
 
@@ -236,40 +237,42 @@ function App() {
   }
 
   return (
-    <BrowserRouter>
-      <Routes>
-        {/* Project Workspace - URL-based routing */}
-        <Route
-          path="/projects/:projectId"
-          element={
-            <ProjectWorkspaceRoute
-              setRefreshTrigger={setRefreshTrigger}
-              isAuthenticated={isAuthenticated}
-              onSignOut={handleSignOut}
-            />
-          }
-        />
+    <PermissionsProvider>
+      <BrowserRouter>
+        <Routes>
+          {/* Project Workspace - URL-based routing */}
+          <Route
+            path="/projects/:projectId"
+            element={
+              <ProjectWorkspaceRoute
+                setRefreshTrigger={setRefreshTrigger}
+                isAuthenticated={isAuthenticated}
+                onSignOut={handleSignOut}
+              />
+            }
+          />
 
-        {/* Dashboard - Home/root route */}
-        <Route
-          path="*"
-          element={
-            <AppContent
-              showCreateDialog={showCreateDialog}
-              setShowCreateDialog={setShowCreateDialog}
-              refreshTrigger={refreshTrigger}
-              setRefreshTrigger={setRefreshTrigger}
-              isAdmin={isAdmin}
-              isAuthenticated={isAuthenticated}
-              onSignOut={handleSignOut}
-              userId={userId}
-              userEmail={userEmail}
-              userRole={userRole}
-            />
-          }
-        />
-      </Routes>
-    </BrowserRouter>
+          {/* Dashboard - Home/root route */}
+          <Route
+            path="*"
+            element={
+              <AppContent
+                showCreateDialog={showCreateDialog}
+                setShowCreateDialog={setShowCreateDialog}
+                refreshTrigger={refreshTrigger}
+                setRefreshTrigger={setRefreshTrigger}
+                isAdmin={isAdmin}
+                isAuthenticated={isAuthenticated}
+                onSignOut={handleSignOut}
+                userId={userId}
+                userEmail={userEmail}
+                userRole={userRole}
+              />
+            }
+          />
+        </Routes>
+      </BrowserRouter>
+    </PermissionsProvider>
   );
 }
 

--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -15,6 +15,7 @@ import {
 import { Sparkle, Plus, ChatCircle, CaretDown, Hash, Books, DownloadSimple, CircleNotch, CurrencyDollar } from '@phosphor-icons/react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { Button } from '../ui/button';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import type { Chat, ChatMetadata } from '../../lib/api/chats';
 import type { CostTracking } from '../../lib/api/projects';
 
@@ -61,6 +62,8 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
   onExportChat,
   exportingChat,
 }) => {
+  const { hasPermission } = usePermissions();
+
   return (
     <div className="border-b px-4 py-3">
       {/* Title row - matches Sources/Studio/ChatEmptyState structure */}
@@ -105,27 +108,29 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
           </DropdownMenu>
         </div>
         <div className="flex items-center gap-2">
-          {/* Export chat button */}
-          <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={onExportChat}
-                disabled={!activeChat || !activeChat.messages?.length || exportingChat}
-                className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
-              >
-                {exportingChat ? (
-                  <CircleNotch size={32} weight="bold" className="animate-spin" />
-                ) : (
-                  <DownloadSimple size={32} weight="bold" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Export as PDF</TooltipContent>
-          </Tooltip>
-          </TooltipProvider>
+          {/* Export chat button — hidden when chat_export permission is disabled */}
+          {hasPermission("chat_features", "chat_export") && (
+            <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onExportChat}
+                  disabled={!activeChat || !activeChat.messages?.length || exportingChat}
+                  className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
+                >
+                  {exportingChat ? (
+                    <CircleNotch size={32} weight="bold" className="animate-spin" />
+                  ) : (
+                    <DownloadSimple size={32} weight="bold" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Export as PDF</TooltipContent>
+            </Tooltip>
+            </TooltipProvider>
+          )}
 
           {/* Source count indicator */}
           <div className="flex items-center gap-1.5 px-2 py-1 bg-muted rounded-md">

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -8,6 +8,7 @@
 import React, { useRef, useEffect } from 'react';
 import { Textarea } from '../ui/textarea';
 import { PaperPlaneTilt, Microphone, CodeBlock, StopCircle } from '@phosphor-icons/react';
+import { usePermissions } from '@/contexts/PermissionsContext';
 
 interface ChatInputProps {
   message: string;
@@ -37,6 +38,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   onToggleRawMode,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { hasPermission } = usePermissions();
+  const canUseVoice = hasPermission("chat_features", "voice_input");
 
   // Display value combines typed message and partial transcript
   const displayMessage = partialTranscript
@@ -72,28 +75,30 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     <div className="p-4 pt-2">
       {/* Floating pill container - mic, textarea, send all inside */}
       <div className="flex items-center gap-2 border rounded-2xl px-3 py-2 bg-background">
-        {/* Microphone Button - seamlessly integrated */}
-        <button
-          type="button"
-          onClick={onMicClick}
-          disabled={sending || !transcriptionConfigured}
-          title={
-            !transcriptionConfigured
-              ? 'Set up ElevenLabs API key in settings'
-              : sending
-              ? 'Wait for response to complete'
-              : isRecording
-              ? 'Click to stop recording'
-              : 'Click to start recording'
-          }
-          className={`flex-shrink-0 p-1.5 rounded-full transition-colors ${
-            isRecording
-              ? 'bg-red-500 text-white animate-pulse'
-              : 'text-muted-foreground hover:text-foreground'
-          } ${sending || !transcriptionConfigured ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-        >
-          <Microphone size={18} />
-        </button>
+        {/* Microphone Button — hidden when voice_input permission is disabled */}
+        {canUseVoice && (
+          <button
+            type="button"
+            onClick={onMicClick}
+            disabled={sending || !transcriptionConfigured}
+            title={
+              !transcriptionConfigured
+                ? 'Set up ElevenLabs API key in settings'
+                : sending
+                ? 'Wait for response to complete'
+                : isRecording
+                ? 'Click to stop recording'
+                : 'Click to start recording'
+            }
+            className={`flex-shrink-0 p-1.5 rounded-full transition-colors ${
+              isRecording
+                ? 'bg-red-500 text-white animate-pulse'
+                : 'text-muted-foreground hover:text-foreground'
+            } ${sending || !transcriptionConfigured ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+          >
+            <Microphone size={18} />
+          </button>
+        )}
 
         {/* Textarea - no border, blends with container */}
         <Textarea
@@ -153,7 +158,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       </div>
 
       <p className="text-xs text-muted-foreground mt-2 text-center">
-        {isRecording
+        {!canUseVoice
+          ? 'Type your message'
+          : isRecording
           ? 'Listening... Click mic to stop'
           : !transcriptionConfigured
           ? 'Voice input requires ElevenLabs API key (Admin Settings)'

--- a/frontend/src/components/settings/sections/PermissionsModal.tsx
+++ b/frontend/src/components/settings/sections/PermissionsModal.tsx
@@ -1,0 +1,409 @@
+/**
+ * PermissionsModal Component
+ * Per-user module permissions editor for admin settings.
+ * 5 collapsible categories with master + individual toggles.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  CaretDown,
+  CaretRight,
+  CircleNotch,
+  ShieldCheck,
+  Files,
+  Database,
+  Palette,
+  Plugs,
+  ChatCircle,
+  Minus,
+} from '@phosphor-icons/react';
+import { usersAPI } from '@/lib/api/settings';
+import type { UserPermissions } from '@/lib/api/settings';
+import { useToast } from '@/components/ui/use-toast';
+import { createLogger } from '@/lib/logger';
+import { cn } from '@/lib/utils';
+
+const log = createLogger('permissions-modal');
+
+// ---------------------------------------------------------------------------
+// Category config — icon, label, description, sub-items
+// ---------------------------------------------------------------------------
+
+const CATEGORY_CONFIG: Record<
+  keyof UserPermissions,
+  {
+    label: string;
+    description: string;
+    icon: React.ElementType;
+    iconColor: string;
+    items: Record<string, string>;
+  }
+> = {
+  document_sources: {
+    label: 'Document Sources',
+    description: 'Upload and process files',
+    icon: Files,
+    iconColor: 'text-blue-600 bg-blue-50',
+    items: {
+      pdf: 'PDF',
+      docx: 'DOCX',
+      pptx: 'PPTX',
+      image: 'Images',
+      audio: 'Audio',
+      url_youtube: 'URL / YouTube',
+      text: 'Text / Paste',
+      google_drive: 'Google Drive',
+    },
+  },
+  data_sources: {
+    label: 'Data Sources',
+    description: 'Live data connections',
+    icon: Database,
+    iconColor: 'text-emerald-600 bg-emerald-50',
+    items: {
+      database: 'Database (PostgreSQL / MySQL)',
+      csv: 'CSV Files',
+      freshdesk: 'Freshdesk Tickets',
+    },
+  },
+  studio: {
+    label: 'Studio',
+    description: 'Content generation',
+    icon: Palette,
+    iconColor: 'text-violet-600 bg-violet-50',
+    items: {
+      audio_overview: 'Audio Overview',
+      ad_creative: 'Ad Creative',
+      flash_cards: 'Flash Cards',
+      flow_diagrams: 'Flow Diagrams',
+      infographics: 'Infographics',
+      mind_maps: 'Mind Maps',
+      quizzes: 'Quizzes',
+      social_posts: 'Social Posts',
+      emails: 'Email Templates',
+      websites: 'Websites',
+      components: 'UI Components',
+      videos: 'Videos',
+      wireframes: 'Wireframes',
+      presentations: 'Presentations',
+      prds: 'PRDs',
+      marketing_strategies: 'Marketing Strategies',
+      blogs: 'Blogs',
+      business_reports: 'Business Reports',
+    },
+  },
+  integrations: {
+    label: 'Integrations',
+    description: 'Third-party services',
+    icon: Plugs,
+    iconColor: 'text-amber-600 bg-amber-50',
+    items: {
+      jira: 'Jira',
+      notion: 'Notion',
+      mcp: 'MCP Connections',
+      elevenlabs: 'ElevenLabs (Voice)',
+    },
+  },
+  chat_features: {
+    label: 'Chat Features',
+    description: 'Advanced capabilities',
+    icon: ChatCircle,
+    iconColor: 'text-rose-600 bg-rose-50',
+    items: {
+      memory: 'Memory (Store / Recall)',
+      voice_input: 'Voice Input',
+      chat_export: 'Chat Export (PDF)',
+    },
+  },
+};
+
+const CATEGORY_ORDER: (keyof UserPermissions)[] = [
+  'document_sources',
+  'data_sources',
+  'studio',
+  'integrations',
+  'chat_features',
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildDefaultPermissions(): UserPermissions {
+  const perms: Record<string, { enabled: boolean; items: Record<string, boolean> }> = {};
+  for (const key of CATEGORY_ORDER) {
+    const items: Record<string, boolean> = {};
+    for (const itemKey of Object.keys(CATEGORY_CONFIG[key].items)) {
+      items[itemKey] = true;
+    }
+    perms[key] = { enabled: true, items };
+  }
+  return perms as unknown as UserPermissions;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface PermissionsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  userId: string;
+  userEmail: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const PermissionsModal: React.FC<PermissionsModalProps> = ({
+  open,
+  onOpenChange,
+  userId,
+  userEmail,
+}) => {
+  const [permissions, setPermissions] = useState<UserPermissions>(buildDefaultPermissions());
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
+    new Set(['document_sources', 'data_sources']),
+  );
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const { success, error } = useToast();
+
+  // Fetch on open
+  const loadPermissions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const perms = await usersAPI.getUserPermissions(userId);
+      setPermissions(perms);
+    } catch (err) {
+      log.error({ err }, 'failed to load permissions');
+      setPermissions(buildDefaultPermissions());
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    if (open) loadPermissions();
+  }, [open, loadPermissions]);
+
+  // --------------------------------------------------
+  // Toggle logic
+  // --------------------------------------------------
+
+  const toggleCategory = (catKey: keyof UserPermissions) => {
+    setPermissions((prev) => {
+      const cat = prev[catKey];
+      const next = !cat.enabled;
+      const items: Record<string, boolean> = {};
+      for (const k of Object.keys(cat.items)) items[k] = next;
+      return { ...prev, [catKey]: { enabled: next, items } };
+    });
+  };
+
+  const toggleItem = (catKey: keyof UserPermissions, itemKey: string) => {
+    setPermissions((prev) => {
+      const cat = prev[catKey];
+      const items = { ...cat.items, [itemKey]: !cat.items[itemKey] };
+      const anyOn = Object.values(items).some(Boolean);
+      return { ...prev, [catKey]: { enabled: anyOn, items } };
+    });
+  };
+
+  const toggleExpanded = (key: string) => {
+    setExpandedCategories((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  };
+
+  // --------------------------------------------------
+  // Save
+  // --------------------------------------------------
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await usersAPI.updateUserPermissions(userId, permissions);
+      success('Permissions updated');
+      onOpenChange(false);
+    } catch (err) {
+      log.error({ err }, 'failed to save permissions');
+      const axErr = err as { response?: { data?: { error?: string } } };
+      error(axErr.response?.data?.error || 'Failed to save permissions');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Count enabled / total for a category
+  const countEnabled = (catKey: keyof UserPermissions) => {
+    const items = permissions[catKey].items;
+    const total = Object.keys(items).length;
+    const on = Object.values(items).filter(Boolean).length;
+    return { on, total };
+  };
+
+  // --------------------------------------------------
+  // Render
+  // --------------------------------------------------
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px] max-h-[85vh] flex flex-col gap-0 p-0 overflow-hidden">
+        {/* Header */}
+        <DialogHeader className="px-6 pt-6 pb-4 border-b bg-stone-50/50">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-amber-100">
+              <ShieldCheck size={20} weight="duotone" className="text-amber-700" />
+            </div>
+            <div>
+              <DialogTitle className="text-base">Module Permissions</DialogTitle>
+              <p className="text-sm text-muted-foreground mt-0.5">{userEmail}</p>
+            </div>
+          </div>
+        </DialogHeader>
+
+        {/* Body */}
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <CircleNotch size={24} className="animate-spin text-stone-300" />
+          </div>
+        ) : (
+          <div className="overflow-y-auto flex-1 px-6 py-4 space-y-2">
+            {CATEGORY_ORDER.map((catKey) => {
+              const config = CATEGORY_CONFIG[catKey];
+              const cat = permissions[catKey];
+              const isExpanded = expandedCategories.has(catKey);
+              const { on, total } = countEnabled(catKey);
+              const allOn = on === total;
+              const noneOn = on === 0;
+              const isIndeterminate = !noneOn && !allOn;
+              const Icon = config.icon;
+
+              return (
+                <div
+                  key={catKey}
+                  className={cn(
+                    'rounded-lg border transition-colors',
+                    isExpanded ? 'border-stone-200 bg-white' : 'border-stone-100 bg-stone-50/50 hover:bg-stone-50',
+                  )}
+                >
+                  {/* Category row */}
+                  <div className="flex items-center gap-3 px-4 py-3">
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(catKey)}
+                      className="text-stone-400 hover:text-stone-600 transition-colors"
+                    >
+                      {isExpanded ? <CaretDown size={12} weight="bold" /> : <CaretRight size={12} weight="bold" />}
+                    </button>
+
+                    <div className={cn('p-1.5 rounded-md', config.iconColor)}>
+                      <Icon size={14} weight="duotone" />
+                    </div>
+
+                    <Checkbox
+                      checked={isIndeterminate ? 'indeterminate' : cat.enabled}
+                      onCheckedChange={() => toggleCategory(catKey)}
+                    />
+
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(catKey)}
+                      className="flex-1 text-left flex items-center justify-between min-w-0"
+                    >
+                      <div className="min-w-0">
+                        <span className="text-sm font-medium text-stone-800">
+                          {config.label}
+                        </span>
+                        <span className="hidden sm:inline ml-2 text-xs text-stone-400">
+                          {config.description}
+                        </span>
+                      </div>
+
+                      {/* Counter pill */}
+                      <span
+                        className={cn(
+                          'text-[11px] font-medium px-2 py-0.5 rounded-full flex-shrink-0 ml-2 tabular-nums',
+                          noneOn
+                            ? 'bg-red-50 text-red-600'
+                            : allOn
+                              ? 'bg-emerald-50 text-emerald-600'
+                              : 'bg-amber-50 text-amber-700',
+                        )}
+                      >
+                        {on}/{total}
+                      </span>
+                    </button>
+                  </div>
+
+                  {/* Expanded items */}
+                  {isExpanded && (
+                    <div className="px-4 pb-3 pl-[4.25rem]">
+                      <div className="border-t border-dashed border-stone-150 pt-3 flex flex-wrap gap-x-1 gap-y-1">
+                        {Object.entries(config.items).map(([itemKey, label]) => {
+                          const isOn = cat.items[itemKey] !== false;
+                          return (
+                            <button
+                              key={itemKey}
+                              type="button"
+                              onClick={() => toggleItem(catKey, itemKey)}
+                              className={cn(
+                                'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-all',
+                                'border cursor-pointer select-none',
+                                isOn
+                                  ? 'bg-stone-800 text-white border-stone-800 hover:bg-stone-700'
+                                  : 'bg-white text-stone-400 border-stone-200 hover:border-stone-300 hover:text-stone-500 line-through decoration-stone-300',
+                              )}
+                            >
+                              {isOn ? (
+                                <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 flex-shrink-0" />
+                              ) : (
+                                <Minus size={10} className="flex-shrink-0 opacity-50" />
+                              )}
+                              {label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Footer */}
+        <DialogFooter className="px-6 py-4 border-t bg-stone-50/30">
+          <Button variant="soft" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving || loading}>
+            {saving ? (
+              <>
+                <CircleNotch size={14} className="animate-spin mr-1.5" />
+                Saving...
+              </>
+            ) : (
+              'Save Permissions'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/settings/sections/TeamSection.tsx
+++ b/frontend/src/components/settings/sections/TeamSection.tsx
@@ -40,6 +40,7 @@ import {
   DotsThreeVertical,
   Key,
   Trash,
+  Sliders,
 } from '@phosphor-icons/react';
 import { usersAPI } from '@/lib/api/settings';
 import type { UserSummary } from '@/lib/api/settings';
@@ -47,6 +48,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { CreateUserDialog } from '../team/CreateUserDialog';
 import { DeleteUserDialog } from '../team/DeleteUserDialog';
 import { PasswordDisplay } from '../team/PasswordDisplay';
+import { PermissionsModal } from './PermissionsModal';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('team-section');
@@ -67,6 +69,7 @@ export const TeamSection: React.FC<TeamSectionProps> = ({ currentUserId }) => {
   const [selectedUser, setSelectedUser] = useState<UserSummary | null>(null);
   const [resetPassword, setResetPassword] = useState('');
   const [resettingPassword, setResettingPassword] = useState(false);
+  const [editingPermissionsUser, setEditingPermissionsUser] = useState<UserSummary | null>(null);
 
   const { success, error } = useToast();
 
@@ -223,6 +226,10 @@ export const TeamSection: React.FC<TeamSectionProps> = ({ currentUserId }) => {
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => setEditingPermissionsUser(user)}>
+                          <Sliders size={16} className="mr-2" />
+                          Edit Permissions
+                        </DropdownMenuItem>
                         <DropdownMenuItem onClick={() => openResetPasswordDialog(user)}>
                           <Key size={16} className="mr-2" />
                           Reset Password
@@ -260,6 +267,16 @@ export const TeamSection: React.FC<TeamSectionProps> = ({ currentUserId }) => {
           userId={selectedUser.id}
           userEmail={selectedUser.email || selectedUser.id}
           onUserDeleted={handleUserDeleted}
+        />
+      )}
+
+      {/* Edit Permissions Modal */}
+      {editingPermissionsUser && (
+        <PermissionsModal
+          open={!!editingPermissionsUser}
+          onOpenChange={(open) => { if (!open) setEditingPermissionsUser(null); }}
+          userId={editingPermissionsUser.id}
+          userEmail={editingPermissionsUser.email || ''}
         />
       )}
 

--- a/frontend/src/components/sources/AddSourcesSheet.tsx
+++ b/frontend/src/components/sources/AddSourcesSheet.tsx
@@ -15,6 +15,7 @@ import { ResearchTab } from './ResearchTab';
 import { DatabaseTab } from './DatabaseTab';
 import { McpTab } from './McpTab';
 import { FreshdeskTab } from './FreshdeskTab';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import { MAX_SOURCES } from '../../lib/api/sources';
 
 interface AddSourcesSheetProps {
@@ -49,6 +50,34 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
   uploading,
 }) => {
   const isAtLimit = sourcesCount >= MAX_SOURCES;
+  const { hasPermission } = usePermissions();
+
+  // Permission checks for each source tab
+  // Upload covers PDF, DOCX, PPTX, Image, Audio — show if any document_sources sub-type is allowed
+  const canUpload = hasPermission('document_sources', 'pdf');
+  const canLink = hasPermission('document_sources', 'url_youtube');
+  const canPaste = hasPermission('document_sources', 'text');
+  const canDrive = hasPermission('document_sources', 'google_drive');
+  const canDatabase = hasPermission('data_sources', 'database');
+  const canFreshdesk = hasPermission('data_sources', 'freshdesk');
+  // Note: CSV permission exists (hasPermission('data_sources', 'csv')) but no CSV tab yet
+
+  // Research and MCP are always shown (no dedicated permission key) — gated at category level
+  const canResearch = hasPermission('document_sources');
+  const canMcp = hasPermission('data_sources');
+
+  // Pick the first visible tab as default
+  const defaultTab = canUpload ? 'upload'
+    : canLink ? 'link'
+    : canPaste ? 'paste'
+    : canDrive ? 'drive'
+    : canResearch ? 'research'
+    : canDatabase ? 'database'
+    : canMcp ? 'mcp'
+    : canFreshdesk ? 'freshdesk'
+    : 'upload';
+
+  const tabTriggerClass = "px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white";
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -63,124 +92,132 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
             matters most to you. ({sourcesCount}/{MAX_SOURCES} used)
           </p>
 
-          <Tabs defaultValue="upload" className="w-full">
+          <Tabs defaultValue={defaultTab} className="w-full">
             <TabsList className="w-full h-auto flex flex-wrap gap-2 bg-transparent p-0">
-              <TabsTrigger
-                value="upload"
-                className="px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white"
-              >
-                Upload
-              </TabsTrigger>
-              <TabsTrigger
-                value="link"
-                className="px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white"
-              >
-                Link
-              </TabsTrigger>
-              <TabsTrigger
-                value="paste"
-                className="px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white"
-              >
-                Paste
-              </TabsTrigger>
-              <TabsTrigger
-                value="drive"
-                className="px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white"
-              >
-                Drive
-              </TabsTrigger>
-              <TabsTrigger
-                value="research"
-                className="px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white"
-              >
-                Research
-              </TabsTrigger>
-              <TabsTrigger
-                value="database"
-                className="px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white"
-              >
-                Database
-              </TabsTrigger>
-              <TabsTrigger
-                value="mcp"
-                className="px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white"
-              >
-                MCP
-              </TabsTrigger>
-              <TabsTrigger
-                value="freshdesk"
-                className="px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white"
-              >
-                Freshdesk
-              </TabsTrigger>
+              {canUpload && (
+                <TabsTrigger value="upload" className={tabTriggerClass}>
+                  Upload
+                </TabsTrigger>
+              )}
+              {canLink && (
+                <TabsTrigger value="link" className={tabTriggerClass}>
+                  Link
+                </TabsTrigger>
+              )}
+              {canPaste && (
+                <TabsTrigger value="paste" className={tabTriggerClass}>
+                  Paste
+                </TabsTrigger>
+              )}
+              {canDrive && (
+                <TabsTrigger value="drive" className={tabTriggerClass}>
+                  Drive
+                </TabsTrigger>
+              )}
+              {canResearch && (
+                <TabsTrigger value="research" className={tabTriggerClass}>
+                  Research
+                </TabsTrigger>
+              )}
+              {canDatabase && (
+                <TabsTrigger value="database" className={tabTriggerClass}>
+                  Database
+                </TabsTrigger>
+              )}
+              {canMcp && (
+                <TabsTrigger value="mcp" className={tabTriggerClass}>
+                  MCP
+                </TabsTrigger>
+              )}
+              {canFreshdesk && (
+                <TabsTrigger value="freshdesk" className={tabTriggerClass}>
+                  Freshdesk
+                </TabsTrigger>
+              )}
             </TabsList>
 
-            <TabsContent value="upload" className="mt-6">
-              <UploadTab
-                onUpload={onUpload}
-                uploading={uploading}
-                isAtLimit={isAtLimit}
-              />
-            </TabsContent>
+            {canUpload && (
+              <TabsContent value="upload" className="mt-6">
+                <UploadTab
+                  onUpload={onUpload}
+                  uploading={uploading}
+                  isAtLimit={isAtLimit}
+                />
+              </TabsContent>
+            )}
 
-            <TabsContent value="link" className="mt-6">
-              <LinkTab onAddUrl={onAddUrl} isAtLimit={isAtLimit} />
-            </TabsContent>
+            {canLink && (
+              <TabsContent value="link" className="mt-6">
+                <LinkTab onAddUrl={onAddUrl} isAtLimit={isAtLimit} />
+              </TabsContent>
+            )}
 
-            <TabsContent value="paste" className="mt-6">
-              <PasteTab onAddText={onAddText} isAtLimit={isAtLimit} />
-            </TabsContent>
+            {canPaste && (
+              <TabsContent value="paste" className="mt-6">
+                <PasteTab onAddText={onAddText} isAtLimit={isAtLimit} />
+              </TabsContent>
+            )}
 
-            <TabsContent value="drive" className="mt-6">
-              <GoogleDriveTab
-                projectId={projectId}
-                onImportComplete={() => {
-                  onImportComplete();
-                  onOpenChange(false); // Close sheet after import
-                }}
-                isAtLimit={isAtLimit}
-              />
-            </TabsContent>
+            {canDrive && (
+              <TabsContent value="drive" className="mt-6">
+                <GoogleDriveTab
+                  projectId={projectId}
+                  onImportComplete={() => {
+                    onImportComplete();
+                    onOpenChange(false); // Close sheet after import
+                  }}
+                  isAtLimit={isAtLimit}
+                />
+              </TabsContent>
+            )}
 
-            <TabsContent value="research" className="mt-6">
-              <ResearchTab
-                onAddResearch={onAddResearch}
-                isAtLimit={isAtLimit}
-              />
-            </TabsContent>
+            {canResearch && (
+              <TabsContent value="research" className="mt-6">
+                <ResearchTab
+                  onAddResearch={onAddResearch}
+                  isAtLimit={isAtLimit}
+                />
+              </TabsContent>
+            )}
 
-            <TabsContent value="database" className="mt-6">
-              <DatabaseTab
-                isAtLimit={isAtLimit}
-                onAddDatabase={async (connectionId, name, description) => {
-                  await onAddDatabase(connectionId, name, description);
-                  onImportComplete();
-                  onOpenChange(false);
-                }}
-              />
-            </TabsContent>
+            {canDatabase && (
+              <TabsContent value="database" className="mt-6">
+                <DatabaseTab
+                  isAtLimit={isAtLimit}
+                  onAddDatabase={async (connectionId, name, description) => {
+                    await onAddDatabase(connectionId, name, description);
+                    onImportComplete();
+                    onOpenChange(false);
+                  }}
+                />
+              </TabsContent>
+            )}
 
-            <TabsContent value="mcp" className="mt-6">
-              <McpTab
-                isAtLimit={isAtLimit}
-                onAddMcp={async (connectionId, resourceUris, name, description) => {
-                  await onAddMcp(connectionId, resourceUris, name, description);
-                  onImportComplete();
-                  onOpenChange(false);
-                }}
-              />
-            </TabsContent>
+            {canMcp && (
+              <TabsContent value="mcp" className="mt-6">
+                <McpTab
+                  isAtLimit={isAtLimit}
+                  onAddMcp={async (connectionId, resourceUris, name, description) => {
+                    await onAddMcp(connectionId, resourceUris, name, description);
+                    onImportComplete();
+                    onOpenChange(false);
+                  }}
+                />
+              </TabsContent>
+            )}
 
-            <TabsContent value="freshdesk" className="mt-6">
-              <FreshdeskTab
-                isAtLimit={isAtLimit}
-                onAddFreshdesk={async (name, description) => {
-                  await onAddFreshdesk(name, description);
-                  onImportComplete();
-                  onOpenChange(false);
-                }}
-              />
-            </TabsContent>
+            {canFreshdesk && (
+              <TabsContent value="freshdesk" className="mt-6">
+                <FreshdeskTab
+                  isAtLimit={isAtLimit}
+                  onAddFreshdesk={async (name, description) => {
+                    await onAddFreshdesk(name, description);
+                    onImportComplete();
+                    onOpenChange(false);
+                  }}
+                />
+              </TabsContent>
+            )}
           </Tabs>
         </div>
       </SheetContent>

--- a/frontend/src/components/sources/AddSourcesSheet.tsx
+++ b/frontend/src/components/sources/AddSourcesSheet.tsx
@@ -54,7 +54,9 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
 
   // Permission checks for each source tab
   // Upload covers PDF, DOCX, PPTX, Image, Audio — show if any document_sources sub-type is allowed
-  const canUpload = hasPermission('document_sources', 'pdf');
+  const canUpload = ['pdf', 'docx', 'pptx', 'image', 'audio'].some(
+    (item) => hasPermission('document_sources', item)
+  );
   const canLink = hasPermission('document_sources', 'url_youtube');
   const canPaste = hasPermission('document_sources', 'text');
   const canDrive = hasPermission('document_sources', 'google_drive');

--- a/frontend/src/components/studio/StudioToolItem.tsx
+++ b/frontend/src/components/studio/StudioToolItem.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { Button } from '../ui/button';
 import { cn } from '@/lib/utils';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import type { GenerationOption, StudioSignal, StudioItemId } from './types';
 
 interface StudioToolItemProps {
@@ -16,15 +17,40 @@ interface StudioToolItemProps {
   onClick: (optionId: StudioItemId, signals: StudioSignal[]) => void;
 }
 
+/**
+ * Maps studio option IDs (singular/shorthand) to permission item keys (plural/full).
+ * Only entries where the two names differ are listed — identical keys fall through.
+ */
+const STUDIO_PERMISSION_MAP: Partial<Record<StudioItemId, string>> = {
+  quiz: 'quizzes',
+  mind_map: 'mind_maps',
+  business_report: 'business_reports',
+  marketing_strategy: 'marketing_strategies',
+  ads_creative: 'ad_creative',
+  prd: 'prds',
+  flow_diagram: 'flow_diagrams',
+  presentation: 'presentations',
+  blog: 'blogs',
+  social: 'social_posts',
+  website: 'websites',
+  email_templates: 'emails',
+  video: 'videos',
+};
+
 export const StudioToolItem: React.FC<StudioToolItemProps> = ({
   option,
   signals,
   onClick,
 }) => {
+  const { hasPermission } = usePermissions();
+  const permissionKey = STUDIO_PERMISSION_MAP[option.id] ?? option.id;
+
+  // Hide the item entirely when the user lacks permission
+  if (!hasPermission('studio', permissionKey)) return null;
+
   const Icon = option.icon;
   const isActive = signals.length > 0;
 
-  
   return (
     <Button
       variant="soft"

--- a/frontend/src/contexts/PermissionsContext.tsx
+++ b/frontend/src/contexts/PermissionsContext.tsx
@@ -1,0 +1,83 @@
+/**
+ * PermissionsContext
+ * Educational Note: Provides per-user permission state to the entire app tree.
+ * Fetches the current user's permissions from the backend on mount and exposes
+ * a `hasPermission(category, item?)` helper that components can call to gate UI
+ * features. Defaults to "allow" while loading or on error so the app stays
+ * usable even if the permissions endpoint is unavailable.
+ */
+
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import axios from 'axios';
+import { API_BASE_URL } from '@/lib/api/client';
+
+// Permission category structure
+interface PermissionCategory {
+  enabled: boolean;
+  items: Record<string, boolean>;
+}
+
+export interface UserPermissions {
+  document_sources: PermissionCategory;
+  data_sources: PermissionCategory;
+  studio: PermissionCategory;
+  integrations: PermissionCategory;
+  chat_features: PermissionCategory;
+}
+
+interface PermissionsContextValue {
+  permissions: UserPermissions | null;
+  loading: boolean;
+  hasPermission: (category: string, item?: string) => boolean;
+  refreshPermissions: () => Promise<void>;
+}
+
+const PermissionsContext = createContext<PermissionsContextValue>({
+  permissions: null,
+  loading: true,
+  hasPermission: () => true, // Default to allow during loading
+  refreshPermissions: async () => {},
+});
+
+export const usePermissions = () => useContext(PermissionsContext);
+
+export const PermissionsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [permissions, setPermissions] = useState<UserPermissions | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadPermissions = useCallback(async () => {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/settings/users/me/permissions`);
+      if (response.data.success) {
+        setPermissions(response.data.permissions);
+      }
+    } catch {
+      // Silent fail — default to all-enabled if API fails
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPermissions();
+  }, [loadPermissions]);
+
+  const hasPermission = useCallback((category: string, item?: string): boolean => {
+    if (!permissions) return true; // Default allow during loading/error
+
+    const cat = permissions[category as keyof UserPermissions];
+    if (!cat) return true; // Unknown category = allow
+
+    if (!cat.enabled) return false; // Entire category disabled
+
+    if (!item) return true; // Category-level check passed
+
+    return cat.items[item] !== false; // Default to true for unknown items
+  }, [permissions]);
+
+  return (
+    <PermissionsContext.Provider value={{ permissions, loading, hasPermission, refreshPermissions: loadPermissions }}>
+      {children}
+    </PermissionsContext.Provider>
+  );
+};

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -428,6 +428,49 @@ class UsersAPI {
       throw error;
     }
   }
+
+  /**
+   * Get permissions for a specific user
+   * Educational Note: Returns the category-based permission structure that
+   * controls which features are available to this user.
+   */
+  async getUserPermissions(userId: string): Promise<UserPermissions> {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/settings/users/${userId}/permissions`);
+      return response.data.permissions;
+    } catch (error) {
+      log.error({ err: error }, 'failed to fetch user permissions');
+      throw error;
+    }
+  }
+
+  /**
+   * Update permissions for a specific user
+   * Educational Note: Replaces the full permission object for the user.
+   * Only admins should be able to call this endpoint.
+   */
+  async updateUserPermissions(userId: string, permissions: UserPermissions): Promise<void> {
+    try {
+      await axios.put(`${API_BASE_URL}/settings/users/${userId}/permissions`, { permissions });
+    } catch (error) {
+      log.error({ err: error }, 'failed to update user permissions');
+      throw error;
+    }
+  }
+}
+
+// Permission types for per-user feature gating
+interface PermissionCategory {
+  enabled: boolean;
+  items: Record<string, boolean>;
+}
+
+export interface UserPermissions {
+  document_sources: PermissionCategory;
+  data_sources: PermissionCategory;
+  studio: PermissionCategory;
+  integrations: PermissionCategory;
+  chat_features: PermissionCategory;
 }
 
 export const usersAPI = new UsersAPI();


### PR DESCRIPTION
## Summary

Adds per-user module permissions — admin can control exactly which features each user can access via **Settings → Team → Edit Permissions**. 5 categories with individual sub-item toggles, all enabled by default. Disabled features are hidden from the UI AND blocked at the API level (403).

**Categories:**
- **Document Sources** — PDF, DOCX, PPTX, Image, Audio, URL/YouTube, Text, Google Drive
- **Data Sources** — Database (PostgreSQL/MySQL), CSV, Freshdesk
- **Studio** — All 18 generation types
- **Integrations** — Jira, Notion, MCP, ElevenLabs
- **Chat Features** — Memory, Voice Input, Chat Export

## What changed

**Backend (31 files):**
- Migration `00019_user_permissions.sql` — adds `permissions JSONB DEFAULT NULL` to users table
- `permissions.py` — get/update/check helpers with merge-with-defaults
- `rbac.py` — new `@require_permission(category, item)` decorator
- `users.py` — GET/PUT permissions endpoints + GET /me/permissions
- All 18 studio generation endpoints — `@require_permission("studio", item)`
- Source upload endpoints — permission checks on file upload, URL, text, Google Drive, database, freshdesk
- `main_chat_service._get_tools()` — filters chat tools based on user permissions

**Frontend:**
- `PermissionsProvider` context — loads on app mount, provides `hasPermission()` hook
- `PermissionsModal` — polished 5-category editor with color-coded icons, chip-style toggles, counter pills
- `TeamSection` — "Edit Permissions" in user action dropdown
- `ChatHeader` — export button hidden when disabled
- `ChatInput` — mic button hidden when disabled
- `StudioToolItem` — items hidden when studio permission is off
- `AddSourcesSheet` — source tabs hidden based on permissions

## Test plan

- [ ] Migration applies cleanly
- [ ] Existing users (permissions=NULL) have full access — zero behavior change
- [ ] Admin → Team → user → Edit Permissions → disable Freshdesk under Data Sources → Save
- [ ] That user's Sources panel "Add" menu doesn't show Freshdesk tab
- [ ] That user's chat tools don't include `analyze_freshdesk_agent`
- [ ] Direct API call to freshdesk endpoint returns 403
- [ ] Disable entire Studio category → all 18 studio items hidden from user
- [ ] Admin users always have full access regardless of permissions
- [ ] Re-enable a permission → user sees it immediately on next page load