### PR TITLE
feat: Mixpanel as a project-scoped source with live Query API tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,10 @@ JIRA_API_KEY=...                # Jira API token
 # OR (legacy format):
 # JIRA_DOMAIN=...               # Jira domain (https://your-company.atlassian.net)
 NOTION_API_KEY=...              # Notion integration
+MIXPANEL_SERVICE_ACCOUNT_USERNAME=...  # Mixpanel service account username
+MIXPANEL_SERVICE_ACCOUNT_SECRET=...    # Mixpanel service account secret
+MIXPANEL_PROJECT_ID=...                # Mixpanel numeric project ID
+MIXPANEL_REGION=us                     # us (default) | eu | in
 ANTHROPIC_TIER=1                # 1-4, controls rate limits
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,4 +12,4 @@
 | 8 | ✅ | **Opik logs — thread & unique user info** | Shipped — user_id, project_id, chat_id (thread_id), and tags attached to every trace |
 | 9 | ✅ | **Studio Business & Product section bug** | Shipped — fire-and-forget triggerGeneration + DB source fallback + mermaid sanitization |
 | 10 | ✅ | **Ledger DB** | Shipped — database connections support PostgreSQL/MySQL as sources with live SQL query agent |
-| 11 | ⬜ | **Mixpanel MCP connection** | MCP server integration for Mixpanel analytics |
+| 11 | ✅ | **Mixpanel MCP connection** | Shipped — Mixpanel as a project-scoped source with live Query API tools (list_events, query_events, segmentation, funnels, retention, JQL) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,4 +12,4 @@
 | 8 | ✅ | **Opik logs — thread & unique user info** | Shipped — user_id, project_id, chat_id (thread_id), and tags attached to every trace |
 | 9 | ✅ | **Studio Business & Product section bug** | Shipped — fire-and-forget triggerGeneration + DB source fallback + mermaid sanitization |
 | 10 | ✅ | **Ledger DB** | Shipped — database connections support PostgreSQL/MySQL as sources with live SQL query agent |
-| 11 | ✅ | **Mixpanel MCP connection** | Shipped — Mixpanel as a project-scoped source with live Query API tools (list_events, query_events, segmentation, funnels, retention, JQL) |
+| 11 | ✅ | **Mixpanel MCP connection** | Shipped — Mixpanel as a project-scoped source with live Query API tools (list_events, query_events, segmentation, funnels, retention, JQL). See [plan.md](plan.md) for the Option A vs Option B tradeoff and the clean-replacement migration path if we move to hosted MCP + OAuth later. |

--- a/backend/app/api/settings/api_keys.py
+++ b/backend/app/api/settings/api_keys.py
@@ -168,6 +168,30 @@ API_KEYS_CONFIG = [
         'category': 'integrations'
     },
     {
+        'id': 'MIXPANEL_SERVICE_ACCOUNT_USERNAME',
+        'name': 'Mixpanel Service Account Username',
+        'description': 'Service account username (Mixpanel → Project settings → Service Accounts)',
+        'category': 'integrations'
+    },
+    {
+        'id': 'MIXPANEL_SERVICE_ACCOUNT_SECRET',
+        'name': 'Mixpanel Service Account Secret',
+        'description': 'Service account secret (shown only at creation time)',
+        'category': 'integrations'
+    },
+    {
+        'id': 'MIXPANEL_PROJECT_ID',
+        'name': 'Mixpanel Project ID',
+        'description': 'Numeric project ID (Mixpanel → Project settings → Overview)',
+        'category': 'integrations'
+    },
+    {
+        'id': 'MIXPANEL_REGION',
+        'name': 'Mixpanel Region',
+        'description': 'Data residency region: us (default), eu, or in',
+        'category': 'integrations'
+    },
+    {
         'id': 'OPIK_API_KEY',
         'name': 'Opik API Key',
         'description': 'Opik LLM observability — auto-traces all Claude calls (comet.com/opik)',
@@ -327,6 +351,14 @@ def update_api_keys():
                 elif key_id in ('FRESHDESK_API_KEY', 'FRESHDESK_DOMAIN'):
                     from app.services.integrations.freshdesk.freshdesk_service import freshdesk_service
                     freshdesk_service.reload_config()
+                elif key_id in (
+                    'MIXPANEL_SERVICE_ACCOUNT_USERNAME',
+                    'MIXPANEL_SERVICE_ACCOUNT_SECRET',
+                    'MIXPANEL_PROJECT_ID',
+                    'MIXPANEL_REGION',
+                ):
+                    from app.services.integrations.knowledge_bases.mixpanel.mixpanel_service import mixpanel_service
+                    mixpanel_service.reload_config()
                 elif key_id in ('OPIK_API_KEY', 'OPIK_WORKSPACE', 'OPIK_PROJECT_NAME', 'OPIK_URL_OVERRIDE'):
                     # Reset Claude client so it re-initializes with/without Opik wrapping
                     from app.services.integrations.claude.claude_service import claude_service
@@ -530,6 +562,21 @@ def _validate_key(key_id: str, value: str) -> tuple[bool, str]:
 
     elif key_id == 'FRESHDESK_DOMAIN':
         # Supporting field — just accept it
+        is_valid = bool(value)
+        message = 'Value accepted' if is_valid else 'Value is empty'
+        return is_valid, message
+
+    elif key_id == 'MIXPANEL_SERVICE_ACCOUNT_SECRET':
+        # Mixpanel validation needs username + project_id from env (must be saved first)
+        mixpanel_username = env_service.get_key('MIXPANEL_SERVICE_ACCOUNT_USERNAME')
+        mixpanel_project_id = env_service.get_key('MIXPANEL_PROJECT_ID')
+        mixpanel_region = env_service.get_key('MIXPANEL_REGION') or 'us'
+        return validation_service.validate_mixpanel_key(
+            value, mixpanel_username, mixpanel_project_id, mixpanel_region
+        )
+
+    elif key_id in ('MIXPANEL_SERVICE_ACCOUNT_USERNAME', 'MIXPANEL_PROJECT_ID', 'MIXPANEL_REGION'):
+        # Supporting fields for Mixpanel — just accept them
         is_valid = bool(value)
         message = 'Value accepted' if is_valid else 'Value is empty'
         return is_valid, message

--- a/backend/app/api/sources/uploads.py
+++ b/backend/app/api/sources/uploads.py
@@ -502,6 +502,45 @@ def add_jira_source_endpoint(project_id: str):
         return jsonify({'success': False, 'error': str(e)}), 500
 
 
+@sources_bp.route('/projects/<project_id>/sources/mixpanel', methods=['POST'])
+@require_permission("data_sources", "mixpanel")
+def add_mixpanel_source_endpoint(project_id: str):
+    """
+    Add a Mixpanel source (live API flag) to a project.
+
+    Educational Note: Mixpanel sources are lightweight flags that enable the
+    Mixpanel chat tools (mixpanel_list_events, mixpanel_query_events, etc.)
+    for this specific project. No data is synced locally — all queries hit
+    the Mixpanel Query API live using the globally-configured Service Account.
+
+    Request Body:
+        {
+            "name": "Mixpanel Analytics",   # optional display name
+            "description": "Our Mixpanel"   # optional
+        }
+    """
+    try:
+        data = request.get_json() or {}
+
+        source = source_service.add_mixpanel_source(
+            project_id=project_id,
+            name=data.get('name'),
+            description=data.get('description', ''),
+        )
+
+        return jsonify({
+            'success': True,
+            'source': source,
+            'message': 'Mixpanel source added successfully'
+        }), 201
+
+    except ValueError as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+    except Exception as e:
+        current_app.logger.error(f"Error adding Mixpanel source: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
 @sources_bp.route('/projects/<project_id>/sources/mcp', methods=['POST'])
 def add_mcp_source(project_id: str):
     """

--- a/backend/app/services/app_settings/validation/mixpanel_validator.py
+++ b/backend/app/services/app_settings/validation/mixpanel_validator.py
@@ -12,13 +12,12 @@ from typing import Optional, Tuple
 import requests
 from requests.auth import HTTPBasicAuth
 
+from app.services.integrations.knowledge_bases.mixpanel.mixpanel_service import MixpanelService
+
 logger = logging.getLogger(__name__)
 
-REGION_HOSTS = {
-    "us": "https://mixpanel.com",
-    "eu": "https://eu.mixpanel.com",
-    "in": "https://in.mixpanel.com",
-}
+# Reuse the service's region map so the two stay in sync (DRY).
+REGION_HOSTS = MixpanelService.REGION_HOSTS
 
 
 def validate_mixpanel_key(

--- a/backend/app/services/app_settings/validation/mixpanel_validator.py
+++ b/backend/app/services/app_settings/validation/mixpanel_validator.py
@@ -1,0 +1,79 @@
+"""
+Mixpanel service-account credentials validator.
+
+Educational Note: Validates Mixpanel Service Account creds by calling
+/api/query/events/names with Basic Auth. All three values (username, secret,
+project_id) are required — if any are missing the validator returns a helpful
+hint telling the user to save the other fields first.
+"""
+import logging
+from typing import Optional, Tuple
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+logger = logging.getLogger(__name__)
+
+REGION_HOSTS = {
+    "us": "https://mixpanel.com",
+    "eu": "https://eu.mixpanel.com",
+    "in": "https://in.mixpanel.com",
+}
+
+
+def validate_mixpanel_key(
+    secret: str,
+    username: Optional[str] = None,
+    project_id: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """
+    Verify Mixpanel Service Account credentials by hitting /events/names.
+
+    Args:
+        secret: MIXPANEL_SERVICE_ACCOUNT_SECRET (the one being validated)
+        username: MIXPANEL_SERVICE_ACCOUNT_USERNAME (from env)
+        project_id: MIXPANEL_PROJECT_ID (from env)
+        region: "us" | "eu" | "in" (default "us")
+
+    Returns:
+        (is_valid, message)
+    """
+    if not secret:
+        return False, "Service account secret is empty"
+
+    if not username:
+        return False, "Save Mixpanel Service Account Username first, then validate the secret"
+
+    if not project_id:
+        return False, "Save Mixpanel Project ID first, then validate the secret"
+
+    host = REGION_HOSTS.get((region or "us").lower(), REGION_HOSTS["us"])
+    url = f"{host}/api/query/events/names"
+
+    try:
+        response = requests.get(
+            url,
+            auth=HTTPBasicAuth(username, secret),
+            params={"project_id": project_id, "type": "general", "limit": 1},
+            headers={"Accept": "application/json"},
+            timeout=10,
+        )
+
+        if response.status_code == 200:
+            return True, "Valid Mixpanel Service Account credentials"
+        if response.status_code == 401:
+            return False, "Invalid service account username or secret"
+        if response.status_code == 403:
+            return False, "Service account lacks access to this Mixpanel project"
+        if response.status_code == 404:
+            return False, "Project not found — check MIXPANEL_PROJECT_ID"
+        return False, f"Unexpected response: {response.status_code} - {response.text[:120]}"
+
+    except requests.exceptions.Timeout:
+        return False, "Connection timed out"
+    except requests.exceptions.ConnectionError:
+        return False, "Could not connect to Mixpanel API"
+    except Exception as e:
+        logger.error("Mixpanel validation error: %s: %s", type(e).__name__, e)
+        return False, f"Validation failed: {str(e)[:100]}"

--- a/backend/app/services/app_settings/validation/validation_service.py
+++ b/backend/app/services/app_settings/validation/validation_service.py
@@ -18,6 +18,7 @@ from app.services.app_settings.validation.pinecone_validator import validate_pin
 from app.services.app_settings.validation.notion_validator import validate_notion_key
 from app.services.app_settings.validation.jira_validator import validate_jira_key
 from app.services.app_settings.validation.freshdesk_validator import validate_freshdesk_key
+from app.services.app_settings.validation.mixpanel_validator import validate_mixpanel_key
 from app.services.app_settings.validation.opik_validator import validate_opik_key
 
 
@@ -73,6 +74,16 @@ class ValidationService:
     def validate_freshdesk_key(self, api_key: str, domain: Optional[str] = None) -> Tuple[bool, str]:
         """Validate Freshdesk credentials (API key + domain)."""
         return validate_freshdesk_key(api_key, domain)
+
+    def validate_mixpanel_key(
+        self,
+        secret: str,
+        username: Optional[str] = None,
+        project_id: Optional[str] = None,
+        region: Optional[str] = None,
+    ) -> Tuple[bool, str]:
+        """Validate Mixpanel Service Account credentials (secret + username + project_id)."""
+        return validate_mixpanel_key(secret, username, project_id, region)
 
     def validate_opik_key(self, api_key: str) -> Tuple[bool, str]:
         """Validate an Opik API key."""

--- a/backend/app/services/auth/permissions.py
+++ b/backend/app/services/auth/permissions.py
@@ -50,6 +50,8 @@ def _get_default_permissions() -> Dict[str, Any]:
                 "database": True,
                 "csv": True,
                 "freshdesk": True,
+                "jira": True,
+                "mixpanel": True,
             },
         },
         "studio": {
@@ -79,6 +81,7 @@ def _get_default_permissions() -> Dict[str, Any]:
             "enabled": True,
             "items": {
                 "jira": True,
+                "mixpanel": True,
                 "notion": True,
                 "mcp": True,
                 "elevenlabs": True,

--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -115,6 +115,7 @@ class MainChatService:
         has_database_sources: bool = False,
         has_freshdesk_sources: bool = False,
         has_jira_sources: bool = False,
+        has_mixpanel_sources: bool = False,
         user_id: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], Dict]:
         """
@@ -135,6 +136,7 @@ class MainChatService:
             has_database_sources: Whether project has active DATABASE sources
             has_freshdesk_sources: Whether project has active FRESHDESK sources
             has_jira_sources: Whether project has active JIRA sources
+            has_mixpanel_sources: Whether project has active MIXPANEL sources
             user_id: The requesting user's ID (for MCP tool access)
 
         Returns:
@@ -164,6 +166,10 @@ class MainChatService:
         # Add Jira tools only when the project has a .jira source (project-scoped)
         if has_jira_sources and (not user_id or user_has_permission(user_id, "data_sources", "jira")):
             tools.extend(knowledge_base_service.get_jira_tools())
+
+        # Add Mixpanel tools only when the project has a .mixpanel source (project-scoped)
+        if has_mixpanel_sources and (not user_id or user_has_permission(user_id, "data_sources", "mixpanel")):
+            tools.extend(knowledge_base_service.get_mixpanel_tools())
 
         # Add non-Jira knowledge base tools (Notion, GitHub, etc.) — always global
         tools.extend(knowledge_base_service.get_available_tools())
@@ -439,13 +445,18 @@ class MainChatService:
         database_sources = [s for s in active_sources if _file_ext(s) == ".database"]
         freshdesk_sources = [s for s in active_sources if _file_ext(s) == ".freshdesk"]
         jira_sources = [s for s in active_sources if _file_ext(s) == ".jira"]
-        non_csv_sources = [s for s in active_sources if _file_ext(s) not in (".csv", ".database", ".freshdesk", ".jira")]
+        mixpanel_sources = [s for s in active_sources if _file_ext(s) == ".mixpanel"]
+        non_csv_sources = [
+            s for s in active_sources
+            if _file_ext(s) not in (".csv", ".database", ".freshdesk", ".jira", ".mixpanel")
+        ]
         tools, mcp_registry = self._get_tools(
             has_active_sources=bool(non_csv_sources),
             has_csv_sources=bool(csv_sources),
             has_database_sources=bool(database_sources),
             has_freshdesk_sources=bool(freshdesk_sources),
             has_jira_sources=bool(jira_sources),
+            has_mixpanel_sources=bool(mixpanel_sources),
             user_id=resolved_user_id,
         )
 

--- a/backend/app/services/integrations/knowledge_bases/knowledge_base_service.py
+++ b/backend/app/services/integrations/knowledge_bases/knowledge_base_service.py
@@ -13,6 +13,7 @@ from typing import Dict, Any, List, Callable, Tuple
 
 from app.config import tool_loader
 from app.services.integrations.knowledge_bases.jira import jira_service
+from app.services.integrations.knowledge_bases.mixpanel import mixpanel_service
 from app.services.integrations.knowledge_bases.notion import notion_service
 
 
@@ -32,6 +33,15 @@ class KnowledgeBaseService:
 
     # Tool name prefixes for routing
     JIRA_TOOLS = ["jira_list_projects", "jira_search_issues", "jira_get_issue", "jira_get_project"]
+    MIXPANEL_TOOLS = [
+        "mixpanel_list_events",
+        "mixpanel_query_events",
+        "mixpanel_segmentation",
+        "mixpanel_list_funnels",
+        "mixpanel_query_funnel",
+        "mixpanel_retention",
+        "mixpanel_jql",
+    ]
     NOTION_TOOLS = ["notion_search", "notion_read_page", "notion_get_database_schema", "notion_query_database"]
     GITHUB_TOOLS = []  # Future: ["github_search_prs", "github_get_issue", ...]
 
@@ -48,6 +58,14 @@ class KnowledgeBaseService:
             "jira_search_issues": self._execute_jira_search_issues,
             "jira_get_issue": self._execute_jira_get_issue,
             "jira_get_project": self._execute_jira_get_project,
+            # Mixpanel tools
+            "mixpanel_list_events": self._execute_mixpanel_list_events,
+            "mixpanel_query_events": self._execute_mixpanel_query_events,
+            "mixpanel_segmentation": self._execute_mixpanel_segmentation,
+            "mixpanel_list_funnels": self._execute_mixpanel_list_funnels,
+            "mixpanel_query_funnel": self._execute_mixpanel_query_funnel,
+            "mixpanel_retention": self._execute_mixpanel_retention,
+            "mixpanel_jql": self._execute_mixpanel_jql,
             # Notion tools
             "notion_search": self._execute_notion_search,
             "notion_read_page": self._execute_notion_read_page,
@@ -104,6 +122,21 @@ class KnowledgeBaseService:
         """
         if jira_service.is_configured():
             return [self._get_tool(name) for name in self.JIRA_TOOLS]
+        return []
+
+    def get_mixpanel_tools(self) -> List[Dict[str, Any]]:
+        """
+        Get Mixpanel-specific tools if Mixpanel is configured.
+
+        Educational Note: Mirrors get_jira_tools — project-scoped. Tools are
+        only added to the chat tool list when the project has an active
+        .mixpanel source flag.
+
+        Returns:
+            List of Mixpanel tool definitions, or empty list if not configured
+        """
+        if mixpanel_service.is_configured():
+            return [self._get_tool(name) for name in self.MIXPANEL_TOOLS]
         return []
 
     def can_handle(self, tool_name: str) -> bool:
@@ -307,6 +340,143 @@ class KnowledgeBaseService:
                 lines.append("")
 
         return "\n".join(lines)
+
+    # --- Mixpanel formatters ---
+
+    def _execute_mixpanel_list_events(self, tool_input: Dict[str, Any]) -> str:
+        """List tracked event names."""
+        limit = tool_input.get("limit", 100)
+        result = mixpanel_service.list_events(limit=limit)
+        if not result["success"]:
+            return f"Error: {result.get('error', 'Unknown error')}"
+
+        events = result.get("events", [])
+        lines = [f"Found {result['total']} tracked event(s) in Mixpanel:", ""]
+        if not events:
+            lines.append("No events tracked yet.")
+        else:
+            for name in events:
+                lines.append(f"- {name}")
+        return "\n".join(lines)
+
+    def _execute_mixpanel_query_events(self, tool_input: Dict[str, Any]) -> str:
+        """Event counts over time."""
+        event_names = tool_input.get("event_names") or []
+        from_date = tool_input.get("from_date")
+        to_date = tool_input.get("to_date")
+        unit = tool_input.get("unit", "day")
+
+        result = mixpanel_service.query_events(
+            event_names=event_names,
+            from_date=from_date,
+            to_date=to_date,
+            unit=unit,
+        )
+        if not result["success"]:
+            return f"Error: {result.get('error', 'Unknown error')}"
+        return self._format_mixpanel_data(result.get("data"), title=f"Event counts ({unit}, {from_date} → {to_date})")
+
+    def _execute_mixpanel_segmentation(self, tool_input: Dict[str, Any]) -> str:
+        """Segmented event counts."""
+        event = tool_input.get("event")
+        from_date = tool_input.get("from_date")
+        to_date = tool_input.get("to_date")
+        on = tool_input.get("on")
+        where = tool_input.get("where")
+        unit = tool_input.get("unit", "day")
+
+        result = mixpanel_service.segmentation(
+            event=event, from_date=from_date, to_date=to_date,
+            on=on, where=where, unit=unit,
+        )
+        if not result["success"]:
+            return f"Error: {result.get('error', 'Unknown error')}"
+        return self._format_mixpanel_data(
+            result.get("data"),
+            title=f"Segmentation of {event} by {on or '(none)'} ({from_date} → {to_date})",
+        )
+
+    def _execute_mixpanel_list_funnels(self, tool_input: Dict[str, Any]) -> str:
+        """List funnels."""
+        result = mixpanel_service.list_funnels()
+        if not result["success"]:
+            return f"Error: {result.get('error', 'Unknown error')}"
+
+        funnels = result.get("funnels", [])
+        lines = [f"Found {result['total']} funnel(s):", ""]
+        if not funnels:
+            lines.append("No funnels configured in Mixpanel.")
+        else:
+            for f in funnels:
+                lines.append(f"- **{f.get('name', '(unnamed)')}** (funnel_id: {f.get('funnel_id')})")
+        return "\n".join(lines)
+
+    def _execute_mixpanel_query_funnel(self, tool_input: Dict[str, Any]) -> str:
+        """Funnel conversion."""
+        funnel_id = tool_input.get("funnel_id")
+        from_date = tool_input.get("from_date")
+        to_date = tool_input.get("to_date")
+        unit = tool_input.get("unit", "day")
+
+        result = mixpanel_service.query_funnel(
+            funnel_id=funnel_id, from_date=from_date, to_date=to_date, unit=unit,
+        )
+        if not result["success"]:
+            return f"Error: {result.get('error', 'Unknown error')}"
+        return self._format_mixpanel_data(
+            result.get("data"),
+            title=f"Funnel {funnel_id} ({unit}, {from_date} → {to_date})",
+        )
+
+    def _execute_mixpanel_retention(self, tool_input: Dict[str, Any]) -> str:
+        """Retention analysis."""
+        born_event = tool_input.get("born_event")
+        event = tool_input.get("event")
+        from_date = tool_input.get("from_date")
+        to_date = tool_input.get("to_date")
+        retention_type = tool_input.get("retention_type", "birth")
+        unit = tool_input.get("unit", "day")
+
+        result = mixpanel_service.retention(
+            born_event=born_event, event=event,
+            from_date=from_date, to_date=to_date,
+            retention_type=retention_type, unit=unit,
+        )
+        if not result["success"]:
+            return f"Error: {result.get('error', 'Unknown error')}"
+        return self._format_mixpanel_data(
+            result.get("data"),
+            title=f"Retention: {born_event} → {event or '(any)'} ({retention_type}, {unit})",
+        )
+
+    def _execute_mixpanel_jql(self, tool_input: Dict[str, Any]) -> str:
+        """Run a JQL script."""
+        script = tool_input.get("script")
+        result = mixpanel_service.jql(script=script)
+        if not result["success"]:
+            return f"Error: {result.get('error', 'Unknown error')}"
+        return self._format_mixpanel_data(result.get("data"), title="JQL result")
+
+    @staticmethod
+    def _format_mixpanel_data(data: Any, title: str) -> str:
+        """
+        Render Mixpanel Query API payload as a compact JSON block Claude can reason over.
+
+        Educational Note: Mixpanel responses have several shapes (events dict,
+        segmentation nested dict, funnels list). Rather than hand-format each,
+        we emit JSON inside a fenced block — Claude's strong at parsing JSON.
+        """
+        import json as _json
+        try:
+            rendered = _json.dumps(data, indent=2, default=str)
+        except Exception:
+            rendered = str(data)
+
+        # Keep the block small — truncate huge payloads to protect context window
+        if len(rendered) > 15000:
+            rendered = rendered[:15000] + "\n... (truncated)"
+
+        return f"## {title}\n\n```json\n{rendered}\n```"
 
     # --- Notion formatters ---
 

--- a/backend/app/services/integrations/knowledge_bases/mixpanel/__init__.py
+++ b/backend/app/services/integrations/knowledge_bases/mixpanel/__init__.py
@@ -1,0 +1,10 @@
+"""
+Mixpanel Integration Package.
+
+Educational Note: Provides Mixpanel analytics query access via the Service
+Account REST API (HTTP Basic). Tools expose event discovery, segmentation,
+funnels, retention, and JQL queries to chat.
+"""
+from app.services.integrations.knowledge_bases.mixpanel.mixpanel_service import mixpanel_service
+
+__all__ = ["mixpanel_service"]

--- a/backend/app/services/integrations/knowledge_bases/mixpanel/mixpanel_service.py
+++ b/backend/app/services/integrations/knowledge_bases/mixpanel/mixpanel_service.py
@@ -264,7 +264,7 @@ class MixpanelService:
 
         Endpoint: GET /funnels?funnel_id=N&from_date=Y&to_date=Z&unit=day
         """
-        if not funnel_id:
+        if funnel_id is None:
             return {"success": False, "error": "funnel_id is required (integer)."}
         if not from_date or not to_date:
             return {"success": False, "error": "from_date and to_date are required (YYYY-MM-DD)."}

--- a/backend/app/services/integrations/knowledge_bases/mixpanel/mixpanel_service.py
+++ b/backend/app/services/integrations/knowledge_bases/mixpanel/mixpanel_service.py
@@ -1,0 +1,329 @@
+"""
+Mixpanel Integration Service - Query API access for NoobBook chat.
+
+Educational Note: Uses Mixpanel's Service Account auth (HTTP Basic) against
+the Query API (https://mixpanel.com/api/query/). No OAuth — admin configures
+one service account globally; all users in the app share access to that
+Mixpanel project.
+
+Lazy singleton pattern mirroring jira_service.
+"""
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+logger = logging.getLogger(__name__)
+
+
+class MixpanelService:
+    """
+    Mixpanel Query API service.
+
+    Config (env vars):
+        MIXPANEL_SERVICE_ACCOUNT_USERNAME
+        MIXPANEL_SERVICE_ACCOUNT_SECRET
+        MIXPANEL_PROJECT_ID
+        MIXPANEL_REGION (optional, "us" | "eu" | "in"; default "us")
+    """
+
+    REGION_HOSTS = {
+        "us": "https://mixpanel.com",
+        "eu": "https://eu.mixpanel.com",
+        "in": "https://in.mixpanel.com",
+    }
+
+    def __init__(self):
+        self._auth: Optional[HTTPBasicAuth] = None
+        self._project_id: Optional[str] = None
+        self._base_url: Optional[str] = None
+        self._configured: Optional[bool] = None
+
+    def _load_config(self) -> None:
+        if self._configured is not None:
+            return
+
+        username = os.getenv("MIXPANEL_SERVICE_ACCOUNT_USERNAME", "").strip().strip('"')
+        secret = os.getenv("MIXPANEL_SERVICE_ACCOUNT_SECRET", "").strip().strip('"')
+        project_id = os.getenv("MIXPANEL_PROJECT_ID", "").strip().strip('"')
+        region = os.getenv("MIXPANEL_REGION", "us").strip().lower() or "us"
+
+        host = self.REGION_HOSTS.get(region, self.REGION_HOSTS["us"])
+        self._base_url = f"{host}/api/query"
+        self._auth = HTTPBasicAuth(username, secret) if username and secret else None
+        self._project_id = project_id or None
+        self._configured = bool(self._auth and self._project_id)
+
+        if self._configured:
+            logger.info("Mixpanel service configured: project_id=%s region=%s", project_id, region)
+
+    def reload_config(self) -> None:
+        """Reset cached config so next call re-reads env vars."""
+        self._configured = None
+
+    def is_configured(self) -> bool:
+        self._load_config()
+        return bool(self._configured)
+
+    def _make_request(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        method: str = "GET",
+    ) -> Dict[str, Any]:
+        """
+        Call the Mixpanel Query API.
+
+        Educational Note: Mixpanel's Query API returns either JSON objects or
+        NDJSON (for /export). The endpoints we use here all return JSON.
+        """
+        self._load_config()
+        if not self._configured:
+            return {
+                "success": False,
+                "error": (
+                    "Mixpanel not configured. Please add MIXPANEL_SERVICE_ACCOUNT_USERNAME, "
+                    "MIXPANEL_SERVICE_ACCOUNT_SECRET, and MIXPANEL_PROJECT_ID to your .env."
+                ),
+            }
+
+        # project_id is required on every Query API call
+        merged_params = {"project_id": self._project_id}
+        if params:
+            merged_params.update({k: v for k, v in params.items() if v is not None})
+
+        url = f"{self._base_url}/{endpoint.lstrip('/')}"
+        headers = {"Accept": "application/json"}
+
+        try:
+            if method == "GET":
+                response = requests.get(
+                    url, auth=self._auth, headers=headers, params=merged_params, timeout=30
+                )
+            elif method == "POST":
+                response = requests.post(
+                    url, auth=self._auth, headers=headers, data=merged_params, timeout=30
+                )
+            else:
+                return {"success": False, "error": f"Unsupported HTTP method: {method}"}
+
+            if response.status_code == 200:
+                try:
+                    return {"success": True, "data": response.json()}
+                except ValueError:
+                    return {
+                        "success": False,
+                        "error": f"Invalid JSON response from Mixpanel: {response.text[:200]}",
+                    }
+            if response.status_code == 401:
+                return {
+                    "success": False,
+                    "error": "Authentication failed. Check service account username/secret.",
+                }
+            if response.status_code == 402:
+                return {
+                    "success": False,
+                    "error": "Mixpanel rejected the request (payment/quota). See response: "
+                    + response.text[:200],
+                }
+            if response.status_code == 403:
+                return {
+                    "success": False,
+                    "error": "Permission denied. Service account must have access to the project.",
+                }
+            if response.status_code == 404:
+                return {"success": False, "error": f"Not found: {endpoint}"}
+            if response.status_code == 429:
+                return {
+                    "success": False,
+                    "error": "Rate limit hit (Mixpanel Query API: 60/hr, 5 concurrent). Try again later.",
+                }
+            return {
+                "success": False,
+                "error": f"Mixpanel API error: {response.status_code} - {response.text[:200]}",
+            }
+        except requests.exceptions.Timeout:
+            return {"success": False, "error": "Mixpanel request timed out."}
+        except requests.exceptions.ConnectionError:
+            return {"success": False, "error": "Could not connect to Mixpanel API."}
+        except Exception as e:
+            return {"success": False, "error": f"Request failed: {str(e)}"}
+
+    # --- Tool methods ---
+
+    def list_events(self, limit: int = 100) -> Dict[str, Any]:
+        """
+        List event names tracked in the project.
+
+        Endpoint: GET /events/names?type=general&limit=N
+        """
+        result = self._make_request(
+            "events/names",
+            params={"type": "general", "limit": min(max(limit, 1), 255)},
+        )
+        if not result["success"]:
+            return result
+
+        names = result["data"]
+        if not isinstance(names, list):
+            names = []
+
+        return {"success": True, "events": names, "total": len(names)}
+
+    def query_events(
+        self,
+        event_names: List[str],
+        from_date: str,
+        to_date: str,
+        unit: str = "day",
+        event_type: str = "general",
+    ) -> Dict[str, Any]:
+        """
+        Get event counts over time.
+
+        Endpoint: GET /events?event=["A","B"]&from_date=YYYY-MM-DD&to_date=YYYY-MM-DD&unit=day&type=general
+        """
+        if not event_names:
+            return {"success": False, "error": "event_names is required (non-empty list)."}
+        if not from_date or not to_date:
+            return {"success": False, "error": "from_date and to_date are required (YYYY-MM-DD)."}
+
+        return self._make_request(
+            "events",
+            params={
+                "event": json.dumps(event_names),
+                "from_date": from_date,
+                "to_date": to_date,
+                "unit": unit,
+                "type": event_type,
+            },
+        )
+
+    def segmentation(
+        self,
+        event: str,
+        from_date: str,
+        to_date: str,
+        on: Optional[str] = None,
+        where: Optional[str] = None,
+        unit: str = "day",
+        segmentation_type: str = "general",
+    ) -> Dict[str, Any]:
+        """
+        Segment a single event by a property.
+
+        Endpoint: GET /segmentation?event=X&from_date=Y&to_date=Z&on=properties["..."]&type=general
+        """
+        if not event:
+            return {"success": False, "error": "event is required."}
+        if not from_date or not to_date:
+            return {"success": False, "error": "from_date and to_date are required (YYYY-MM-DD)."}
+
+        params: Dict[str, Any] = {
+            "event": event,
+            "from_date": from_date,
+            "to_date": to_date,
+            "unit": unit,
+            "type": segmentation_type,
+        }
+        if on:
+            params["on"] = on
+        if where:
+            params["where"] = where
+
+        return self._make_request("segmentation", params=params)
+
+    def list_funnels(self) -> Dict[str, Any]:
+        """List funnels configured in the project. Endpoint: GET /funnels/list"""
+        result = self._make_request("funnels/list")
+        if not result["success"]:
+            return result
+
+        funnels = result["data"]
+        if not isinstance(funnels, list):
+            funnels = []
+
+        formatted = [
+            {"funnel_id": f.get("funnel_id"), "name": f.get("name")}
+            for f in funnels
+        ]
+        return {"success": True, "funnels": formatted, "total": len(formatted)}
+
+    def query_funnel(
+        self,
+        funnel_id: int,
+        from_date: str,
+        to_date: str,
+        unit: str = "day",
+    ) -> Dict[str, Any]:
+        """
+        Query funnel conversion over time.
+
+        Endpoint: GET /funnels?funnel_id=N&from_date=Y&to_date=Z&unit=day
+        """
+        if not funnel_id:
+            return {"success": False, "error": "funnel_id is required (integer)."}
+        if not from_date or not to_date:
+            return {"success": False, "error": "from_date and to_date are required (YYYY-MM-DD)."}
+
+        return self._make_request(
+            "funnels",
+            params={
+                "funnel_id": funnel_id,
+                "from_date": from_date,
+                "to_date": to_date,
+                "unit": unit,
+            },
+        )
+
+    def retention(
+        self,
+        born_event: str,
+        event: Optional[str],
+        from_date: str,
+        to_date: str,
+        retention_type: str = "birth",
+        unit: str = "day",
+    ) -> Dict[str, Any]:
+        """
+        Retention analysis.
+
+        Endpoint: GET /retention?from_date=Y&to_date=Z&retention_type=birth&born_event=X&event=Y&unit=day
+        """
+        if not born_event:
+            return {"success": False, "error": "born_event is required."}
+        if not from_date or not to_date:
+            return {"success": False, "error": "from_date and to_date are required (YYYY-MM-DD)."}
+
+        params: Dict[str, Any] = {
+            "from_date": from_date,
+            "to_date": to_date,
+            "retention_type": retention_type,
+            "born_event": born_event,
+            "unit": unit,
+        }
+        if event:
+            params["event"] = event
+
+        return self._make_request("retention", params=params)
+
+    def jql(self, script: str) -> Dict[str, Any]:
+        """
+        Run a JQL script.
+
+        Endpoint: POST /jql  (form-encoded with `script`)
+
+        Educational Note: JQL is feature-complete but deprecated in Mixpanel's
+        docs. Still the most expressive query tool — kept as an escape hatch.
+        """
+        if not script or not script.strip():
+            return {"success": False, "error": "script is required (JavaScript JQL code)."}
+
+        return self._make_request("jql", params={"script": script}, method="POST")
+
+
+# Singleton instance
+mixpanel_service = MixpanelService()

--- a/backend/app/services/source_services/source_processing/mixpanel_processor.py
+++ b/backend/app/services/source_services/source_processing/mixpanel_processor.py
@@ -1,0 +1,164 @@
+"""
+Mixpanel Processor - Handles MIXPANEL source processing.
+
+Educational Note: Lightweight verifier. Confirms the Mixpanel Query API is
+reachable with the configured Service Account, fetches a sample of tracked
+event names for the summary, and marks the source ready. All real queries
+happen live via the chat tools (mixpanel_list_events, mixpanel_query_events,
+mixpanel_segmentation, mixpanel_funnel, mixpanel_retention, mixpanel_jql).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+from app.services.ai_services.summary_service import summary_service
+from app.services.integrations.knowledge_bases.mixpanel.mixpanel_service import mixpanel_service
+from app.services.integrations.supabase import storage_service
+
+logger = logging.getLogger(__name__)
+
+
+def _build_processed_text(
+    source_name: str,
+    captured_at: str,
+    event_count: int,
+    event_names: list[str],
+) -> str:
+    """Build processed text summary of the connected Mixpanel project."""
+    header_lines = [
+        f"# Extracted from MIXPANEL source: {source_name}",
+        "# Type: MIXPANEL",
+        f"# Captured at: {captured_at}",
+        "# ---",
+        "",
+    ]
+
+    lines = [
+        "## Mixpanel Connection Summary",
+        "",
+        f"Total event names tracked: {event_count}",
+        "",
+    ]
+
+    if event_names:
+        lines.append("### Sample Events")
+        for name in event_names[:30]:
+            lines.append(f"- {name}")
+        if event_count > 30:
+            lines.append(f"- ... and {event_count - 30} more")
+        lines.append("")
+
+    lines.append(
+        "Tip: Use mixpanel_list_events, mixpanel_query_events, mixpanel_segmentation, "
+        "mixpanel_list_funnels, mixpanel_query_funnel, mixpanel_retention, and "
+        "mixpanel_jql tools in chat for live analytics queries."
+    )
+    lines.append("")
+
+    return "\n".join(header_lines + lines)
+
+
+def process_mixpanel(
+    project_id: str,
+    source_id: str,
+    source: Dict[str, Any],
+    raw_file_path: Path,
+    source_service,
+) -> Dict[str, Any]:
+    """
+    Process a MIXPANEL source:
+    1) Verify Mixpanel Query API connection
+    2) Fetch a sample of event names for the summary
+    3) Generate AI summary
+    4) Mark ready (no embedding — queries go through live API tools)
+    """
+    captured_at = datetime.now().isoformat()
+    embedding_info = source.get("embedding_info", {}) or {}
+
+    try:
+        result = mixpanel_service.list_events(limit=100)
+    except Exception as e:
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": f"Failed to connect to Mixpanel: {str(e)}"},
+        )
+        return {"success": False, "error": str(e)}
+
+    if not result.get("success"):
+        error_msg = result.get("error", "Failed to connect to Mixpanel API")
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": error_msg},
+        )
+        return {"success": False, "error": error_msg}
+
+    events = result.get("events", [])
+    event_count = result.get("total", len(events))
+
+    processed_text = _build_processed_text(
+        source_name=source.get("name", "Mixpanel Analytics"),
+        captured_at=captured_at,
+        event_count=event_count,
+        event_names=events,
+    )
+
+    processed_path = storage_service.upload_processed_file(
+        project_id=project_id,
+        source_id=source_id,
+        content=processed_text,
+    )
+    if not processed_path:
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": "Failed to upload processed summary"},
+        )
+        return {"success": False, "error": "Failed to upload processed file"}
+
+    processing_info = {
+        "processor": "mixpanel_connection_verify",
+        "captured_at": captured_at,
+        "events_found": event_count,
+    }
+
+    merged_embedding_info = {
+        **embedding_info,
+        "is_embedded": False,
+        "file_extension": ".mixpanel",
+    }
+
+    summary_info: Dict[str, Any] = {}
+    try:
+        summary_source_metadata = {
+            "name": source.get("name", "Mixpanel Analytics"),
+            "category": "mixpanel",
+            "file_extension": ".mixpanel",
+            "embedding_info": merged_embedding_info,
+            "processing_info": {
+                **processing_info,
+                "total_pages": max(1, event_count),
+            },
+        }
+        summary_info = (
+            summary_service.generate_summary(
+                project_id, source_id, summary_source_metadata
+            )
+            or {}
+        )
+    except Exception:
+        logger.exception("Summary generation failed for source %s", source_id)
+        summary_info = {}
+
+    source_service.update_source(
+        project_id,
+        source_id,
+        status="ready",
+        processing_info=processing_info,
+        embedding_info=merged_embedding_info,
+        summary_info=summary_info if summary_info else None,
+    )
+
+    return {"success": True, "status": "ready"}

--- a/backend/app/services/source_services/source_processing/source_processing_service.py
+++ b/backend/app/services/source_services/source_processing/source_processing_service.py
@@ -71,6 +71,7 @@ class SourceProcessingService:
         ".database": "database",  # Database sources (Postgres/MySQL)
         ".freshdesk": "freshdesk",  # Freshdesk ticket sources
         ".jira": "jira",  # Jira project sources (live API flag)
+        ".mixpanel": "mixpanel",  # Mixpanel analytics sources (live API flag)
         ".mcp": "mcp",  # MCP server resources
         ".research": "research",  # Deep research source
     }
@@ -186,6 +187,10 @@ class SourceProcessingService:
             elif processor_type == "jira":
                 from app.services.source_services.source_processing.jira_processor import process_jira
                 return process_jira(project_id, source_id, source, raw_file_path, source_service)
+
+            elif processor_type == "mixpanel":
+                from app.services.source_services.source_processing.mixpanel_processor import process_mixpanel
+                return process_mixpanel(project_id, source_id, source, raw_file_path, source_service)
 
             elif processor_type == "mcp":
                 from app.services.source_services.source_processing.mcp_processor import process_mcp

--- a/backend/app/services/source_services/source_service.py
+++ b/backend/app/services/source_services/source_service.py
@@ -27,6 +27,7 @@ from app.services.source_services.source_upload import (
     add_freshdesk_source,
     add_jira_source,
     add_mcp_source,
+    add_mixpanel_source,
 )
 # Local path utils used for temp file staging during source processing
 from app.utils.path_utils import (
@@ -426,6 +427,21 @@ class SourceService:
         specific project. No data sync — tools query Jira live.
         """
         return add_jira_source(project_id, name, description)
+
+    def add_mixpanel_source(
+        self,
+        project_id: str,
+        name: Optional[str] = None,
+        description: str = "",
+    ) -> Dict[str, Any]:
+        """
+        Add a Mixpanel source flag to a project.
+
+        Educational Note: Same lightweight pattern as Jira — enables Mixpanel
+        chat tools (mixpanel_list_events, mixpanel_query_events, etc.) for
+        this specific project. Queries Mixpanel's Query API live.
+        """
+        return add_mixpanel_source(project_id, name, description)
 
     def add_mcp_source(
         self,

--- a/backend/app/services/source_services/source_upload/__init__.py
+++ b/backend/app/services/source_services/source_upload/__init__.py
@@ -18,6 +18,7 @@ from app.services.source_services.source_upload.database_upload import add_datab
 from app.services.source_services.source_upload.freshdesk_upload import add_freshdesk_source
 from app.services.source_services.source_upload.jira_upload import add_jira_source
 from app.services.source_services.source_upload.mcp_upload import add_mcp_source
+from app.services.source_services.source_upload.mixpanel_upload import add_mixpanel_source
 
 __all__ = [
     "upload_file",
@@ -29,4 +30,5 @@ __all__ = [
     "add_freshdesk_source",
     "add_jira_source",
     "add_mcp_source",
+    "add_mixpanel_source",
 ]

--- a/backend/app/services/source_services/source_upload/mixpanel_upload.py
+++ b/backend/app/services/source_services/source_upload/mixpanel_upload.py
@@ -1,0 +1,123 @@
+"""
+Mixpanel Upload Handler - Create a MIXPANEL source flag for a project.
+
+Educational Note: Same lightweight pattern as jira_upload — the source acts
+as a per-project flag that enables Mixpanel chat tools. No data is synced
+locally; all queries go live to the Mixpanel Query API.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from app.services.background_services import task_service
+from app.services.integrations.knowledge_bases.mixpanel.mixpanel_service import mixpanel_service
+from app.services.integrations.supabase import storage_service
+from app.services.source_services import source_index_service
+
+logger = logging.getLogger(__name__)
+
+
+def add_mixpanel_source(
+    project_id: str,
+    name: Optional[str] = None,
+    description: str = "",
+) -> Dict[str, Any]:
+    """
+    Create a MIXPANEL source in a project and trigger processing.
+
+    Args:
+        project_id: The project UUID
+        name: Optional display name in the Sources list
+        description: Optional description
+
+    Returns:
+        Source metadata dictionary
+
+    Raises:
+        ValueError: If Mixpanel is not configured
+    """
+    if not mixpanel_service.is_configured():
+        raise ValueError(
+            "Mixpanel not configured. Please add MIXPANEL_SERVICE_ACCOUNT_USERNAME, "
+            "MIXPANEL_SERVICE_ACCOUNT_SECRET, and MIXPANEL_PROJECT_ID to your .env file."
+        )
+
+    source_id = str(uuid.uuid4())
+    stored_filename = f"{source_id}.mixpanel"
+
+    raw_payload = {
+        "kind": "mixpanel_source",
+        "created_at": datetime.now().isoformat(),
+    }
+
+    raw_bytes = json.dumps(raw_payload, indent=2).encode("utf-8")
+    storage_path = storage_service.upload_raw_file(
+        project_id=project_id,
+        source_id=source_id,
+        filename=stored_filename,
+        file_data=raw_bytes,
+        content_type="application/json; charset=utf-8",
+    )
+    if not storage_path:
+        raise ValueError("Failed to create Mixpanel source metadata in storage")
+
+    display_name = (name or "Mixpanel Analytics").strip()
+    if not display_name:
+        display_name = "Mixpanel Analytics"
+
+    source_metadata = {
+        "id": source_id,
+        "project_id": project_id,
+        "name": display_name,
+        "description": description,
+        "type": "MIXPANEL",
+        "status": "uploaded",
+        "raw_file_path": storage_path,
+        "file_size": len(raw_bytes),
+        "is_active": False,
+        "embedding_info": {
+            "original_filename": stored_filename,
+            "mime_type": "application/json",
+            "file_extension": ".mixpanel",
+            "stored_filename": stored_filename,
+            "source_type": "mixpanel",
+            "is_global": False,
+        },
+        "processing_info": {
+            "created_at": datetime.now().isoformat(),
+            "note": "Mixpanel source created. Processing will verify connection.",
+        },
+    }
+
+    source_index_service.add_source_to_index(project_id, source_metadata)
+    _submit_processing_task(project_id, source_id)
+    return source_metadata
+
+
+def _submit_processing_task(project_id: str, source_id: str) -> None:
+    """Submit a background task to process the Mixpanel source."""
+    try:
+        from app.services.source_services.source_processing import (
+            source_processing_service,
+        )
+        from app.services.source_services import source_service
+
+        task_service.submit_task(
+            "source_processing",
+            source_id,
+            source_processing_service.process_source,
+            project_id,
+            source_id,
+        )
+        source_service.update_source(project_id, source_id, status="processing")
+    except Exception as e:
+        logger.error(
+            "Failed to submit Mixpanel processing task for source %s: %s",
+            source_id,
+            e,
+        )

--- a/backend/app/services/tools/chat_tools/mixpanel_jql.json
+++ b/backend/app/services/tools/chat_tools/mixpanel_jql.json
@@ -1,0 +1,14 @@
+{
+  "name": "mixpanel_jql",
+  "description": "Run a Mixpanel JQL (JavaScript Query Language) script for arbitrary custom queries. Use this ONLY when other tools can't express the question (e.g. complex joins, multi-step pipelines). Your script must return a JSON-serializable value via the final `return` from Events/People pipelines.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "script": {
+        "type": "string",
+        "description": "JQL JavaScript source. Example: `function main() { return Events({from_date: '2026-01-01', to_date: '2026-01-31'}).groupBy(['name'], mixpanel.reducer.count()); }`"
+      }
+    },
+    "required": ["script"]
+  }
+}

--- a/backend/app/services/tools/chat_tools/mixpanel_list_events.json
+++ b/backend/app/services/tools/chat_tools/mixpanel_list_events.json
@@ -1,0 +1,14 @@
+{
+  "name": "mixpanel_list_events",
+  "description": "List event names being tracked in the connected Mixpanel project. Use this first to discover what events are available before running queries. Returns up to `limit` event name strings sorted by recency.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "limit": {
+        "type": "integer",
+        "description": "Maximum number of event names to return (default: 100, max: 255)"
+      }
+    },
+    "required": []
+  }
+}

--- a/backend/app/services/tools/chat_tools/mixpanel_list_funnels.json
+++ b/backend/app/services/tools/chat_tools/mixpanel_list_funnels.json
@@ -1,0 +1,9 @@
+{
+  "name": "mixpanel_list_funnels",
+  "description": "List funnels configured in the Mixpanel project. Use this to discover funnel IDs before querying a specific funnel's conversion data.",
+  "input_schema": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  }
+}

--- a/backend/app/services/tools/chat_tools/mixpanel_query_events.json
+++ b/backend/app/services/tools/chat_tools/mixpanel_query_events.json
@@ -1,0 +1,28 @@
+{
+  "name": "mixpanel_query_events",
+  "description": "Get time-bucketed counts for one or more events from Mixpanel. Use this to answer questions like 'how many Signups happened last week?' Returns a per-date count per event. Dates must be in YYYY-MM-DD format.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "event_names": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "List of event names to query (e.g. [\"Signed Up\", \"Purchase\"])"
+      },
+      "from_date": {
+        "type": "string",
+        "description": "Start date inclusive (YYYY-MM-DD)"
+      },
+      "to_date": {
+        "type": "string",
+        "description": "End date inclusive (YYYY-MM-DD)"
+      },
+      "unit": {
+        "type": "string",
+        "enum": ["minute", "hour", "day", "week", "month"],
+        "description": "Time bucket size (default: day)"
+      }
+    },
+    "required": ["event_names", "from_date", "to_date"]
+  }
+}

--- a/backend/app/services/tools/chat_tools/mixpanel_query_funnel.json
+++ b/backend/app/services/tools/chat_tools/mixpanel_query_funnel.json
@@ -1,0 +1,27 @@
+{
+  "name": "mixpanel_query_funnel",
+  "description": "Get conversion data for a specific funnel over a date range. Call mixpanel_list_funnels first to find the funnel_id.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "funnel_id": {
+        "type": "integer",
+        "description": "Numeric funnel ID (from mixpanel_list_funnels)"
+      },
+      "from_date": {
+        "type": "string",
+        "description": "Start date inclusive (YYYY-MM-DD)"
+      },
+      "to_date": {
+        "type": "string",
+        "description": "End date inclusive (YYYY-MM-DD)"
+      },
+      "unit": {
+        "type": "string",
+        "enum": ["day", "week", "month"],
+        "description": "Time bucket size (default: day)"
+      }
+    },
+    "required": ["funnel_id", "from_date", "to_date"]
+  }
+}

--- a/backend/app/services/tools/chat_tools/mixpanel_retention.json
+++ b/backend/app/services/tools/chat_tools/mixpanel_retention.json
@@ -1,0 +1,36 @@
+{
+  "name": "mixpanel_retention",
+  "description": "Compute retention: given a cohort of users who did `born_event`, how many came back and did `event` in subsequent buckets. Use for questions like 'what's our weekly retention for new signups?'",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "born_event": {
+        "type": "string",
+        "description": "Cohort-defining event (e.g. \"Signed Up\")"
+      },
+      "event": {
+        "type": "string",
+        "description": "Return event to measure (e.g. \"App Opened\"). Omit to use any activity."
+      },
+      "from_date": {
+        "type": "string",
+        "description": "Start date inclusive (YYYY-MM-DD)"
+      },
+      "to_date": {
+        "type": "string",
+        "description": "End date inclusive (YYYY-MM-DD)"
+      },
+      "retention_type": {
+        "type": "string",
+        "enum": ["birth", "compounded"],
+        "description": "birth = first-time cohort (default), compounded = recurring cohort"
+      },
+      "unit": {
+        "type": "string",
+        "enum": ["day", "week", "month"],
+        "description": "Retention bucket size (default: day)"
+      }
+    },
+    "required": ["born_event", "from_date", "to_date"]
+  }
+}

--- a/backend/app/services/tools/chat_tools/mixpanel_segmentation.json
+++ b/backend/app/services/tools/chat_tools/mixpanel_segmentation.json
@@ -1,0 +1,35 @@
+{
+  "name": "mixpanel_segmentation",
+  "description": "Segment a single event by a property over a time range. Use this for questions like 'Signups by country in Jan 2026' or 'Purchases by plan over last 30 days'. The `on` expression must use Mixpanel's property-expression syntax (e.g. properties[\"$country_code\"]).",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "event": {
+        "type": "string",
+        "description": "Event name to segment (e.g. \"Signed Up\")"
+      },
+      "from_date": {
+        "type": "string",
+        "description": "Start date inclusive (YYYY-MM-DD)"
+      },
+      "to_date": {
+        "type": "string",
+        "description": "End date inclusive (YYYY-MM-DD)"
+      },
+      "on": {
+        "type": "string",
+        "description": "Property expression to segment on, e.g. 'properties[\"$country_code\"]' or 'properties[\"plan\"]'"
+      },
+      "where": {
+        "type": "string",
+        "description": "Optional filter expression, e.g. 'properties[\"$country_code\"] == \"US\"'"
+      },
+      "unit": {
+        "type": "string",
+        "enum": ["minute", "hour", "day", "week", "month"],
+        "description": "Time bucket size (default: day)"
+      }
+    },
+    "required": ["event", "from_date", "to_date"]
+  }
+}

--- a/frontend/src/components/settings/sections/PermissionsModal.tsx
+++ b/frontend/src/components/settings/sections/PermissionsModal.tsx
@@ -73,6 +73,8 @@ const CATEGORY_CONFIG: Record<
       database: 'Database (PostgreSQL / MySQL)',
       csv: 'CSV Files',
       freshdesk: 'Freshdesk Tickets',
+      jira: 'Jira Issues',
+      mixpanel: 'Mixpanel Analytics',
     },
   },
   studio: {
@@ -108,6 +110,7 @@ const CATEGORY_CONFIG: Record<
     iconColor: 'text-amber-600 bg-amber-50',
     items: {
       jira: 'Jira',
+      mixpanel: 'Mixpanel',
       notion: 'Notion',
       mcp: 'MCP Connections',
       elevenlabs: 'ElevenLabs (Voice)',

--- a/frontend/src/components/sources/AddSourcesSheet.tsx
+++ b/frontend/src/components/sources/AddSourcesSheet.tsx
@@ -16,6 +16,7 @@ import { DatabaseTab } from './DatabaseTab';
 import { McpTab } from './McpTab';
 import { FreshdeskTab } from './FreshdeskTab';
 import { JiraTab } from './JiraTab';
+import { MixpanelTab } from './MixpanelTab';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { MAX_SOURCES } from '../../lib/api/sources';
 
@@ -32,6 +33,7 @@ interface AddSourcesSheetProps {
   onAddMcp: (connectionId: string, resourceUris: string[], name?: string, description?: string) => Promise<void>;
   onAddFreshdesk: (name?: string, description?: string) => Promise<void>;
   onAddJira: (name?: string, description?: string) => Promise<void>;
+  onAddMixpanel: (name?: string, description?: string) => Promise<void>;
   onImportComplete: () => void;
   uploading: boolean;
 }
@@ -49,6 +51,7 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
   onAddMcp,
   onAddFreshdesk,
   onAddJira,
+  onAddMixpanel,
   onImportComplete,
   uploading,
 }) => {
@@ -66,6 +69,7 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
   const canDatabase = hasPermission('data_sources', 'database');
   const canFreshdesk = hasPermission('data_sources', 'freshdesk');
   const canJira = hasPermission('integrations', 'jira');
+  const canMixpanel = hasPermission('integrations', 'mixpanel');
   // Note: CSV permission exists (hasPermission('data_sources', 'csv')) but no CSV tab yet
 
   // Research and MCP are always shown (no dedicated permission key) — gated at category level
@@ -82,6 +86,7 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
     : canMcp ? 'mcp'
     : canFreshdesk ? 'freshdesk'
     : canJira ? 'jira'
+    : canMixpanel ? 'mixpanel'
     : 'upload';
 
   const tabTriggerClass = "px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white";
@@ -144,6 +149,11 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
               {canJira && (
                 <TabsTrigger value="jira" className={tabTriggerClass}>
                   Jira
+                </TabsTrigger>
+              )}
+              {canMixpanel && (
+                <TabsTrigger value="mixpanel" className={tabTriggerClass}>
+                  Mixpanel
                 </TabsTrigger>
               )}
             </TabsList>
@@ -237,6 +247,19 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
                   isAtLimit={isAtLimit}
                   onAddJira={async (name, description) => {
                     await onAddJira(name, description);
+                    onImportComplete();
+                    onOpenChange(false);
+                  }}
+                />
+              </TabsContent>
+            )}
+
+            {canMixpanel && (
+              <TabsContent value="mixpanel" className="mt-6">
+                <MixpanelTab
+                  isAtLimit={isAtLimit}
+                  onAddMixpanel={async (name, description) => {
+                    await onAddMixpanel(name, description);
                     onImportComplete();
                     onOpenChange(false);
                   }}

--- a/frontend/src/components/sources/MixpanelTab.tsx
+++ b/frontend/src/components/sources/MixpanelTab.tsx
@@ -1,0 +1,84 @@
+/**
+ * MixpanelTab Component
+ * Educational Note: Adds a Mixpanel source to the project for live analytics
+ * queries in chat. Similar to JiraTab — credentials are configured globally
+ * in API Keys settings; this just flags the project.
+ */
+
+import React, { useState } from 'react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { CircleNotch, Plus } from '@phosphor-icons/react';
+
+interface MixpanelTabProps {
+  isAtLimit: boolean;
+  onAddMixpanel: (name?: string, description?: string) => Promise<void>;
+}
+
+export const MixpanelTab: React.FC<MixpanelTabProps> = ({ isAtLimit, onAddMixpanel }) => {
+  const [adding, setAdding] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleAdd = async () => {
+    setAdding(true);
+    try {
+      await onAddMixpanel(
+        name.trim() || undefined,
+        description.trim() || undefined
+      );
+      setName('');
+      setDescription('');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm">
+        Connect Mixpanel for live event, funnel, and retention queries in chat.
+      </p>
+      <p className="text-xs text-muted-foreground">
+        Requires a Mixpanel Service Account configured in Admin Settings &rarr; API Keys.
+      </p>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium block">Display name (optional)</label>
+        <Input
+          placeholder="Mixpanel Analytics"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={isAtLimit || adding}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium block">Description (optional)</label>
+        <Input
+          placeholder="Product analytics from Mixpanel"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          disabled={isAtLimit || adding}
+        />
+      </div>
+
+      <Button
+        onClick={handleAdd}
+        disabled={isAtLimit || adding}
+      >
+        {adding ? (
+          <>
+            <CircleNotch size={16} className="mr-2 animate-spin" />
+            Adding...
+          </>
+        ) : (
+          <>
+            <Plus size={16} className="mr-2" />
+            Add Mixpanel Source
+          </>
+        )}
+      </Button>
+    </div>
+  );
+};

--- a/frontend/src/components/sources/SourcesPanel.tsx
+++ b/frontend/src/components/sources/SourcesPanel.tsx
@@ -533,6 +533,32 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
   };
 
   /**
+   * Handle adding a Mixpanel source
+   */
+  const handleAddMixpanel = async (name?: string, description?: string) => {
+    if (sources.length >= MAX_SOURCES) {
+      error(`Cannot add. Maximum ${MAX_SOURCES} sources allowed.`);
+      return;
+    }
+
+    try {
+      await sourcesAPI.addMixpanelSource(projectId, name, description);
+      success('Mixpanel source added — verifying connection. Check the status bar for progress.');
+      await loadSources();
+      setSheetOpen(false);
+    } catch (err: unknown) {
+      log.error({ err }, 'failed to add Mixpanel source');
+      const errorMessage = err instanceof Error ? err.message : 'Failed to add Mixpanel source';
+      if (typeof err === 'object' && err !== null && 'response' in err) {
+        const axiosErr = err as { response?: { data?: { error?: string } } };
+        error(axiosErr.response?.data?.error || errorMessage);
+      } else {
+        error(errorMessage);
+      }
+    }
+  };
+
+  /**
    * Handle Freshdesk sync
    */
   const handleSyncFreshdesk = async (sourceId: string) => {
@@ -830,6 +856,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
         onAddMcp={handleAddMcp}
         onAddFreshdesk={handleAddFreshdesk}
         onAddJira={handleAddJira}
+        onAddMixpanel={handleAddMixpanel}
         onImportComplete={loadSources}
         uploading={uploading}
       />

--- a/frontend/src/lib/api/sources.ts
+++ b/frontend/src/lib/api/sources.ts
@@ -434,6 +434,32 @@ class SourcesAPI {
     }
   }
 
+  /**
+   * Add a Mixpanel source for live analytics queries in chat
+   * Educational Note: Mixpanel Service Account credentials are configured
+   * globally in API Keys settings. The backend uses these to query the
+   * Mixpanel Query API live — no data is synced locally.
+   */
+  async addMixpanelSource(
+    projectId: string,
+    name?: string,
+    description?: string
+  ): Promise<Source> {
+    try {
+      const response = await axios.post(
+        `${API_BASE_URL}/projects/${projectId}/sources/mixpanel`,
+        {
+          name: name || undefined,
+          description: description || undefined,
+        }
+      );
+      return response.data.source;
+    } catch (error) {
+      log.error({ err: error }, 'failed to add Mixpanel source');
+      throw error;
+    }
+  }
+
   async syncFreshdesk(projectId: string, sourceId: string): Promise<void> {
     try {
       await axios.post(`${API_BASE_URL}/projects/${projectId}/sources/${sourceId}/freshdesk-sync`);

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,106 @@
+# Mixpanel Integration: What Next?
+
+## Where we are today
+
+Option A is built and sitting in an open PR, not yet merged or deployed. It adds Mixpanel as a project-scoped source with seven tools for querying events, funnels, retention, etc. Under the hood, it uses a single Mixpanel Service Account that an admin configures once in the settings page, shared by every user.
+
+Mixpanel also runs a hosted MCP server (Option B) that does more and scales better. Since nothing is deployed yet, either approach is still on the table. This doc is the decision, not a retroactive justification.
+
+## Option A: Service Account + REST (open in a PR, not yet merged)
+
+One admin adds one secret. Everyone in NoobBook can query Mixpanel.
+
+```mermaid
+flowchart LR
+    A[Admin] -->|one time| B[Paste service account<br/>into API Keys]
+    U[Any user] -->|asks question in chat| C[Claude]
+    C -->|uses one of 7 tools| D[NoobBook backend]
+    D -->|Basic Auth, shared secret| E[(Mixpanel Query API)]
+    E -->|JSON result| D --> C --> U
+```
+
+**What we get:**
+- Simple. No per-user onboarding.
+- Works for users who don't have Mixpanel accounts themselves.
+- Portable. Doesn't lock us to Anthropic's API. If we swap models later, the integration keeps working.
+- Ships the minute an admin pastes a secret.
+
+**What we give up:**
+- Shared 60 queries/hour across the whole app. Fine for a small team. Breaks down once 20+ people are using it.
+- Mixpanel's audit log shows every query as coming from the same service account. You can't tell who did what.
+- Seven handpicked tools. No dashboard creation, no session replays, no writes. If Mixpanel adds new capabilities, we have to add them by hand.
+- If a user in NoobBook shouldn't see certain Mixpanel data, we can't enforce that. The service account sees everything.
+
+## Option B: Hosted MCP + per-user OAuth
+
+Each user clicks "Connect Mixpanel" once, logs in with their Mixpanel account (or SSO), and their personal token is stored. When they ask a question in chat, Claude talks to Mixpanel's hosted MCP server using that user's token.
+
+```mermaid
+flowchart LR
+    subgraph Setup[One time per user]
+        U1[User] -->|click Connect| B1[NoobBook backend]
+        B1 -->|OAuth redirect| M1[Mixpanel login + consent]
+        M1 -->|user token| B1
+        B1 -->|store per user| DB[(users.mixpanel_tokens)]
+    end
+
+    subgraph Query[Every chat message]
+        U2[User] -->|asks question| C[Claude]
+        C -->|talks directly to MCP,<br/>using that user's token| MCP[(Mixpanel hosted MCP<br/>26 tools)]
+        MCP -->|result| C --> U2
+    end
+```
+
+**What we get:**
+- 600 queries/hour per user. A 50-person team has roughly 500x more headroom than today.
+- 26 tools instead of 7. Dashboards, tags, issues, session replays, and more.
+- Real per-user audit trail. Mixpanel sees Daisy's query as Daisy's query.
+- Permissions enforced by Mixpanel itself. If a user's Mixpanel role restricts them, the chat respects that automatically.
+- Mixpanel maintains the tools. When they add features, we get them for free.
+
+**What we give up:**
+- Every user needs a Mixpanel account. If your PMs do but your support team doesn't, the support team is out.
+- Each user goes through a one-time connect flow. Friction we don't have today.
+- Tied to Anthropic's Messages API. If we ever want to run a non-Anthropic model in chat, we'd have to wrap the MCP server ourselves.
+- Real engineering work. Roughly 2 to 3 days to build the OAuth flow, token refresh, and plumb it through the chat service. Most of the code we shipped for Option A is still reusable (source flag, processor, permissions, tab), but the query layer gets rewritten.
+
+## How to think about it
+
+Option A is correct when:
+- Only a handful of people use it
+- Everyone on the team shares the same view of Mixpanel data
+- Some NoobBook users don't have Mixpanel accounts and shouldn't need them
+
+Option B is correct when:
+- Usage grows past roughly 10 active people per day (we'll hit the rate limit)
+- Security or compliance cares about who queried what
+- Users ask for features we didn't build (dashboards, session replay, cohorts)
+- We want the integration to stay current without ongoing maintenance from us
+
+## Side by side
+
+| Dimension | Option A (in PR) | Option B (hosted MCP) |
+|---|---|---|
+| Setup burden | 1 admin, 2 minutes | 1 admin + every user, 30 seconds each |
+| Rate limit | 60/hr shared | 600/hr per user |
+| Tools available | 7 | 26 |
+| Audit trail | Shared account | Per user |
+| Works without Mixpanel accounts | Yes | No |
+| LLM provider lock-in | None | Anthropic only |
+| Dev effort from here | Merge the PR | Roughly 3 days on top of the PR |
+
+## Recommendation
+
+Merge Option A as is. It unblocks anyone who wants to try Mixpanel in chat right now, and the structural pieces (source flag, permissions, tab, processor) are the same pieces Option B would need anyway. If the team decides later to move to Option B, we keep all of that and only swap the query layer.
+
+Revisit when any of these happen:
+1. The 60/hr rate limit actually bites (users see "try again later" messages)
+2. Someone asks "who ran that query?" and we can't answer
+3. A user wants to do something in Mixpanel our seven tools don't cover
+4. Security or legal raises the shared-service-account pattern as a concern
+
+Budget roughly 3 days for the Option B migration when we commit to it.
+
+## Open question for the team
+
+Is anyone expecting heavy Mixpanel use in the next quarter? If yes, it's probably worth doing Option B proactively rather than scrambling when limits start hitting. If not, we're fine to let usage tell us.


### PR DESCRIPTION
## Summary

Roadmap item **#11** — Mixpanel analytics in chat. Mirrors the Jira pattern: lightweight `.mixpanel` source flag per project, no local data sync, live queries via Mixpanel's Query API.

## How it works

**1. Admin adds creds once** — *Settings → API Keys → Integrations* → paste Mixpanel service account `username`, `secret`, `project_id`. Validator hits `/events/names` to verify.

**2. User adds Mixpanel to a project** — *Sources → Add → Mixpanel → Add*. Backend creates a tiny `.mixpanel` flag file, processor lists available events for the summary, marks `ready`. Takes ~2 seconds.

**3. Chat gets 7 tools, only in that project** — `main_chat_service` sees the `.mixpanel` flag and adds `mixpanel_list_events`, `mixpanel_query_events`, `mixpanel_segmentation`, `mixpanel_list_funnels`, `mixpanel_query_funnel`, `mixpanel_retention`, `mixpanel_jql` to Claude's tool list. Projects without the flag don't see them.

**4. User asks a question** — Claude picks the right tool → `knowledge_base_service` routes to `mixpanel_service` → hits Mixpanel's Query API with Basic Auth → returns JSON → Claude answers.

```
User: "How many signups last week?"
  ↓
Claude → mixpanel_query_events(event_names=["Signed Up"], from=..., to=...)
  ↓
mixpanel_service → GET mixpanel.com/api/query/events (Basic Auth)
  ↓
JSON result → Claude → "You had 1,247 signups last week."
```

### Why Service Account + REST, not the hosted MCP server?
Mixpanel's hosted MCP requires OAuth 2.0 + PKCE per-user. Our MCP client only supports static tokens today. Service Account + REST reuses the Jira path and ships in one PR.

## Test plan
- [ ] Settings → API Keys → save wrong secret → validator rejects.
- [ ] Save correct creds → masked on reload.
- [ ] Without creds, add Mixpanel source → clean toast \"Mixpanel not configured…\".
- [ ] With creds, add source → status goes to \"ready\", summary lists events.
- [ ] Ask \"what events are tracked?\" → Claude calls \`mixpanel_list_events\`.
- [ ] Ask \"signups last week?\" → Claude calls \`mixpanel_query_events\`.
- [ ] Project without \`.mixpanel\` flag → no Mixpanel tools in tool list.
- [ ] Toggle \`integrations.mixpanel\` off → tab disappears.

Closes roadmap item #11.