### PR TITLE
Smooth UX: kill refresh/remount cascades

### DIFF
--- a/backend/app/api/messages/routes.py
+++ b/backend/app/api/messages/routes.py
@@ -82,7 +82,7 @@ def send_message(project_id, chat_id):
 
         # Delegate all processing to main_chat_service
         # This is the RAG + agentic loop entry point
-        user_msg, assistant_msg = main_chat_service.send_message(
+        result = main_chat_service.send_message(
             project_id=project_id,
             chat_id=chat_id,
             user_message_text=user_message_text
@@ -90,8 +90,9 @@ def send_message(project_id, chat_id):
 
         return jsonify({
             'success': True,
-            'user_message': user_msg,
-            'assistant_message': assistant_msg
+            'user_message': result['user_message'],
+            'assistant_message': result['assistant_message'],
+            'sync': result.get('sync'),
         }), 200
 
     except ValueError as e:

--- a/backend/app/api/projects/active_tasks.py
+++ b/backend/app/api/projects/active_tasks.py
@@ -6,7 +6,6 @@ status bar to poll. Aggregates sources being processed, studio jobs in progress,
 and background tasks into a unified list.
 """
 
-from datetime import datetime
 from flask import jsonify, current_app
 
 from app.api.projects import projects_bp
@@ -58,6 +57,7 @@ def get_active_tasks(project_id: str):
                         "label": src.get("name", "Source"),
                         "detail": detail,
                         "status": status,
+                        "target_id": src.get("id"),
                         "created_at": src.get("created_at"),
                     })
         except Exception as e:
@@ -88,6 +88,7 @@ def get_active_tasks(project_id: str):
                     "detail": detail,
                     "status": job.get("status"),
                     "progress": job.get("progress"),
+                    "target_id": job.get("id"),
                     "created_at": job.get("created_at"),
                 })
         except Exception as e:
@@ -98,7 +99,7 @@ def get_active_tasks(project_id: str):
             supabase = get_supabase()
             bg_response = (
                 supabase.table("background_tasks")
-                .select("id, task_type, target_type, status, message, created_at, started_at")
+                .select("id, task_type, target_id, target_type, status, message, created_at, started_at")
                 .in_("status", ["pending", "running"])
                 .order("created_at", desc=False)
                 .execute()
@@ -112,9 +113,12 @@ def get_active_tasks(project_id: str):
                 tasks.append({
                     "id": task.get("id"),
                     "type": "background",
+                    "task_type": task_type,
                     "label": _format_task_type(task_type),
                     "detail": task.get("message") or "Processing...",
                     "status": task.get("status"),
+                    "target_id": task.get("target_id"),
+                    "target_type": task.get("target_type"),
                     "created_at": task.get("started_at") or task.get("created_at"),
                 })
         except Exception as e:

--- a/backend/app/api/studio/__init__.py
+++ b/backend/app/api/studio/__init__.py
@@ -79,6 +79,7 @@ from app.api.studio import prds  # noqa: F401
 from app.api.studio import marketing_strategies  # noqa: F401
 from app.api.studio import blogs  # noqa: F401
 from app.api.studio import business_reports  # noqa: F401
+from app.api.studio import job_groups  # noqa: F401
 
 # Educational Note: The noqa comments tell flake8 to ignore the
 # "imported but unused" warning. We import to register routes,

--- a/backend/app/api/studio/job_groups.py
+++ b/backend/app/api/studio/job_groups.py
@@ -1,0 +1,30 @@
+"""
+Grouped Studio Jobs endpoint.
+
+Educational Note: Studio used to bootstrap by having every section hit its own
+list endpoint on mount. This route lets the frontend hydrate once and fan the
+results back out locally.
+"""
+
+from flask import jsonify, current_app
+
+from app.api.studio import studio_bp
+from app.services.studio_services import studio_index_service
+
+
+@studio_bp.route('/projects/<project_id>/studio/job-groups', methods=['GET'])
+def list_grouped_studio_jobs(project_id: str):
+    """List all studio jobs for a project, grouped by job_type."""
+    try:
+        jobs_by_type = studio_index_service.list_jobs_grouped(project_id)
+        return jsonify({
+            'success': True,
+            'jobs_by_type': jobs_by_type,
+            'count': sum(len(jobs) for jobs in jobs_by_type.values()),
+        }), 200
+    except Exception as e:
+        current_app.logger.error(f"Error listing grouped studio jobs: {e}")
+        return jsonify({
+            'success': False,
+            'error': f'Failed to list grouped studio jobs: {str(e)}'
+        }), 500

--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -17,6 +17,7 @@ import logging
 from typing import Dict, Any, Tuple, List, Optional, Callable
 
 from app.services.data_services import chat_service
+from app.services.data_services.user_service import get_user_service
 
 logger = logging.getLogger(__name__)
 from app.services.integrations.claude import claude_service
@@ -363,6 +364,23 @@ class MainChatService:
         if on_event:
             on_event(event_name, payload or {})
 
+    def _build_sync_payload(
+        self,
+        project_id: str,
+        chat_id: str,
+        user_id: Optional[str],
+    ) -> Dict[str, Any]:
+        sync = chat_service.get_chat_sync_state(project_id, chat_id) or {}
+        if user_id:
+            try:
+                sync["user_usage"] = get_user_service().get_usage_summary(user_id)
+            except Exception as exc:
+                logger.warning("Failed to build usage summary for %s: %s", user_id, exc)
+                sync["user_usage"] = None
+        else:
+            sync["user_usage"] = None
+        return sync
+
     def _call_claude(
         self,
         *,
@@ -584,7 +602,11 @@ class MainChatService:
                 model=response.get("model"),
                 tokens=response.get("usage")
             )
-            self._emit_event(on_event, "assistant_done", assistant_msg)
+            sync_payload = self._build_sync_payload(project_id, chat_id, resolved_user_id)
+            self._emit_event(on_event, "assistant_done", {
+                "assistant_message": assistant_msg,
+                "sync": sync_payload,
+            })
 
         except Exception as api_error:
             partial_text = api_error.partial_text if isinstance(api_error, ClaudeStreamError) else ""
@@ -620,6 +642,7 @@ class MainChatService:
                 {
                     "message": str(api_error),
                     "assistant_message": assistant_msg,
+                    "sync": self._build_sync_payload(project_id, chat_id, resolved_user_id),
                 },
             )
 
@@ -637,12 +660,14 @@ class MainChatService:
                 self._generate_and_update_chat_title,
                 project_id,
                 chat_id,
-                user_message_text
+                user_message_text,
+                target_type="chat",
             )
 
         return {
             "user_message": user_msg,
             "assistant_message": assistant_msg,
+            "sync": self._build_sync_payload(project_id, chat_id, resolved_user_id),
         }
 
     def send_message(
@@ -650,15 +675,14 @@ class MainChatService:
         project_id: str,
         chat_id: str,
         user_message_text: str
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """Process a user message and return the saved user + assistant messages."""
-        result = self._run_message_flow(
+    ) -> Dict[str, Any]:
+        """Process a user message and return saved messages plus sync metadata."""
+        return self._run_message_flow(
             project_id=project_id,
             chat_id=chat_id,
             user_message_text=user_message_text,
             stream_text=False,
         )
-        return result["user_message"], result["assistant_message"]
 
     def stream_message(
         self,

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -461,6 +461,24 @@ class ChatService:
             },
         }
 
+    def get_chat_sync_state(self, project_id: str, chat_id: str) -> Optional[Dict[str, Any]]:
+        chat = self.get_chat(project_id, chat_id)
+        if not chat:
+            return None
+
+        return {
+            "chat": {
+                "id": chat["id"],
+                "title": chat["title"],
+                "created_at": chat["created_at"],
+                "updated_at": chat["updated_at"],
+                "message_count": chat["message_count"],
+                "selected_source_ids": chat.get("selected_source_ids"),
+            },
+            "studio_signals": chat.get("studio_signals", []),
+            "chat_costs": self.get_chat_costs(project_id, chat_id),
+        }
+
     def get_chat_costs_raw(self, chat_id: str) -> Optional[Dict[str, Any]]:
         """
         Load raw costs JSONB for a chat by chat_id only (no project scoping).

--- a/backend/app/services/data_services/user_service.py
+++ b/backend/app/services/data_services/user_service.py
@@ -9,6 +9,7 @@ operations always use the service_role key.
 """
 import logging
 import os
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from supabase import create_client
@@ -180,6 +181,36 @@ class UserService:
             total += costs.get("total_cost", 0.0)
         return total
 
+    def get_usage_summary(self, user_id: str) -> Optional[Dict[str, Any]]:
+        user = self.get_user(user_id)
+        if not user:
+            return None
+
+        cost_limit = user.get("cost_limit")
+        reset_frequency = user.get("reset_frequency")
+        period_spend = user.get("period_spend", 0.0)
+        period_start = user.get("period_start")
+        total_spend = self.get_user_total_spend(user_id)
+
+        if reset_frequency and cost_limit:
+            current_spend = period_spend
+        elif cost_limit:
+            current_spend = total_spend
+        else:
+            current_spend = total_spend
+
+        usage_pct = (current_spend / cost_limit * 100) if cost_limit and cost_limit > 0 else 0
+
+        return {
+            "cost_limit": cost_limit,
+            "reset_frequency": reset_frequency,
+            "current_spend": current_spend,
+            "total_spend": total_spend,
+            "period_start": period_start,
+            "usage_percent": usage_pct,
+            "snapshot_at": datetime.utcnow().isoformat() + "Z",
+        }
+
     def count_admins(self) -> int:
         resp = (
             self.supabase.table(self.table)
@@ -337,4 +368,3 @@ def get_user_service() -> UserService:
     if _user_service is None:
         _user_service = UserService()
     return _user_service
-

--- a/backend/app/services/studio_services/studio_index_service.py
+++ b/backend/app/services/studio_services/studio_index_service.py
@@ -256,6 +256,38 @@ def list_jobs(
         return []
 
 
+def list_jobs_grouped(project_id: str) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    List all studio jobs for a project, grouped by job_type.
+
+    Educational Note: This supports Studio bootstrap without issuing one
+    request per section. Callers can filter by source client-side.
+    """
+    try:
+        client = _get_client()
+        response = (
+            client.table("studio_jobs")
+            .select("*")
+            .eq("project_id", project_id)
+            .order("created_at", desc=True)
+            .execute()
+        )
+
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
+        for row in (response.data or []):
+            mapped = _map_job(row)
+            if not mapped:
+                continue
+            job_type = mapped.get("job_type")
+            if not job_type:
+                continue
+            grouped.setdefault(job_type, []).append(mapped)
+        return grouped
+    except Exception as e:
+        logger.error("Failed to list grouped studio jobs (project=%s): %s", project_id, e)
+        return {}
+
+
 def delete_job(
     project_id: str,
     job_id: str

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { AuthPage } from './components/auth/AuthPage';
 import { authAPI } from './lib/api/auth';
 import { createLogger } from '@/lib/logger';
 import { PermissionsProvider } from './contexts/PermissionsContext';
+import { IntegrationsProvider } from './contexts/IntegrationsContext';
 
 const log = createLogger('app');
 
@@ -238,40 +239,42 @@ function App() {
 
   return (
     <PermissionsProvider>
-      <BrowserRouter>
-        <Routes>
-          {/* Project Workspace - URL-based routing */}
-          <Route
-            path="/projects/:projectId"
-            element={
-              <ProjectWorkspaceRoute
-                setRefreshTrigger={setRefreshTrigger}
-                isAuthenticated={isAuthenticated}
-                onSignOut={handleSignOut}
-              />
-            }
-          />
+      <IntegrationsProvider>
+        <BrowserRouter>
+          <Routes>
+            {/* Project Workspace - URL-based routing */}
+            <Route
+              path="/projects/:projectId"
+              element={
+                <ProjectWorkspaceRoute
+                  setRefreshTrigger={setRefreshTrigger}
+                  isAuthenticated={isAuthenticated}
+                  onSignOut={handleSignOut}
+                />
+              }
+            />
 
-          {/* Dashboard - Home/root route */}
-          <Route
-            path="*"
-            element={
-              <AppContent
-                showCreateDialog={showCreateDialog}
-                setShowCreateDialog={setShowCreateDialog}
-                refreshTrigger={refreshTrigger}
-                setRefreshTrigger={setRefreshTrigger}
-                isAdmin={isAdmin}
-                isAuthenticated={isAuthenticated}
-                onSignOut={handleSignOut}
-                userId={userId}
-                userEmail={userEmail}
-                userRole={userRole}
-              />
-            }
-          />
-        </Routes>
-      </BrowserRouter>
+            {/* Dashboard - Home/root route */}
+            <Route
+              path="*"
+              element={
+                <AppContent
+                  showCreateDialog={showCreateDialog}
+                  setShowCreateDialog={setShowCreateDialog}
+                  refreshTrigger={refreshTrigger}
+                  setRefreshTrigger={setRefreshTrigger}
+                  isAdmin={isAdmin}
+                  isAuthenticated={isAuthenticated}
+                  onSignOut={handleSignOut}
+                  userId={userId}
+                  userEmail={userEmail}
+                  userRole={userRole}
+                />
+              }
+            />
+          </Routes>
+        </BrowserRouter>
+      </IntegrationsProvider>
     </PermissionsProvider>
   );
 }

--- a/frontend/src/components/brand/BrandAssetUploader.tsx
+++ b/frontend/src/components/brand/BrandAssetUploader.tsx
@@ -18,7 +18,7 @@ import {
 } from '../ui/dialog';
 import { UploadSimple, CircleNotch, X } from '@phosphor-icons/react';
 import { cn } from '../../lib/utils';
-import { brandAPI, createAssetFormData, type BrandAssetType } from '../../lib/api/brand';
+import { brandAPI, createAssetFormData, type BrandAsset, type BrandAssetType } from '../../lib/api/brand';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('brand-asset-uploader');
@@ -27,7 +27,7 @@ interface BrandAssetUploaderProps {
   assetType: BrandAssetType;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onUploaded: () => void;
+  onUploaded: (asset: BrandAsset) => void;
   acceptedTypes?: string;
 }
 
@@ -114,7 +114,7 @@ export const BrandAssetUploader: React.FC<BrandAssetUploaderProps> = ({
       const response = await brandAPI.uploadAsset(formData);
 
       if (response.data.success) {
-        onUploaded();
+        onUploaded(response.data.asset);
         handleClose();
       } else {
         setError(response.data.error || 'Upload failed');

--- a/frontend/src/components/brand/BrandConfigContext.tsx
+++ b/frontend/src/components/brand/BrandConfigContext.tsx
@@ -1,0 +1,76 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { brandAPI, type BrandConfig } from '@/lib/api/brand';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('brand-config-context');
+
+interface BrandConfigContextValue {
+  config: BrandConfig | null;
+  initialLoading: boolean;
+  refreshConfig: (options?: { silent?: boolean; force?: boolean }) => Promise<BrandConfig | null>;
+  patchConfig: (updates: Partial<BrandConfig>) => void;
+}
+
+const BrandConfigContext = createContext<BrandConfigContextValue | null>(null);
+
+export const BrandConfigProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [config, setConfig] = useState<BrandConfig | null>(null);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [loaded, setLoaded] = useState(false);
+
+  const refreshConfig = useCallback(async (options?: { silent?: boolean; force?: boolean }) => {
+    const { silent = false, force = false } = options ?? {};
+    if (loaded && !force) {
+      return config;
+    }
+
+    if (!silent) {
+      setInitialLoading(true);
+    }
+
+    try {
+      const response = await brandAPI.getConfig();
+      const nextConfig = response.data.success ? response.data.config : null;
+      setConfig(nextConfig);
+      setLoaded(true);
+      return nextConfig;
+    } catch (err) {
+      log.error({ err }, 'failed to load brand config');
+      throw err;
+    } finally {
+      if (!silent) {
+        setInitialLoading(false);
+      }
+    }
+  }, [config, loaded]);
+
+  useEffect(() => {
+    refreshConfig().catch(() => {
+      setInitialLoading(false);
+    });
+  }, [refreshConfig]);
+
+  const value = useMemo<BrandConfigContextValue>(() => ({
+    config,
+    initialLoading,
+    refreshConfig,
+    patchConfig: (updates) => {
+      setConfig((prev) => (prev ? { ...prev, ...updates } : prev));
+    },
+  }), [config, initialLoading, refreshConfig]);
+
+  return (
+    <BrandConfigContext.Provider value={value}>
+      {children}
+    </BrandConfigContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useBrandConfig = () => {
+  const context = useContext(BrandConfigContext);
+  if (!context) {
+    throw new Error('useBrandConfig must be used within BrandConfigProvider');
+  }
+  return context;
+};

--- a/frontend/src/components/brand/BrandConfigContext.tsx
+++ b/frontend/src/components/brand/BrandConfigContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { brandAPI, type BrandConfig } from '@/lib/api/brand';
 import { createLogger } from '@/lib/logger';
 
@@ -16,12 +16,19 @@ const BrandConfigContext = createContext<BrandConfigContextValue | null>(null);
 export const BrandConfigProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [config, setConfig] = useState<BrandConfig | null>(null);
   const [initialLoading, setInitialLoading] = useState(true);
-  const [loaded, setLoaded] = useState(false);
+  const configRef = useRef<BrandConfig | null>(null);
+  const loadedRef = useRef(false);
+
+  // Keep refs in sync so the callbacks can read current state without listing
+  // it in their dep arrays (which would recreate them on every patchConfig).
+  useEffect(() => {
+    configRef.current = config;
+  }, [config]);
 
   const refreshConfig = useCallback(async (options?: { silent?: boolean; force?: boolean }) => {
     const { silent = false, force = false } = options ?? {};
-    if (loaded && !force) {
-      return config;
+    if (loadedRef.current && !force) {
+      return configRef.current;
     }
 
     if (!silent) {
@@ -32,7 +39,8 @@ export const BrandConfigProvider: React.FC<{ children: React.ReactNode }> = ({ c
       const response = await brandAPI.getConfig();
       const nextConfig = response.data.success ? response.data.config : null;
       setConfig(nextConfig);
-      setLoaded(true);
+      configRef.current = nextConfig;
+      loadedRef.current = true;
       return nextConfig;
     } catch (err) {
       log.error({ err }, 'failed to load brand config');
@@ -42,7 +50,7 @@ export const BrandConfigProvider: React.FC<{ children: React.ReactNode }> = ({ c
         setInitialLoading(false);
       }
     }
-  }, [config, loaded]);
+  }, []);
 
   useEffect(() => {
     refreshConfig().catch(() => {

--- a/frontend/src/components/brand/sections/ColorsSection.tsx
+++ b/frontend/src/components/brand/sections/ColorsSection.tsx
@@ -14,6 +14,7 @@ import { brandAPI, type ColorPalette, type CustomColor, type ColorEnabled, getDe
 import { ColorPicker } from '../ColorPicker';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { useBrandConfig } from '../BrandConfigContext';
 
 const log = createLogger('brand-colors');
 
@@ -29,38 +30,26 @@ const COLOR_FIELDS: { key: keyof Omit<ColorPalette, 'custom' | 'enabled'>; label
 export const ColorsSection: React.FC = () => {
   const [colors, setColors] = useState<ColorPalette>(getDefaultColors());
   const [enabled, setEnabled] = useState<ColorEnabled>(getDefaultColorEnabled());
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [newColorName, setNewColorName] = useState('');
   const [newColorValue, setNewColorValue] = useState('#000000');
   const { success: showSuccess, error: showError } = useToast();
-
-  const loadColors = async () => {
-    try {
-      setLoading(true);
-      const response = await brandAPI.getConfig();
-      if (response.data.success) {
-        const loaded = response.data.config.colors;
-        setColors({ ...loaded, custom: loaded.custom ?? [] });
-        setEnabled(loaded.enabled ?? getDefaultColorEnabled());
-      }
-    } catch (error) {
-      log.error({ err: error }, 'failed to load colors');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const { config, initialLoading, patchConfig } = useBrandConfig();
 
   useEffect(() => {
-    loadColors();
-  }, []);
+    if (!config) return;
+    const loaded = config.colors;
+    setColors({ ...loaded, custom: loaded.custom ?? [] });
+    setEnabled(loaded.enabled ?? getDefaultColorEnabled());
+  }, [config]);
 
   const handleSave = async () => {
     try {
       setSaving(true);
       const response = await brandAPI.updateColors({ ...colors, enabled });
       if (response.data.success) {
+        patchConfig({ colors: response.data.config.colors });
         setSaved(true);
         showSuccess('Colors saved');
         setTimeout(() => setSaved(false), 2000);
@@ -108,7 +97,7 @@ export const ColorsSection: React.FC = () => {
     }));
   };
 
-  if (loading) {
+  if (initialLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <CircleNotch size={24} className="animate-spin text-muted-foreground" />

--- a/frontend/src/components/brand/sections/FeatureSettingsSection.tsx
+++ b/frontend/src/components/brand/sections/FeatureSettingsSection.tsx
@@ -10,6 +10,7 @@ import { CircleNotch, Check } from '@phosphor-icons/react';
 import { brandAPI, type FeatureSettings, getDefaultFeatureSettings } from '../../../lib/api/brand';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { useBrandConfig } from '../BrandConfigContext';
 
 const log = createLogger('brand-feature-settings');
 
@@ -74,34 +75,22 @@ const features: FeatureConfig[] = [
 
 export const FeatureSettingsSection: React.FC = () => {
   const [settings, setSettings] = useState<FeatureSettings>(getDefaultFeatureSettings());
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const { success: showSuccess, error: showError } = useToast();
-
-  const loadSettings = async () => {
-    try {
-      setLoading(true);
-      const response = await brandAPI.getConfig();
-      if (response.data.success) {
-        setSettings(response.data.config.feature_settings);
-      }
-    } catch (error) {
-      log.error({ err: error }, 'failed to load settings');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const { config, initialLoading, patchConfig } = useBrandConfig();
 
   useEffect(() => {
-    loadSettings();
-  }, []);
+    if (!config) return;
+    setSettings(config.feature_settings);
+  }, [config]);
 
   const handleSave = async () => {
     try {
       setSaving(true);
       const response = await brandAPI.updateFeatureSettings(settings);
       if (response.data.success) {
+        patchConfig({ feature_settings: response.data.config.feature_settings });
         setSaved(true);
         showSuccess('Feature settings saved');
         setTimeout(() => setSaved(false), 2000);
@@ -137,7 +126,7 @@ export const FeatureSettingsSection: React.FC = () => {
     setSettings(disabled as FeatureSettings);
   };
 
-  if (loading) {
+  if (initialLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <CircleNotch size={24} className="animate-spin text-muted-foreground" />

--- a/frontend/src/components/brand/sections/GuidelinesSection.tsx
+++ b/frontend/src/components/brand/sections/GuidelinesSection.tsx
@@ -12,6 +12,7 @@ import { Plus, X, CircleNotch, Check, PencilSimple, Trash } from '@phosphor-icon
 import { brandAPI, type BrandVoice, type BestPractices } from '../../../lib/api/brand';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { useBrandConfig } from '../BrandConfigContext';
 
 const log = createLogger('brand-guidelines');
 
@@ -26,9 +27,9 @@ export const GuidelinesSection: React.FC = () => {
     dos: [],
     donts: [],
   });
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const { config, initialLoading, patchConfig } = useBrandConfig();
 
   const { success: showSuccess, error: showError } = useToast();
 
@@ -44,26 +45,12 @@ export const GuidelinesSection: React.FC = () => {
   const [editDoValue, setEditDoValue] = useState('');
   const [editDontValue, setEditDontValue] = useState('');
 
-  const loadConfig = async () => {
-    try {
-      setLoading(true);
-      const response = await brandAPI.getConfig();
-      if (response.data.success) {
-        const config = response.data.config;
-        setGuidelines(config.guidelines || '');
-        setVoice(config.voice);
-        setBestPractices(config.best_practices);
-      }
-    } catch (error) {
-      log.error({ err: error }, 'failed to load config');
-    } finally {
-      setLoading(false);
-    }
-  };
-
   useEffect(() => {
-    loadConfig();
-  }, []);
+    if (!config) return;
+    setGuidelines(config.guidelines || '');
+    setVoice(config.voice);
+    setBestPractices(config.best_practices);
+  }, [config]);
 
   const handleSave = async () => {
     try {
@@ -74,6 +61,11 @@ export const GuidelinesSection: React.FC = () => {
         best_practices: bestPractices,
       });
       if (response.data.success) {
+        patchConfig({
+          guidelines: response.data.config.guidelines,
+          voice: response.data.config.voice,
+          best_practices: response.data.config.best_practices,
+        });
         setSaved(true);
         showSuccess('Guidelines saved');
         setTimeout(() => setSaved(false), 2000);
@@ -191,7 +183,7 @@ export const GuidelinesSection: React.FC = () => {
     setEditDontValue('');
   };
 
-  if (loading) {
+  if (initialLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <CircleNotch size={24} className="animate-spin text-muted-foreground" />

--- a/frontend/src/components/brand/sections/IconsSection.tsx
+++ b/frontend/src/components/brand/sections/IconsSection.tsx
@@ -1,6 +1,7 @@
 /**
  * IconsSection Component
- * Educational Note: Manages brand icons with upload functionality.
+ * Manages brand icons with upload functionality. Assets are fetched once on
+ * mount; subsequent delete/setPrimary/upload update local state only.
  */
 import React, { useState, useEffect } from 'react';
 import { Button } from '../../ui/button';
@@ -9,37 +10,40 @@ import { brandAPI, type BrandAsset } from '../../../lib/api/brand';
 import { BrandAssetCard } from '../BrandAssetCard';
 import { BrandAssetUploader } from '../BrandAssetUploader';
 import { createLogger } from '@/lib/logger';
+import { removeOne, upsertOne } from '@/lib/resourceState';
 
 const log = createLogger('brand-icons');
 
 export const IconsSection: React.FC = () => {
   const [assets, setAssets] = useState<BrandAsset[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [uploaderOpen, setUploaderOpen] = useState(false);
 
-  const loadAssets = async () => {
-    try {
-      setLoading(true);
-      const response = await brandAPI.listAssets('icon');
-      if (response.data.success) {
-        setAssets(response.data.assets);
-      }
-    } catch (error) {
-      log.error({ err: error }, 'failed to load icons');
-    } finally {
-      setLoading(false);
-    }
-  };
-
   useEffect(() => {
-    loadAssets();
+    let cancelled = false;
+    brandAPI.listAssets('icon')
+      .then((response) => {
+        if (cancelled) return;
+        if (response.data.success) {
+          setAssets(response.data.assets);
+        }
+      })
+      .catch((error) => {
+        log.error({ err: error }, 'failed to load icons');
+      })
+      .finally(() => {
+        if (!cancelled) setInitialLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleDelete = async (assetId: string) => {
     try {
       const response = await brandAPI.deleteAsset(assetId);
       if (response.data.success) {
-        loadAssets();
+        setAssets((prev) => removeOne(prev, assetId));
       }
     } catch (error) {
       log.error({ err: error }, 'failed to delete asset');
@@ -50,11 +54,23 @@ export const IconsSection: React.FC = () => {
     try {
       const response = await brandAPI.setAssetPrimary(assetId);
       if (response.data.success) {
-        loadAssets();
+        setAssets((prev) => prev.map((asset) => ({
+          ...asset,
+          is_primary: asset.id === assetId,
+        })));
       }
     } catch (error) {
       log.error({ err: error }, 'failed to set primary');
     }
+  };
+
+  const handleUploaded = (asset: BrandAsset) => {
+    setAssets((prev) => {
+      const normalized = asset.is_primary
+        ? prev.map((existing) => ({ ...existing, is_primary: false }))
+        : prev;
+      return upsertOne(normalized, asset, { prepend: true });
+    });
   };
 
   return (
@@ -72,7 +88,7 @@ export const IconsSection: React.FC = () => {
         </Button>
       </div>
 
-      {loading ? (
+      {initialLoading ? (
         <div className="flex items-center justify-center py-12">
           <CircleNotch size={24} className="animate-spin text-muted-foreground" />
         </div>
@@ -101,7 +117,7 @@ export const IconsSection: React.FC = () => {
         assetType="icon"
         open={uploaderOpen}
         onOpenChange={setUploaderOpen}
-        onUploaded={loadAssets}
+        onUploaded={handleUploaded}
         acceptedTypes="image/svg+xml,image/png,image/x-icon"
       />
     </div>

--- a/frontend/src/components/brand/sections/LogosSection.tsx
+++ b/frontend/src/components/brand/sections/LogosSection.tsx
@@ -1,6 +1,7 @@
 /**
  * LogosSection Component
- * Educational Note: Manages brand logos with upload and primary selection.
+ * Manages brand logos with upload and primary selection. Assets are fetched
+ * once on mount; subsequent delete/setPrimary/upload update local state only.
  */
 import React, { useState, useEffect } from 'react';
 import { Button } from '../../ui/button';
@@ -9,37 +10,40 @@ import { brandAPI, type BrandAsset } from '../../../lib/api/brand';
 import { BrandAssetCard } from '../BrandAssetCard';
 import { BrandAssetUploader } from '../BrandAssetUploader';
 import { createLogger } from '@/lib/logger';
+import { removeOne, upsertOne } from '@/lib/resourceState';
 
 const log = createLogger('brand-logos');
 
 export const LogosSection: React.FC = () => {
   const [assets, setAssets] = useState<BrandAsset[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [uploaderOpen, setUploaderOpen] = useState(false);
 
-  const loadAssets = async () => {
-    try {
-      setLoading(true);
-      const response = await brandAPI.listAssets('logo');
-      if (response.data.success) {
-        setAssets(response.data.assets);
-      }
-    } catch (error) {
-      log.error({ err: error }, 'failed to load logos');
-    } finally {
-      setLoading(false);
-    }
-  };
-
   useEffect(() => {
-    loadAssets();
+    let cancelled = false;
+    brandAPI.listAssets('logo')
+      .then((response) => {
+        if (cancelled) return;
+        if (response.data.success) {
+          setAssets(response.data.assets);
+        }
+      })
+      .catch((error) => {
+        log.error({ err: error }, 'failed to load logos');
+      })
+      .finally(() => {
+        if (!cancelled) setInitialLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleDelete = async (assetId: string) => {
     try {
       const response = await brandAPI.deleteAsset(assetId);
       if (response.data.success) {
-        loadAssets();
+        setAssets((prev) => removeOne(prev, assetId));
       }
     } catch (error) {
       log.error({ err: error }, 'failed to delete asset');
@@ -50,11 +54,24 @@ export const LogosSection: React.FC = () => {
     try {
       const response = await brandAPI.setAssetPrimary(assetId);
       if (response.data.success) {
-        loadAssets();
+        setAssets((prev) => prev.map((asset) => ({
+          ...asset,
+          is_primary: asset.id === assetId,
+        })));
       }
     } catch (error) {
       log.error({ err: error }, 'failed to set primary');
     }
+  };
+
+  const handleUploaded = (asset: BrandAsset) => {
+    setAssets((prev) => {
+      // If the new asset is primary, strip primary from siblings before upsert.
+      const normalized = asset.is_primary
+        ? prev.map((existing) => ({ ...existing, is_primary: false }))
+        : prev;
+      return upsertOne(normalized, asset, { prepend: true });
+    });
   };
 
   return (
@@ -72,7 +89,7 @@ export const LogosSection: React.FC = () => {
         </Button>
       </div>
 
-      {loading ? (
+      {initialLoading ? (
         <div className="flex items-center justify-center py-12">
           <CircleNotch size={24} className="animate-spin text-muted-foreground" />
         </div>
@@ -101,7 +118,7 @@ export const LogosSection: React.FC = () => {
         assetType="logo"
         open={uploaderOpen}
         onOpenChange={setUploaderOpen}
-        onUploaded={loadAssets}
+        onUploaded={handleUploaded}
         acceptedTypes="image/svg+xml,image/png,image/jpeg,image/webp"
       />
     </div>

--- a/frontend/src/components/brand/sections/TypographySection.tsx
+++ b/frontend/src/components/brand/sections/TypographySection.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../lib/api/brand';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { useBrandConfig } from '../BrandConfigContext';
 
 const log = createLogger('brand-typography');
 
@@ -34,44 +35,31 @@ type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 export const TypographySection: React.FC = () => {
   const [typography, setTypography] = useState<Typography>(getDefaultTypography());
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const { success: showSuccess, error: showError } = useToast();
-
-  const loadTypography = async () => {
-    try {
-      setLoading(true);
-      const response = await brandAPI.getConfig();
-      if (response.data.success) {
-        // Merge with defaults to handle missing h4, h5, h6 from older configs
-        const loadedTypography = response.data.config.typography;
-        const defaults = getDefaultTypography();
-        setTypography({
-          ...defaults,
-          ...loadedTypography,
-          heading_sizes: {
-            ...defaults.heading_sizes,
-            ...loadedTypography.heading_sizes,
-          },
-        });
-      }
-    } catch (error) {
-      log.error({ err: error }, 'failed to load typography');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const { config, initialLoading, patchConfig } = useBrandConfig();
 
   useEffect(() => {
-    loadTypography();
-  }, []);
+    if (!config) return;
+    const loadedTypography = config.typography;
+    const defaults = getDefaultTypography();
+    setTypography({
+      ...defaults,
+      ...loadedTypography,
+      heading_sizes: {
+        ...defaults.heading_sizes,
+        ...loadedTypography.heading_sizes,
+      },
+    });
+  }, [config]);
 
   const handleSave = async () => {
     try {
       setSaving(true);
       const response = await brandAPI.updateTypography(typography);
       if (response.data.success) {
+        patchConfig({ typography: response.data.config.typography });
         setSaved(true);
         showSuccess('Typography saved');
         setTimeout(() => setSaved(false), 2000);
@@ -104,7 +92,7 @@ export const TypographySection: React.FC = () => {
     return acc;
   }, {} as Record<string, string[]>);
 
-  if (loading) {
+  if (initialLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <CircleNotch size={24} className="animate-spin text-muted-foreground" />

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -7,9 +7,10 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Sparkle } from '@phosphor-icons/react';
+import axios from 'axios';
 import { Skeleton } from '../ui/skeleton';
 import { chatsAPI } from '@/lib/api/chats';
-import type { Chat, ChatMetadata, StudioSignal } from '@/lib/api/chats';
+import type { Chat, ChatMetadata, ChatSyncPayload, StudioSignal } from '@/lib/api/chats';
 import type { CostTracking } from '@/lib/api/projects';
 import { usersAPI, type UserUsage } from '@/lib/api/settings';
 import { sourcesAPI, type Source } from '@/lib/api/sources';
@@ -24,6 +25,7 @@ import { ChatEmptyState } from './ChatEmptyState';
 import { RawMessageView } from './RawMessageView';
 import { exportChatAsPdf } from '@/lib/exportChatPdf';
 import { createLogger } from '@/lib/logger';
+import { API_BASE_URL } from '@/lib/api/client';
 
 const log = createLogger('chat-panel');
 
@@ -67,10 +69,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   const [exportingChat, setExportingChat] = useState(false);
   const [rawMode, setRawMode] = useState(false);
   const [streamingAssistantContent, setStreamingAssistantContent] = useState('');
+  const [titleSyncPollKey, setTitleSyncPollKey] = useState(0);
   // AbortController for cancelling in-flight chat requests
   const abortControllerRef = useRef<AbortController | null>(null);
   const canonicalUserMessageReceivedRef = useRef(false);
   const assistantDeltaReceivedRef = useRef(false);
+  const pendingTitleSyncRef = useRef<{ chatId: string; hasSeenNamingTask: boolean } | null>(null);
 
   // Sources state for header display
   const [sources, setSources] = useState<Source[]>([]);
@@ -216,6 +220,105 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     }
   }, []);
 
+  const applyChatSync = useCallback((sync?: ChatSyncPayload | null): boolean => {
+    if (!sync?.chat) {
+      return false;
+    }
+
+    const syncedChat = sync.chat;
+
+    setAllChats((prev) => {
+      const existing = prev.find((chat) => chat.id === syncedChat.id);
+      const nextChat: ChatMetadata = {
+        id: syncedChat.id,
+        title: syncedChat.title,
+        created_at: syncedChat.created_at,
+        updated_at: syncedChat.updated_at,
+        message_count: syncedChat.message_count,
+      };
+
+      if (existing &&
+          existing.title === nextChat.title &&
+          existing.updated_at === nextChat.updated_at &&
+          existing.message_count === nextChat.message_count) {
+        return prev;
+      }
+
+      return [nextChat, ...prev.filter((chat) => chat.id !== syncedChat.id)];
+    });
+
+    setActiveChat((prev) => {
+      if (!prev || prev.id !== syncedChat.id) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        title: syncedChat.title,
+        updated_at: syncedChat.updated_at,
+        selected_source_ids: syncedChat.selected_source_ids,
+        studio_signals: sync.studio_signals ?? prev.studio_signals,
+      };
+    });
+
+    if (sync.chat_costs) {
+      setChatCosts(sync.chat_costs);
+    }
+
+    if (sync.user_usage) {
+      setUserUsage(sync.user_usage);
+    }
+
+    onCostsChange?.();
+    return true;
+  }, [onCostsChange]);
+
+  const reconcileChatMetadata = useCallback(async (chatId: string) => {
+    try {
+      const [chat] = await Promise.all([
+        chatsAPI.getChat(projectId, chatId),
+        loadChatCosts(chatId),
+        loadUserUsage(),
+      ]);
+
+      setAllChats((prev) => {
+        const existing = prev.find((item) => item.id === chat.id);
+        const nextChat: ChatMetadata = existing
+          ? {
+              ...existing,
+              title: chat.title,
+              updated_at: chat.updated_at,
+              message_count: chat.messages.length,
+            }
+          : {
+              id: chat.id,
+              title: chat.title,
+              created_at: chat.created_at,
+              updated_at: chat.updated_at,
+              message_count: chat.messages.length,
+            };
+
+        return [nextChat, ...prev.filter((item) => item.id !== chat.id)];
+      });
+
+      setActiveChat((prev) => {
+        if (!prev || prev.id !== chat.id) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          title: chat.title,
+          updated_at: chat.updated_at,
+          selected_source_ids: chat.selected_source_ids,
+          studio_signals: chat.studio_signals || prev.studio_signals,
+        };
+      });
+    } catch (err) {
+      log.error({ err, chatId }, 'failed to reconcile chat metadata');
+    }
+  }, [loadChatCosts, loadUserUsage, projectId]);
+
   useEffect(() => {
     if (activeChat?.id) {
       loadChatCosts(activeChat.id);
@@ -228,6 +331,81 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   useEffect(() => {
     loadUserUsage();
   }, [loadUserUsage]);
+
+  useEffect(() => {
+    if (!pendingTitleSyncRef.current) {
+      return undefined;
+    }
+
+    const pending = pendingTitleSyncRef.current;
+    const startedAt = Date.now();
+    // Ceiling so a fast-completing name task that we never observe in
+    // /active-tasks still triggers a reconcile. Haiku often returns in
+    // 1-3s, so anything past 8s means either we missed the window or the
+    // task failed silently — either way, pull fresh metadata.
+    const MAX_WAIT_MS = 8000;
+    let cancelled = false;
+
+    const finishAndReconcile = async () => {
+      pendingTitleSyncRef.current = null;
+      await reconcileChatMetadata(pending.chatId);
+      if (!cancelled) {
+        setTitleSyncPollKey((prev) => prev + 1);
+      }
+    };
+
+    const checkForCompletedNaming = async () => {
+      if (cancelled || pendingTitleSyncRef.current !== pending) {
+        return;
+      }
+
+      const elapsed = Date.now() - startedAt;
+
+      try {
+        const response = await axios.get(`${API_BASE_URL}/projects/${projectId}/active-tasks`);
+        if (cancelled || pendingTitleSyncRef.current !== pending) {
+          return;
+        }
+
+        const namingTask = response.data.success
+          ? (response.data.tasks || []).find((task: {
+              type?: string;
+              target_id?: string;
+              target_type?: string;
+              task_type?: string;
+            }) => (
+              task.type === 'background' &&
+              task.target_type === 'chat' &&
+              task.target_id === pending.chatId &&
+              task.task_type === 'chat_naming'
+            ))
+          : undefined;
+
+        if (namingTask) {
+          pending.hasSeenNamingTask = true;
+          return;
+        }
+
+        if (pending.hasSeenNamingTask || elapsed >= MAX_WAIT_MS) {
+          await finishAndReconcile();
+        }
+      } catch {
+        if (elapsed >= MAX_WAIT_MS && !cancelled && pendingTitleSyncRef.current === pending) {
+          await finishAndReconcile();
+        }
+      }
+    };
+
+    void checkForCompletedNaming();
+    const intervalId = window.setInterval(() => {
+      void checkForCompletedNaming();
+    }, 2000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [projectId, reconcileChatMetadata, titleSyncPollKey]);
 
   /**
    * Send a message and get AI response
@@ -265,40 +443,6 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       };
     });
 
-    const scheduleChatRefreshes = async (chatId: string) => {
-      await loadChats();
-      onCostsChange?.();
-      loadChatCosts(chatId);
-      loadUserUsage();
-
-      setTimeout(async () => {
-        try {
-          const updatedChat = await chatsAPI.getChat(projectId, chatId);
-          setActiveChat(prev => prev && prev.id === chatId
-            ? { ...prev, studio_signals: updatedChat.studio_signals || [] }
-            : prev
-          );
-        } catch {
-          // Silently ignore - signal update is non-critical
-        }
-      }, 1000);
-
-      setTimeout(async () => {
-        try {
-          const updatedChat = await chatsAPI.getChat(projectId, chatId);
-          setActiveChat(prev => prev && prev.id === chatId
-            ? { ...prev, title: updatedChat.title, studio_signals: updatedChat.studio_signals || [] }
-            : prev
-          );
-          setAllChats(prev => prev.map(c =>
-            c.id === chatId ? { ...c, title: updatedChat.title } : c
-          ));
-        } catch {
-          // Silently ignore - title update is non-critical
-        }
-      }, 4000);
-    };
-
     const replaceTempWithCanonicalUser = (canonicalUserMessage: Chat['messages'][number]) => {
       canonicalUserMessageReceivedRef.current = true;
       setActiveChat((prev) => {
@@ -333,7 +477,11 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       setStreamingAssistantContent('');
     };
 
-    const applyFallbackResponse = (result: { user_message: Chat['messages'][number]; assistant_message: Chat['messages'][number] }) => {
+    const applyFallbackResponse = (result: {
+      user_message: Chat['messages'][number];
+      assistant_message: Chat['messages'][number];
+      sync?: ChatSyncPayload | null;
+    }) => {
       canonicalUserMessageReceivedRef.current = true;
       setStreamingAssistantContent('');
       setActiveChat((prev) => {
@@ -347,6 +495,17 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       });
     };
 
+    const shouldWatchForTitleUpdate = currentChat.messages.length === 0;
+    if (shouldWatchForTitleUpdate) {
+      pendingTitleSyncRef.current = {
+        chatId: currentChat.id,
+        hasSeenNamingTask: false,
+      };
+      setTitleSyncPollKey((prev) => prev + 1);
+    }
+
+    let receivedTerminalSync = false;
+
     try {
       const streamResult = await chatsAPI.streamMessage(
         projectId,
@@ -358,19 +517,29 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             assistantDeltaReceivedRef.current = true;
             setStreamingAssistantContent((prev) => prev + delta);
           },
-          onAssistantDone: appendAssistantMessage,
+          onAssistantDone: (payload) => {
+            appendAssistantMessage(payload.assistant_message);
+            receivedTerminalSync = applyChatSync(payload.sync);
+          },
           onErrorEvent: (payload) => {
             setStreamingAssistantContent('');
             if (payload.assistant_message) {
               appendAssistantMessage(payload.assistant_message);
             }
+            receivedTerminalSync = applyChatSync(payload.sync);
           },
         },
         controller.signal
       );
 
       if (streamResult.terminalEvent) {
-        await scheduleChatRefreshes(currentChat.id);
+        if (!receivedTerminalSync && streamResult.terminalSync) {
+          receivedTerminalSync = applyChatSync(streamResult.terminalSync);
+        }
+        if (!receivedTerminalSync) {
+          onCostsChange?.();
+          await reconcileChatMetadata(currentChat.id);
+        }
       }
     } catch (err) {
       // Don't show error toast if user intentionally stopped
@@ -384,7 +553,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           try {
             const fallbackResult = await chatsAPI.sendMessage(projectId, currentChat.id, userMessage);
             applyFallbackResponse(fallbackResult);
-            await scheduleChatRefreshes(currentChat.id);
+            if (!applyChatSync(fallbackResult.sync)) {
+              onCostsChange?.();
+              await reconcileChatMetadata(currentChat.id);
+            }
           } catch (fallbackError) {
             log.error({ err: fallbackError }, 'failed to send message via fallback');
             error('Failed to send message');
@@ -427,7 +599,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   const handleNewChat = async () => {
     try {
       const newChat = await chatsAPI.createChat(projectId, 'New Chat');
-      await loadChats();
+      setAllChats((prev) => [newChat, ...prev]);
       await loadFullChat(newChat.id);
       // New chats start with no sources selected (loadFullChat will call onActiveChatChange)
       setShowChatList(false);
@@ -452,14 +624,18 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   const handleDeleteChat = async (chatId: string) => {
     try {
       await chatsAPI.deleteChat(projectId, chatId);
+      const remainingChats = allChats.filter((chat) => chat.id !== chatId);
+      setAllChats(remainingChats);
 
       // If the deleted chat was active, clear it and reset source selection
       if (activeChat?.id === chatId) {
         setActiveChat(null);
         onActiveChatChange(null, []);
-      }
 
-      await loadChats();
+        if (remainingChats.length > 0) {
+          await loadFullChat(remainingChats[0].id);
+        }
+      }
       success('Chat deleted');
     } catch (err) {
       log.error({ err }, 'failed to Ldeleting chatE');
@@ -472,12 +648,21 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
    */
   const handleRenameChat = async (chatId: string, newTitle: string) => {
     try {
-      await chatsAPI.updateChat(projectId, chatId, newTitle);
-      await loadChats();
+      const updatedChat = await chatsAPI.updateChat(projectId, chatId, newTitle);
+      setAllChats((prev) => prev.map((chat) => (
+        chat.id === chatId
+          ? {
+              ...chat,
+              title: updatedChat.title,
+              updated_at: updatedChat.updated_at,
+              message_count: updatedChat.message_count,
+            }
+          : chat
+      )));
 
       // Update active chat if it was renamed
       if (activeChat?.id === chatId) {
-        setActiveChat(prev => prev ? { ...prev, title: newTitle } : null);
+        setActiveChat(prev => prev ? { ...prev, title: updatedChat.title } : null);
       }
 
       success('Chat renamed');

--- a/frontend/src/components/dashboard/AppSettings.tsx
+++ b/frontend/src/components/dashboard/AppSettings.tsx
@@ -41,6 +41,9 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
 }) => {
   const isAdmin = userRole === 'admin';
   const [activeSection, setActiveSection] = useState<SettingsSection>('profile');
+  const [mountedSections, setMountedSections] = useState<Set<SettingsSection>>(
+    () => new Set(['profile'])
+  );
 
   // Handle section change with admin check
   const handleSectionChange = (section: SettingsSection) => {
@@ -48,6 +51,12 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
     if (!isAdmin && adminOnlySections.includes(section)) {
       return; // Prevent non-admins from switching to admin sections
     }
+    setMountedSections((prev) => {
+      if (prev.has(section)) return prev;
+      const next = new Set(prev);
+      next.add(section);
+      return next;
+    });
     setActiveSection(section);
   };
 
@@ -59,8 +68,8 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
     onOpenChange(isOpen);
   };
 
-  const renderSection = () => {
-    switch (activeSection) {
+  const renderSection = (section: SettingsSection) => {
+    switch (section) {
       case 'profile':
         return <ProfileSection userEmail={userEmail} userRole={userRole} onSignOut={onSignOut} />;
       case 'team':
@@ -79,6 +88,11 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
         return null;
     }
   };
+
+  const visibleSections = Array.from(mountedSections).filter((section) => {
+    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'design', 'system'];
+    return isAdmin || !adminOnlySections.includes(section);
+  });
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -99,7 +113,16 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
 
           {/* Content area */}
           <div className="flex-1 overflow-y-auto p-6 bg-white">
-            <div className="h-full">{renderSection()}</div>
+            <div className="h-full">
+              {visibleSections.map((section) => (
+                <div
+                  key={section}
+                  className={section === activeSection ? 'h-full' : 'hidden'}
+                >
+                  {renderSection(section)}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/frontend/src/components/settings/sections/ApiKeysSection.tsx
+++ b/frontend/src/components/settings/sections/ApiKeysSection.tsx
@@ -91,7 +91,7 @@ export const ApiKeysSection: React.FC = () => {
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [modifiedKeys, setModifiedKeys] = useState<{ [key: string]: string }>({});
   const [showApiKeys, setShowApiKeys] = useState<{ [key: string]: boolean }>({});
-  const [loading, setLoading] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(false);
   const [validationState, setValidationState] = useState<ValidationState>({});
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
 
@@ -102,7 +102,7 @@ export const ApiKeysSection: React.FC = () => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadApiKeys = async () => {
-    setLoading(true);
+    setInitialLoading(true);
     try {
       const keys = await settingsAPI.getApiKeys();
       setApiKeys(keys);
@@ -111,7 +111,7 @@ export const ApiKeysSection: React.FC = () => {
       log.error({ err }, 'failed to load API keys');
       error('Failed to load API keys');
     } finally {
-      setLoading(false);
+      setInitialLoading(false);
     }
   };
 
@@ -177,8 +177,12 @@ export const ApiKeysSection: React.FC = () => {
               message: result.message
             }
           }));
+          setApiKeys(prev => prev.map(key => (
+            key.id === id
+              ? { ...key, is_set: true }
+              : key
+          )));
           success(`${keyName} validated and saved successfully!`);
-          await loadApiKeys();
         } catch (saveErr) {
           const saveErrorMessage = saveErr instanceof Error ? saveErr.message : 'Failed to save';
           setValidationState(prev => ({
@@ -351,7 +355,7 @@ export const ApiKeysSection: React.FC = () => {
     );
   };
 
-  if (loading) {
+  if (initialLoading) {
     return (
       <div className="flex items-center justify-center py-16">
         <div className="flex flex-col items-center gap-3">

--- a/frontend/src/components/settings/sections/DesignSection.tsx
+++ b/frontend/src/components/settings/sections/DesignSection.tsx
@@ -22,6 +22,7 @@ import {
   GuidelinesSection,
   FeatureSettingsSection,
 } from '../../brand/sections';
+import { BrandConfigProvider } from '@/components/brand/BrandConfigContext';
 
 type DesignTab = 'colors' | 'typography' | 'logos' | 'icons' | 'guidelines' | 'features';
 
@@ -42,58 +43,75 @@ const tabs: TabItem[] = [
 
 export const DesignSection: React.FC = () => {
   const [activeTab, setActiveTab] = useState<DesignTab>('colors');
+  const [mountedTabs, setMountedTabs] = useState<Set<DesignTab>>(() => new Set(['colors']));
 
-  const renderContent = () => {
-    switch (activeTab) {
-      case 'colors':
-        return <ColorsSection />;
-      case 'typography':
-        return <TypographySection />;
-      case 'logos':
-        return <LogosSection />;
-      case 'icons':
-        return <IconsSection />;
-      case 'guidelines':
-        return <GuidelinesSection />;
-      case 'features':
-        return <FeatureSettingsSection />;
-      default:
-        return null;
-    }
+  const handleTabChange = (tab: DesignTab) => {
+    setActiveTab(tab);
+    setMountedTabs((prev) => {
+      if (prev.has(tab)) return prev;
+      const next = new Set(prev);
+      next.add(tab);
+      return next;
+    });
   };
 
   return (
-    <div className="flex flex-col h-full -m-6">
-      <div className="flex-shrink-0 px-6 pt-4 pb-1">
-        <h2 className="text-lg font-semibold text-stone-900">Design</h2>
-        <p className="text-sm text-muted-foreground">
-          Brand kit applied across all projects' studio-generated content.
-        </p>
-      </div>
+    <BrandConfigProvider>
+      <div className="flex flex-col h-full -m-6">
+        <div className="flex-shrink-0 px-6 pt-4 pb-1">
+          <h2 className="text-lg font-semibold text-stone-900">Design</h2>
+          <p className="text-sm text-muted-foreground">
+            Brand kit applied across all projects' studio-generated content.
+          </p>
+        </div>
 
-      {/* Horizontal tab bar */}
-      <div className="flex-shrink-0 border-b border-stone-200 px-6">
-        <div className="flex gap-1 -mb-px">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={cn(
-                'flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors',
-                activeTab === tab.id
-                  ? 'border-amber-600 text-amber-700'
-                  : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-              )}
-            >
-              {tab.icon}
-              <span>{tab.label}</span>
-            </button>
+        {/* Horizontal tab bar */}
+        <div className="flex-shrink-0 border-b border-stone-200 px-6">
+          <div className="flex gap-1 -mb-px">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => handleTabChange(tab.id)}
+                className={cn(
+                  'flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors',
+                  activeTab === tab.id
+                    ? 'border-amber-600 text-amber-700'
+                    : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
+                )}
+              >
+                {tab.icon}
+                <span>{tab.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Tab content — scrolls independently */}
+        <div className="flex-1 overflow-y-auto px-6 pb-6">
+          {Array.from(mountedTabs).map((tab) => (
+            <div key={tab} className={tab === activeTab ? 'h-full' : 'hidden'}>
+              {(() => {
+                switch (tab) {
+                  case 'colors':
+                    return <ColorsSection />;
+                  case 'typography':
+                    return <TypographySection />;
+                  case 'logos':
+                    return <LogosSection />;
+                  case 'icons':
+                    return <IconsSection />;
+                  case 'guidelines':
+                    return <GuidelinesSection />;
+                  case 'features':
+                    return <FeatureSettingsSection />;
+                  default:
+                    return null;
+                }
+              })()}
+            </div>
           ))}
         </div>
       </div>
-
-      {/* Tab content — scrolls independently */}
-      <div className="flex-1 overflow-y-auto px-6 pb-6">{renderContent()}</div>
-    </div>
+    </BrandConfigProvider>
   );
 };

--- a/frontend/src/components/settings/sections/IntegrationsSection.tsx
+++ b/frontend/src/components/settings/sections/IntegrationsSection.tsx
@@ -3,7 +3,7 @@
  * Manages Google Drive and Database connections.
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -35,9 +35,10 @@ import {
   Warning,
 } from '@phosphor-icons/react';
 import { googleDriveAPI, databasesAPI, mcpAPI } from '@/lib/api/settings';
-import type { GoogleStatus, DatabaseConnection, DatabaseType, McpConnection, McpAuthType, McpTransport } from '@/lib/api/settings';
+import type { DatabaseType, McpAuthType, McpTransport } from '@/lib/api/settings';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { useIntegrations } from '@/contexts/IntegrationsContext';
 
 const log = createLogger('integrations-section');
 
@@ -46,19 +47,27 @@ interface IntegrationsSectionProps {
 }
 
 export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmin = false }) => {
-  // Google Drive State
-  const [googleStatus, setGoogleStatus] = useState<GoogleStatus>({
-    configured: false,
-    connected: false,
-    email: null,
-  });
-  const [googleLoading, setGoogleLoading] = useState(false);
-
-  // Database State
-  const [dbConnections, setDbConnections] = useState<DatabaseConnection[]>([]);
-  const [dbLoading, setDbLoading] = useState(false);
+  const {
+    googleStatus,
+    googleLoading,
+    dbConnections,
+    dbLoading,
+    mcpConnections,
+    mcpLoading,
+    ensureGoogleStatus,
+    ensureDatabases,
+    ensureMcpConnections,
+    setGoogleStatus,
+    upsertDatabase,
+    removeDatabase,
+    patchDatabase,
+    upsertMcpConnection,
+    removeMcpConnection,
+    patchMcpConnection,
+  } = useIntegrations();
   const [dbCreating, setDbCreating] = useState(false);
   const [dbValidating, setDbValidating] = useState(false);
+  const [googleMutating, setGoogleMutating] = useState(false);
   const [showDbUri, setShowDbUri] = useState(false);
   const [dbValidation, setDbValidation] = useState<{ valid?: boolean; message?: string }>({});
   const [dbForm, setDbForm] = useState<{
@@ -72,10 +81,6 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
     connection_uri: '',
     description: '',
   });
-
-  // MCP State
-  const [mcpConnections, setMcpConnections] = useState<McpConnection[]>([]);
-  const [mcpLoading, setMcpLoading] = useState(false);
   const [mcpCreating, setMcpCreating] = useState(false);
   const [mcpValidating, setMcpValidating] = useState(false);
   const [showMcpToken, setShowMcpToken] = useState(false);
@@ -111,17 +116,8 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
 
   const { success, error, info } = useToast();
 
-  const loadGoogleStatus = useCallback(async () => {
-    try {
-      const status = await googleDriveAPI.getStatus();
-      setGoogleStatus(status);
-    } catch (err) {
-      log.error({ err }, 'failed to load Google status');
-    }
-  }, []);
-
   const handleGoogleConnect = async () => {
-    setGoogleLoading(true);
+    setGoogleMutating(true);
     try {
       const authUrl = await googleDriveAPI.getAuthUrl();
       if (authUrl) {
@@ -132,27 +128,25 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
           if (status.connected) {
             clearInterval(pollInterval);
             setGoogleStatus(status);
-            setGoogleLoading(false);
             success(`Connected as ${status.email}`);
           }
         }, 2000);
         setTimeout(() => {
           clearInterval(pollInterval);
-          setGoogleLoading(false);
         }, 120000);
       } else {
         error('Failed to get Google auth URL. Check your credentials.');
-        setGoogleLoading(false);
       }
     } catch (err) {
       log.error({ err }, 'failed to Lconnecting GoogleE');
       error('Failed to connect Google Drive');
-      setGoogleLoading(false);
+    } finally {
+      setGoogleMutating(false);
     }
   };
 
   const handleGoogleDisconnect = async () => {
-    setGoogleLoading(true);
+    setGoogleMutating(true);
     try {
       const disconnected = await googleDriveAPI.disconnect();
       if (disconnected) {
@@ -165,21 +159,9 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
       log.error({ err }, 'failed to Ldisconnecting GoogleE');
       error('Failed to disconnect Google Drive');
     } finally {
-      setGoogleLoading(false);
+      setGoogleMutating(false);
     }
   };
-
-  const loadDatabases = useCallback(async () => {
-    setDbLoading(true);
-    try {
-      const dbs = await databasesAPI.listDatabases();
-      setDbConnections(dbs);
-    } catch (err) {
-      log.error({ err }, 'failed to load databases');
-    } finally {
-      setDbLoading(false);
-    }
-  }, []);
 
   const handleValidateDatabase = async () => {
     setDbValidating(true);
@@ -199,16 +181,16 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
   const handleCreateDatabase = async () => {
     setDbCreating(true);
     try {
-      await databasesAPI.createDatabase({
+      const created = await databasesAPI.createDatabase({
         name: dbForm.name.trim(),
         db_type: dbForm.db_type,
         connection_uri: dbForm.connection_uri.trim(),
         description: dbForm.description.trim() || undefined,
       });
+      upsertDatabase(created);
       success('Database connection saved');
       setDbForm({ name: '', db_type: 'postgresql', connection_uri: '', description: '' });
       setDbValidation({});
-      await loadDatabases();
     } catch (err) {
       log.error({ err }, 'failed to create database');
       const axiosErr = err as { response?: { data?: { error?: string } } };
@@ -221,8 +203,8 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
   const handleDeleteDatabase = async (connectionId: string) => {
     try {
       await databasesAPI.deleteDatabase(connectionId);
+      removeDatabase(connectionId);
       success('Database connection deleted');
-      await loadDatabases();
     } catch (err) {
       log.error({ err }, 'failed to delete database');
       const axiosErr = err as { response?: { data?: { error?: string } } };
@@ -230,25 +212,11 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
     }
   };
 
-  // MCP Handlers
-  const loadMcpConnections = useCallback(async () => {
-    setMcpLoading(true);
-    try {
-      const conns = await mcpAPI.listConnections();
-      setMcpConnections(conns);
-    } catch (err) {
-      log.error({ err }, 'failed to load MCP connections');
-      error('Failed to load MCP connections');
-    } finally {
-      setMcpLoading(false);
-    }
-  }, [error]);
-
   useEffect(() => {
-    loadGoogleStatus();
-    loadDatabases();
-    loadMcpConnections();
-  }, [loadGoogleStatus, loadDatabases, loadMcpConnections]);
+    ensureGoogleStatus().catch(() => {});
+    ensureDatabases().catch(() => {});
+    ensureMcpConnections().catch(() => {});
+  }, [ensureDatabases, ensureGoogleStatus, ensureMcpConnections]);
 
   const buildMcpAuthConfig = (): Record<string, string> => {
     const token = mcpForm.auth_token.trim();
@@ -312,7 +280,7 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
   const handleCreateMcp = async () => {
     setMcpCreating(true);
     try {
-      await mcpAPI.createConnection({
+      const created = await mcpAPI.createConnection({
         name: mcpForm.name.trim(),
         transport: mcpForm.transport,
         server_url: mcpForm.transport === 'sse' ? mcpForm.server_url.trim() : undefined,
@@ -322,6 +290,7 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
         description: mcpForm.description.trim() || undefined,
         tools_enabled: mcpForm.tools_enabled,
       });
+      upsertMcpConnection(created);
       success('MCP connection saved');
       setMcpForm({
         name: '', transport: 'stdio', server_url: '', auth_type: 'none',
@@ -329,7 +298,6 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
         description: '', tools_enabled: true,
       });
       setMcpValidation({});
-      await loadMcpConnections();
     } catch (err) {
       log.error({ err }, 'failed to create MCP connection');
       const axiosErr = err as { response?: { data?: { error?: string } } };
@@ -340,16 +308,13 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
   };
 
   const handleToggleMcpToolsEnabled = async (connectionId: string, enabled: boolean) => {
-    setMcpConnections((prev) =>
-      prev.map((c) => (c.id === connectionId ? { ...c, tools_enabled: enabled } : c))
-    );
+    patchMcpConnection(connectionId, { tools_enabled: enabled });
     try {
-      await mcpAPI.updateToolsEnabled(connectionId, enabled);
+      const updated = await mcpAPI.updateToolsEnabled(connectionId, enabled);
+      upsertMcpConnection(updated);
       success(enabled ? 'Tools enabled in chat' : 'Tools disabled');
     } catch (err) {
-      setMcpConnections((prev) =>
-        prev.map((c) => (c.id === connectionId ? { ...c, tools_enabled: !enabled } : c))
-      );
+      patchMcpConnection(connectionId, { tools_enabled: !enabled });
       log.error({ err }, 'failed to toggle MCP tools');
       const axiosErr = err as { response?: { data?: { error?: string } } };
       error(axiosErr.response?.data?.error || 'Failed to update tools setting');
@@ -359,8 +324,8 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
   const handleDeleteMcp = async (connectionId: string) => {
     try {
       await mcpAPI.deleteConnection(connectionId);
+      removeMcpConnection(connectionId);
       success('MCP connection deleted');
-      await loadMcpConnections();
     } catch (err) {
       log.error({ err }, 'failed to delete MCP connection');
       const axiosErr = err as { response?: { data?: { error?: string } } };
@@ -369,16 +334,13 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
   };
 
   const handleToggleMcpVisibility = async (connectionId: string, visibleToAll: boolean) => {
-    setMcpConnections((prev) =>
-      prev.map((c) => (c.id === connectionId ? { ...c, visible_to_all: visibleToAll } : c))
-    );
+    patchMcpConnection(connectionId, { visible_to_all: visibleToAll });
     try {
-      await mcpAPI.updateVisibility(connectionId, visibleToAll);
+      const updated = await mcpAPI.updateVisibility(connectionId, visibleToAll);
+      upsertMcpConnection(updated);
       success(visibleToAll ? 'Visible to all users' : 'Admin only');
     } catch (err) {
-      setMcpConnections((prev) =>
-        prev.map((c) => (c.id === connectionId ? { ...c, visible_to_all: !visibleToAll } : c))
-      );
+      patchMcpConnection(connectionId, { visible_to_all: !visibleToAll });
       log.error({ err }, 'failed to update MCP visibility');
       const axiosErr = err as { response?: { data?: { error?: string } } };
       error(axiosErr.response?.data?.error || 'Failed to update visibility');
@@ -387,17 +349,14 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
 
   const handleToggleVisibility = async (connectionId: string, visibleToAll: boolean) => {
     // Optimistic update
-    setDbConnections((prev) =>
-      prev.map((db) => (db.id === connectionId ? { ...db, visible_to_all: visibleToAll } : db))
-    );
+    patchDatabase(connectionId, { visible_to_all: visibleToAll });
     try {
-      await databasesAPI.updateVisibility(connectionId, visibleToAll);
+      const updated = await databasesAPI.updateVisibility(connectionId, visibleToAll);
+      upsertDatabase(updated);
       success(visibleToAll ? 'Visible to all users' : 'Admin only');
     } catch (err) {
       // Revert on failure
-      setDbConnections((prev) =>
-        prev.map((db) => (db.id === connectionId ? { ...db, visible_to_all: !visibleToAll } : db))
-      );
+      patchDatabase(connectionId, { visible_to_all: !visibleToAll });
       log.error({ err }, 'failed to update visibility');
       const axiosErr = err as { response?: { data?: { error?: string } } };
       error(axiosErr.response?.data?.error || 'Failed to update visibility');
@@ -442,9 +401,9 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
                 variant="soft"
                 size="sm"
                 onClick={() => setDisconnectGoogleOpen(true)}
-                disabled={googleLoading}
+                disabled={googleLoading || googleMutating}
               >
-                {googleLoading ? (
+                {googleLoading || googleMutating ? (
                   <CircleNotch size={16} className="animate-spin" />
                 ) : (
                   <>
@@ -458,9 +417,9 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
                 variant="default"
                 size="sm"
                 onClick={handleGoogleConnect}
-                disabled={googleLoading || !googleStatus.configured}
+                disabled={googleLoading || googleMutating || !googleStatus.configured}
               >
-                {googleLoading ? (
+                {googleLoading || googleMutating ? (
                   <CircleNotch size={16} className="animate-spin" />
                 ) : (
                   <>
@@ -492,7 +451,7 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
       <div>
         <h3 className="text-sm font-semibold mb-3">Database Connections</h3>
         <div className="space-y-4">
-          {dbLoading ? (
+          {dbLoading && dbConnections.length === 0 ? (
             <div className="flex items-center justify-center py-6">
               <CircleNotch size={20} className="animate-spin" />
             </div>
@@ -663,7 +622,7 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
       <div>
         <h3 className="text-sm font-semibold mb-3">MCP Connections</h3>
         <div className="space-y-4">
-          {mcpLoading ? (
+          {mcpLoading && mcpConnections.length === 0 ? (
             <div className="flex items-center justify-center py-6">
               <CircleNotch size={20} className="animate-spin" />
             </div>

--- a/frontend/src/components/settings/sections/IntegrationsSection.tsx
+++ b/frontend/src/components/settings/sections/IntegrationsSection.tsx
@@ -120,27 +120,41 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
     setGoogleMutating(true);
     try {
       const authUrl = await googleDriveAPI.getAuthUrl();
-      if (authUrl) {
-        window.open(authUrl, '_blank', 'width=500,height=600');
-        info('Complete authentication in the new window');
-        const pollInterval = setInterval(async () => {
+      if (!authUrl) {
+        error('Failed to get Google auth URL. Check your credentials.');
+        setGoogleMutating(false);
+        return;
+      }
+
+      window.open(authUrl, '_blank', 'width=500,height=600');
+      info('Complete authentication in the new window');
+      // Keep the button disabled while polling runs so a second click cannot
+      // spawn a parallel interval. Button re-enables on success, timeout, or
+      // any poll error.
+      const pollInterval = setInterval(async () => {
+        try {
           const status = await googleDriveAPI.getStatus();
           if (status.connected) {
             clearInterval(pollInterval);
+            clearTimeout(timeoutId);
             setGoogleStatus(status);
+            setGoogleMutating(false);
             success(`Connected as ${status.email}`);
           }
-        }, 2000);
-        setTimeout(() => {
+        } catch (pollErr) {
+          log.error({ err: pollErr }, 'google poll failed');
           clearInterval(pollInterval);
-        }, 120000);
-      } else {
-        error('Failed to get Google auth URL. Check your credentials.');
-      }
+          clearTimeout(timeoutId);
+          setGoogleMutating(false);
+        }
+      }, 2000);
+      const timeoutId = setTimeout(() => {
+        clearInterval(pollInterval);
+        setGoogleMutating(false);
+      }, 120000);
     } catch (err) {
       log.error({ err }, 'failed to Lconnecting GoogleE');
       error('Failed to connect Google Drive');
-    } finally {
       setGoogleMutating(false);
     }
   };

--- a/frontend/src/components/settings/sections/PermissionsModal.tsx
+++ b/frontend/src/components/settings/sections/PermissionsModal.tsx
@@ -239,7 +239,11 @@ export const PermissionsModal: React.FC<PermissionsModalProps> = ({
   const toggleExpanded = (key: string) => {
     setExpandedCategories((prev) => {
       const next = new Set(prev);
-      next.has(key) ? next.delete(key) : next.add(key);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
       return next;
     });
   };

--- a/frontend/src/components/sources/DatabaseTab.tsx
+++ b/frontend/src/components/sources/DatabaseTab.tsx
@@ -7,7 +7,6 @@ import React, { useEffect, useState } from 'react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { CircleNotch, Plus } from '@phosphor-icons/react';
-import { databasesAPI, type DatabaseConnection } from '@/lib/api/settings';
 import {
   Select,
   SelectContent,
@@ -15,6 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../ui/select';
+import { useIntegrations } from '@/contexts/IntegrationsContext';
 
 interface DatabaseTabProps {
   isAtLimit: boolean;
@@ -22,30 +22,40 @@ interface DatabaseTabProps {
 }
 
 export const DatabaseTab: React.FC<DatabaseTabProps> = ({ isAtLimit, onAddDatabase }) => {
-  const [connections, setConnections] = useState<DatabaseConnection[]>([]);
-  const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string>('');
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const {
+    dbConnections: connections,
+    dbLoading: loading,
+    ensureDatabases,
+  } = useIntegrations();
 
   const loadConnections = async () => {
-    setLoading(true);
     try {
-      const dbs = await databasesAPI.listDatabases();
-      setConnections(dbs);
+      const dbs = await ensureDatabases({ force: true });
       if (!selectedConnectionId && dbs.length > 0) {
         setSelectedConnectionId(dbs[0].id);
       }
-    } finally {
-      setLoading(false);
+    } catch {
+      // Handled by shared integrations state
     }
   };
 
   useEffect(() => {
-    loadConnections();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    ensureDatabases().then((dbs) => {
+      if (!selectedConnectionId && dbs.length > 0) {
+        setSelectedConnectionId(dbs[0].id);
+      }
+    }).catch(() => {});
+  }, [ensureDatabases, selectedConnectionId]);
+
+  useEffect(() => {
+    if (!selectedConnectionId && connections.length > 0) {
+      setSelectedConnectionId(connections[0].id);
+    }
+  }, [connections, selectedConnectionId]);
 
   const selected = connections.find((c) => c.id === selectedConnectionId);
 
@@ -161,4 +171,3 @@ export const DatabaseTab: React.FC<DatabaseTabProps> = ({ isAtLimit, onAddDataba
     </div>
   );
 };
-

--- a/frontend/src/components/sources/GoogleDriveTab.tsx
+++ b/frontend/src/components/sources/GoogleDriveTab.tsx
@@ -26,10 +26,11 @@ import {
   Gear,
   MagnifyingGlass,
 } from '@phosphor-icons/react';
-import { googleDriveAPI, type GoogleFile, type GoogleStatus } from '@/lib/api/settings';
+import { googleDriveAPI, type GoogleFile } from '@/lib/api/settings';
 import { useToast } from '../ui/use-toast';
 import { DriveItem } from './drive';
 import { createLogger } from '@/lib/logger';
+import { useIntegrations } from '@/contexts/IntegrationsContext';
 
 const log = createLogger('google-drive-tab');
 
@@ -44,13 +45,6 @@ export const GoogleDriveTab: React.FC<GoogleDriveTabProps> = ({
   onImportComplete,
   isAtLimit,
 }) => {
-  // Connection status
-  const [status, setStatus] = useState<GoogleStatus>({
-    configured: false,
-    connected: false,
-    email: null,
-  });
-
   // Files state
   const [files, setFiles] = useState<GoogleFile[]>([]);
   const [loading, setLoading] = useState(true);
@@ -71,18 +65,23 @@ export const GoogleDriveTab: React.FC<GoogleDriveTabProps> = ({
   const [selectedFile, setSelectedFile] = useState<GoogleFile | null>(null);
 
   const { success, error } = useToast();
+  const {
+    googleStatus: status,
+    ensureGoogleStatus,
+    setGoogleStatus,
+  } = useIntegrations();
 
   const loadStatus = useCallback(async () => {
     setLoading(true);
     try {
-      const googleStatus = await googleDriveAPI.getStatus();
-      setStatus(googleStatus);
+      const googleStatus = await ensureGoogleStatus({ force: true });
+      setGoogleStatus(googleStatus);
     } catch (err) {
       log.error({ err }, 'failed to Lloading Google statusE');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [ensureGoogleStatus, setGoogleStatus]);
 
   /**
    * Load files from Google Drive

--- a/frontend/src/components/sources/McpTab.tsx
+++ b/frontend/src/components/sources/McpTab.tsx
@@ -10,7 +10,7 @@ import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Checkbox } from '../ui/checkbox';
 import { CircleNotch, Plus, ArrowsClockwise, Plug } from '@phosphor-icons/react';
-import { mcpAPI, type McpConnection, type McpResource } from '@/lib/api/settings';
+import { mcpAPI, type McpResource } from '@/lib/api/settings';
 import {
   Select,
   SelectContent,
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '../ui/select';
 import { ScrollArea } from '../ui/scroll-area';
+import { useIntegrations } from '@/contexts/IntegrationsContext';
 
 interface McpTabProps {
   isAtLimit: boolean;
@@ -26,8 +27,6 @@ interface McpTabProps {
 }
 
 export const McpTab: React.FC<McpTabProps> = ({ isAtLimit, onAddMcp }) => {
-  const [connections, setConnections] = useState<McpConnection[]>([]);
-  const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string>('');
   const [name, setName] = useState('');
@@ -40,27 +39,39 @@ export const McpTab: React.FC<McpTabProps> = ({ isAtLimit, onAddMcp }) => {
   const [selectedUris, setSelectedUris] = useState<Set<string>>(new Set());
 
   const [loadError, setLoadError] = useState('');
+  const {
+    mcpConnections: connections,
+    mcpLoading: loading,
+    ensureMcpConnections,
+  } = useIntegrations();
 
   const loadConnections = async () => {
-    setLoading(true);
     setLoadError('');
     try {
-      const conns = await mcpAPI.listConnections();
-      setConnections(conns);
+      const conns = await ensureMcpConnections({ force: true });
       if (!selectedConnectionId && conns.length > 0) {
         setSelectedConnectionId(conns[0].id);
       }
     } catch {
       setLoadError('Failed to load MCP connections. Check your network.');
-    } finally {
-      setLoading(false);
     }
   };
 
   useEffect(() => {
-    loadConnections();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    ensureMcpConnections().then((conns) => {
+      if (!selectedConnectionId && conns.length > 0) {
+        setSelectedConnectionId(conns[0].id);
+      }
+    }).catch(() => {
+      setLoadError('Failed to load MCP connections. Check your network.');
+    });
+  }, [ensureMcpConnections, selectedConnectionId]);
+
+  useEffect(() => {
+    if (!selectedConnectionId && connections.length > 0) {
+      setSelectedConnectionId(connections[0].id);
+    }
+  }, [connections, selectedConnectionId]);
 
   // Reset resources when connection changes
   useEffect(() => {

--- a/frontend/src/components/sources/SourcesPanel.tsx
+++ b/frontend/src/components/sources/SourcesPanel.tsx
@@ -60,6 +60,7 @@ import {
   Plug,
 } from '@phosphor-icons/react';
 import { createLogger } from '@/lib/logger';
+import { patchOne, removeOne, upsertOne } from '@/lib/resourceState';
 
 const log = createLogger('sources-panel');
 
@@ -137,7 +138,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
 
   // State
   const [sources, setSources] = useState<Source[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [initialLoading, setInitialLoading] = useState(true);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [uploading, setUploading] = useState(false);
@@ -181,7 +182,6 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
    */
   const loadSources = useCallback(async () => {
     try {
-      setLoading(true);
       const data = await sourcesAPI.listSources(projectId);
       // Override active flag with per-chat selection
       const ids = selectedSourceIdsRef.current;
@@ -190,7 +190,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
       log.error({ err }, 'failed to load sources');
       errorRef.current('Failed to load sources');
     } finally {
-      setLoading(false);
+      setInitialLoading(false);
     }
   }, [projectId]);
 
@@ -238,7 +238,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
       for (const src of freshdeskSources) {
         try {
           await sourcesAPI.syncFreshdesk(projectId, src.id);
-          await loadSources();
+          await refreshSources();
         } catch {
           // Silent — don't spam errors for background sync
         }
@@ -328,12 +328,12 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
       for (let i = 0; i < fileArray.length; i++) {
         const file = fileArray[i];
         setUploadProgress({ current: i + 1, total: fileArray.length, pct: 0, fileName: file.name });
-        await sourcesAPI.uploadSource(projectId, file, undefined, undefined, (pct) => {
+        const created = await sourcesAPI.uploadSource(projectId, file, undefined, undefined, (pct) => {
           setUploadProgress((prev) => prev ? { ...prev, pct } : prev);
         });
+        setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
       }
       success(`Uploaded ${fileArray.length} file(s) successfully`);
-      await loadSources();
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to Luploading filesE');
@@ -362,9 +362,9 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     }
 
     try {
-      await sourcesAPI.addUrlSource(projectId, url);
+      const created = await sourcesAPI.addUrlSource(projectId, url);
+      setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
       success('URL source added successfully');
-      await loadSources();
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to Ladding URL sourceE');
@@ -389,9 +389,9 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     }
 
     try {
-      await sourcesAPI.addTextSource(projectId, content, name);
+      const created = await sourcesAPI.addTextSource(projectId, content, name);
+      setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
       success('Text source added successfully');
-      await loadSources();
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to Ladding text sourceE');
@@ -418,9 +418,9 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     }
 
     try {
-      await sourcesAPI.addResearchSource(projectId, topic, description, links);
+      const created = await sourcesAPI.addResearchSource(projectId, topic, description, links);
+      setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
       success('Deep research started - this may take a few minutes');
-      await loadSources();
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to Lstarting researchE');
@@ -444,9 +444,9 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     }
 
     try {
-      await sourcesAPI.addDatabaseSource(projectId, connectionId, name, description);
+      const created = await sourcesAPI.addDatabaseSource(projectId, connectionId, name, description);
+      setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
       success('Database source added successfully');
-      await loadSources();
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to Ladding database sourceE');
@@ -470,9 +470,9 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     }
 
     try {
-      await sourcesAPI.addMcpSource(projectId, connectionId, resourceUris, name, description);
+      const created = await sourcesAPI.addMcpSource(projectId, connectionId, resourceUris, name, description);
+      setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
       success('MCP source added successfully');
-      await loadSources();
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to add MCP source');
@@ -496,9 +496,9 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     }
 
     try {
-      await sourcesAPI.addFreshdeskSource(projectId, name, description);
+      const created = await sourcesAPI.addFreshdeskSource(projectId, name, description);
+      setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
       success('Freshdesk sync started — fetching last 30 days of tickets. Check the status bar for progress.');
-      await loadSources();
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to add Freshdesk source');
@@ -522,9 +522,9 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     }
 
     try {
-      await sourcesAPI.addJiraSource(projectId, name, description);
+      const created = await sourcesAPI.addJiraSource(projectId, name, description);
+      setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
       success('Jira source added — processing issues. Check the status bar for progress.');
-      await loadSources();
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to add Jira source');
@@ -548,9 +548,9 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     }
 
     try {
-      await sourcesAPI.addMixpanelSource(projectId, name, description);
+      const created = await sourcesAPI.addMixpanelSource(projectId, name, description);
+      setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
       success('Mixpanel source added — verifying connection. Check the status bar for progress.');
-      await loadSources();
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to add Mixpanel source');
@@ -570,8 +570,8 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
   const handleSyncFreshdesk = async (sourceId: string) => {
     try {
       await sourcesAPI.syncFreshdesk(projectId, sourceId);
+      setSources((prev) => patchOne(prev, sourceId, { status: 'processing' }));
       success('Freshdesk sync started — check status bar for progress');
-      await loadSources();
     } catch (err: unknown) {
       log.error({ err }, 'failed to sync Freshdesk');
       error('Failed to sync Freshdesk tickets');
@@ -581,8 +581,8 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
   const handleBackfillFreshdesk = async (sourceId: string) => {
     try {
       await sourcesAPI.backfillFreshdesk(projectId, sourceId);
+      setSources((prev) => patchOne(prev, sourceId, { status: 'processing' }));
       success('Freshdesk backfill started — check status bar for progress');
-      await loadSources();
     } catch (err: unknown) {
       log.error({ err }, 'failed to backfill Freshdesk');
       error('Failed to backfill Freshdesk tickets');
@@ -595,8 +595,8 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
   const handleDeleteSource = async (sourceId: string, sourceName: string) => {
     try {
       await sourcesAPI.deleteSource(projectId, sourceId);
+      setSources((prev) => removeOne(prev, sourceId));
       success(`Deleted "${sourceName}"`);
-      await loadSources();
       // Notify parent that sources changed (triggers ChatPanel refresh)
       onSourcesChange?.();
     } catch (err) {
@@ -629,12 +629,12 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     if (!renameSourceId || !renameValue.trim()) return;
 
     try {
-      await sourcesAPI.updateSource(projectId, renameSourceId, {
+      const updated = await sourcesAPI.updateSource(projectId, renameSourceId, {
         name: renameValue.trim(),
       });
+      setSources((prev) => upsertOne(prev, { ...updated, active: selectedSourceIdsRef.current.includes(updated.id) }));
       success('Source renamed successfully');
       setRenameDialogOpen(false);
-      await loadSources();
     } catch (err) {
       log.error({ err }, 'failed to Lrenaming sourceE');
       error('Failed to rename source');
@@ -694,8 +694,8 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
   const handleCancelProcessing = async (sourceId: string) => {
     try {
       await sourcesAPI.cancelProcessing(projectId, sourceId);
+      setSources((prev) => patchOne(prev, sourceId, { status: 'uploaded' }));
       success('Processing cancelled');
-      await loadSources();
     } catch (err) {
       log.error({ err }, 'failed to Lcancelling processingE');
       error('Failed to cancel processing');
@@ -708,8 +708,8 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
   const handleRetryProcessing = async (sourceId: string) => {
     try {
       await sourcesAPI.retryProcessing(projectId, sourceId);
+      setSources((prev) => patchOne(prev, sourceId, { status: 'processing', error_message: null }));
       success('Processing restarted');
-      await loadSources();
     } catch (err) {
       log.error({ err }, 'failed to Lretrying processingE');
       error('Failed to retry processing');
@@ -832,7 +832,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
 
           <SourcesList
             sources={sources}
-            loading={loading}
+            loading={initialLoading}
             searchQuery={searchQuery}
             onDownload={handleDownloadSource}
             onDelete={handleDeleteSource}
@@ -864,7 +864,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
         onAddJira={handleAddJira}
         onAddMixpanel={handleAddMixpanel}
         uploadProgress={uploadProgress}
-        onImportComplete={loadSources}
+        onImportComplete={refreshSources}
         uploading={uploading}
       />
 

--- a/frontend/src/contexts/IntegrationsContext.tsx
+++ b/frontend/src/contexts/IntegrationsContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import {
   databasesAPI,
   googleDriveAPI,
@@ -53,17 +53,34 @@ export const IntegrationsProvider: React.FC<{ children: React.ReactNode }> = ({ 
   const [mcpLoaded, setMcpLoaded] = useState(false);
   const [mcpLoading, setMcpLoading] = useState(false);
 
+  // Refs mirror the current values so each ensure* callback can short-circuit
+  // without listing live state in its dep array. Without this, every local
+  // mutation (upsert/remove/patch) would recreate the callback and cascade
+  // effect re-runs through every consumer.
+  const googleStatusRef = useRef<GoogleStatus>(DEFAULT_GOOGLE_STATUS);
+  const googleLoadedRef = useRef(false);
+  const dbConnectionsRef = useRef<DatabaseConnection[]>([]);
+  const dbLoadedRef = useRef(false);
+  const mcpConnectionsRef = useRef<McpConnection[]>([]);
+  const mcpLoadedRef = useRef(false);
+
+  useEffect(() => { googleStatusRef.current = googleStatus; }, [googleStatus]);
+  useEffect(() => { dbConnectionsRef.current = dbConnections; }, [dbConnections]);
+  useEffect(() => { mcpConnectionsRef.current = mcpConnections; }, [mcpConnections]);
+
   const ensureGoogleStatus = useCallback(async (options?: { force?: boolean; silent?: boolean }) => {
     const { force = false, silent = false } = options ?? {};
-    if (googleLoaded && !force) {
-      return googleStatus;
+    if (googleLoadedRef.current && !force) {
+      return googleStatusRef.current;
     }
 
     if (!silent) setGoogleLoading(true);
     try {
       const status = await googleDriveAPI.getStatus();
       setGoogleStatus(status);
+      googleStatusRef.current = status;
       setGoogleLoaded(true);
+      googleLoadedRef.current = true;
       return status;
     } catch (err) {
       log.error({ err }, 'failed to load Google status');
@@ -71,19 +88,21 @@ export const IntegrationsProvider: React.FC<{ children: React.ReactNode }> = ({ 
     } finally {
       if (!silent) setGoogleLoading(false);
     }
-  }, [googleLoaded, googleStatus]);
+  }, []);
 
   const ensureDatabases = useCallback(async (options?: { force?: boolean; silent?: boolean }) => {
     const { force = false, silent = false } = options ?? {};
-    if (dbLoaded && !force) {
-      return dbConnections;
+    if (dbLoadedRef.current && !force) {
+      return dbConnectionsRef.current;
     }
 
     if (!silent) setDbLoading(true);
     try {
       const databases = await databasesAPI.listDatabases();
       setDbConnections(databases);
+      dbConnectionsRef.current = databases;
       setDbLoaded(true);
+      dbLoadedRef.current = true;
       return databases;
     } catch (err) {
       log.error({ err }, 'failed to load databases');
@@ -91,19 +110,21 @@ export const IntegrationsProvider: React.FC<{ children: React.ReactNode }> = ({ 
     } finally {
       if (!silent) setDbLoading(false);
     }
-  }, [dbConnections, dbLoaded]);
+  }, []);
 
   const ensureMcpConnections = useCallback(async (options?: { force?: boolean; silent?: boolean }) => {
     const { force = false, silent = false } = options ?? {};
-    if (mcpLoaded && !force) {
-      return mcpConnections;
+    if (mcpLoadedRef.current && !force) {
+      return mcpConnectionsRef.current;
     }
 
     if (!silent) setMcpLoading(true);
     try {
       const connections = await mcpAPI.listConnections();
       setMcpConnections(connections);
+      mcpConnectionsRef.current = connections;
       setMcpLoaded(true);
+      mcpLoadedRef.current = true;
       return connections;
     } catch (err) {
       log.error({ err }, 'failed to load MCP connections');
@@ -111,7 +132,7 @@ export const IntegrationsProvider: React.FC<{ children: React.ReactNode }> = ({ 
     } finally {
       if (!silent) setMcpLoading(false);
     }
-  }, [mcpConnections, mcpLoaded]);
+  }, []);
 
   const value = useMemo<IntegrationsContextValue>(() => ({
     googleStatus,

--- a/frontend/src/contexts/IntegrationsContext.tsx
+++ b/frontend/src/contexts/IntegrationsContext.tsx
@@ -1,0 +1,165 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import {
+  databasesAPI,
+  googleDriveAPI,
+  mcpAPI,
+  type DatabaseConnection,
+  type GoogleStatus,
+  type McpConnection,
+} from '@/lib/api/settings';
+import { createLogger } from '@/lib/logger';
+import { patchOne, removeOne, upsertOne } from '@/lib/resourceState';
+
+const log = createLogger('integrations-context');
+
+interface IntegrationsContextValue {
+  googleStatus: GoogleStatus;
+  googleLoaded: boolean;
+  googleLoading: boolean;
+  dbConnections: DatabaseConnection[];
+  dbLoaded: boolean;
+  dbLoading: boolean;
+  mcpConnections: McpConnection[];
+  mcpLoaded: boolean;
+  mcpLoading: boolean;
+  ensureGoogleStatus: (options?: { force?: boolean; silent?: boolean }) => Promise<GoogleStatus>;
+  ensureDatabases: (options?: { force?: boolean; silent?: boolean }) => Promise<DatabaseConnection[]>;
+  ensureMcpConnections: (options?: { force?: boolean; silent?: boolean }) => Promise<McpConnection[]>;
+  setGoogleStatus: React.Dispatch<React.SetStateAction<GoogleStatus>>;
+  upsertDatabase: (database: DatabaseConnection) => void;
+  removeDatabase: (id: string) => void;
+  patchDatabase: (id: string, updates: Partial<DatabaseConnection>) => void;
+  upsertMcpConnection: (connection: McpConnection) => void;
+  removeMcpConnection: (id: string) => void;
+  patchMcpConnection: (id: string, updates: Partial<McpConnection>) => void;
+}
+
+const DEFAULT_GOOGLE_STATUS: GoogleStatus = {
+  configured: false,
+  connected: false,
+  email: null,
+};
+
+const IntegrationsContext = createContext<IntegrationsContextValue | null>(null);
+
+export const IntegrationsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [googleStatus, setGoogleStatus] = useState<GoogleStatus>(DEFAULT_GOOGLE_STATUS);
+  const [googleLoaded, setGoogleLoaded] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
+  const [dbConnections, setDbConnections] = useState<DatabaseConnection[]>([]);
+  const [dbLoaded, setDbLoaded] = useState(false);
+  const [dbLoading, setDbLoading] = useState(false);
+  const [mcpConnections, setMcpConnections] = useState<McpConnection[]>([]);
+  const [mcpLoaded, setMcpLoaded] = useState(false);
+  const [mcpLoading, setMcpLoading] = useState(false);
+
+  const ensureGoogleStatus = useCallback(async (options?: { force?: boolean; silent?: boolean }) => {
+    const { force = false, silent = false } = options ?? {};
+    if (googleLoaded && !force) {
+      return googleStatus;
+    }
+
+    if (!silent) setGoogleLoading(true);
+    try {
+      const status = await googleDriveAPI.getStatus();
+      setGoogleStatus(status);
+      setGoogleLoaded(true);
+      return status;
+    } catch (err) {
+      log.error({ err }, 'failed to load Google status');
+      throw err;
+    } finally {
+      if (!silent) setGoogleLoading(false);
+    }
+  }, [googleLoaded, googleStatus]);
+
+  const ensureDatabases = useCallback(async (options?: { force?: boolean; silent?: boolean }) => {
+    const { force = false, silent = false } = options ?? {};
+    if (dbLoaded && !force) {
+      return dbConnections;
+    }
+
+    if (!silent) setDbLoading(true);
+    try {
+      const databases = await databasesAPI.listDatabases();
+      setDbConnections(databases);
+      setDbLoaded(true);
+      return databases;
+    } catch (err) {
+      log.error({ err }, 'failed to load databases');
+      throw err;
+    } finally {
+      if (!silent) setDbLoading(false);
+    }
+  }, [dbConnections, dbLoaded]);
+
+  const ensureMcpConnections = useCallback(async (options?: { force?: boolean; silent?: boolean }) => {
+    const { force = false, silent = false } = options ?? {};
+    if (mcpLoaded && !force) {
+      return mcpConnections;
+    }
+
+    if (!silent) setMcpLoading(true);
+    try {
+      const connections = await mcpAPI.listConnections();
+      setMcpConnections(connections);
+      setMcpLoaded(true);
+      return connections;
+    } catch (err) {
+      log.error({ err }, 'failed to load MCP connections');
+      throw err;
+    } finally {
+      if (!silent) setMcpLoading(false);
+    }
+  }, [mcpConnections, mcpLoaded]);
+
+  const value = useMemo<IntegrationsContextValue>(() => ({
+    googleStatus,
+    googleLoaded,
+    googleLoading,
+    dbConnections,
+    dbLoaded,
+    dbLoading,
+    mcpConnections,
+    mcpLoaded,
+    mcpLoading,
+    ensureGoogleStatus,
+    ensureDatabases,
+    ensureMcpConnections,
+    setGoogleStatus,
+    upsertDatabase: (database) => setDbConnections((prev) => upsertOne(prev, database, { prepend: true })),
+    removeDatabase: (id) => setDbConnections((prev) => removeOne(prev, id)),
+    patchDatabase: (id, updates) => setDbConnections((prev) => patchOne(prev, id, updates)),
+    upsertMcpConnection: (connection) => setMcpConnections((prev) => upsertOne(prev, connection, { prepend: true })),
+    removeMcpConnection: (id) => setMcpConnections((prev) => removeOne(prev, id)),
+    patchMcpConnection: (id, updates) => setMcpConnections((prev) => patchOne(prev, id, updates)),
+  }), [
+    dbConnections,
+    dbLoaded,
+    dbLoading,
+    ensureDatabases,
+    ensureGoogleStatus,
+    ensureMcpConnections,
+    googleLoaded,
+    googleLoading,
+    googleStatus,
+    mcpConnections,
+    mcpLoaded,
+    mcpLoading,
+  ]);
+
+  return (
+    <IntegrationsContext.Provider value={value}>
+      {children}
+    </IntegrationsContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useIntegrations = () => {
+  const context = useContext(IntegrationsContext);
+  if (!context) {
+    throw new Error('useIntegrations must be used within IntegrationsProvider');
+  }
+  return context;
+};

--- a/frontend/src/contexts/PermissionsContext.tsx
+++ b/frontend/src/contexts/PermissionsContext.tsx
@@ -39,6 +39,7 @@ const PermissionsContext = createContext<PermissionsContextValue>({
   refreshPermissions: async () => {},
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const usePermissions = () => useContext(PermissionsContext);
 
 export const PermissionsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/frontend/src/lib/api/chats.ts
+++ b/frontend/src/lib/api/chats.ts
@@ -11,6 +11,7 @@ import { API_BASE_URL } from './client';
 import { createLogger } from '@/lib/logger';
 import { getAccessToken } from '../auth/session';
 import type { CostTracking } from './projects';
+import type { UserUsage } from './settings';
 
 const log = createLogger('chats-api');
 
@@ -63,6 +64,22 @@ export interface Chat {
   };
 }
 
+export interface ChatSyncChatMetadata {
+  id: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+  message_count: number;
+  selected_source_ids: string[] | null;
+}
+
+export interface ChatSyncPayload {
+  chat: ChatSyncChatMetadata;
+  studio_signals: StudioSignal[];
+  chat_costs: CostTracking;
+  user_usage: UserUsage | null;
+}
+
 /**
  * Educational Note: Raw message for debug/raw view.
  * Includes the original content blocks (tool_use, tool_result, etc.)
@@ -85,26 +102,28 @@ export interface RawMessage {
 export interface SendMessageResponse {
   user_message: Message;
   assistant_message: Message;
+  sync?: ChatSyncPayload | null;
 }
 
 export type ChatStreamEvent =
   | { type: 'user_message'; payload: Message }
   | { type: 'assistant_delta'; payload: { delta: string } }
-  | { type: 'assistant_done'; payload: Message }
-  | { type: 'error'; payload: { message: string; assistant_message?: Message | null } };
+  | { type: 'assistant_done'; payload: { assistant_message: Message; sync?: ChatSyncPayload | null } }
+  | { type: 'error'; payload: { message: string; assistant_message?: Message | null; sync?: ChatSyncPayload | null } };
 
 export interface StreamMessageCallbacks {
   onEvent?: (event: ChatStreamEvent) => void;
   onUserMessage?: (message: Message) => void;
   onAssistantDelta?: (delta: string) => void;
-  onAssistantDone?: (message: Message) => void;
-  onErrorEvent?: (payload: { message: string; assistant_message?: Message | null }) => void;
+  onAssistantDone?: (payload: { assistant_message: Message; sync?: ChatSyncPayload | null }) => void;
+  onErrorEvent?: (payload: { message: string; assistant_message?: Message | null; sync?: ChatSyncPayload | null }) => void;
 }
 
 export interface StreamMessageResult {
   hadUserMessage: boolean;
   hadAssistantDelta: boolean;
   terminalEvent: 'assistant_done' | 'error' | null;
+  terminalSync?: ChatSyncPayload | null;
 }
 
 /**
@@ -184,10 +203,12 @@ class ChatsAPI {
         break;
       case 'assistant_done':
         state.terminalEvent = 'assistant_done';
+        state.terminalSync = payload.sync ?? null;
         this.notifyStreamEvent({ type: 'assistant_done', payload }, callbacks);
         break;
       case 'error':
         state.terminalEvent = 'error';
+        state.terminalSync = payload.sync ?? null;
         this.notifyStreamEvent({ type: 'error', payload }, callbacks);
         break;
       case 'ping':
@@ -282,7 +303,8 @@ class ChatsAPI {
       );
       return {
         user_message: response.data.user_message,
-        assistant_message: response.data.assistant_message
+        assistant_message: response.data.assistant_message,
+        sync: response.data.sync,
       };
     } catch (error) {
       log.error({ err: error }, 'failed to send message');
@@ -326,6 +348,7 @@ class ChatsAPI {
       hadUserMessage: false,
       hadAssistantDelta: false,
       terminalEvent: null,
+      terminalSync: null,
     };
     let buffer = '';
 

--- a/frontend/src/lib/api/studio/ads.ts
+++ b/frontend/src/lib/api/studio/ads.ts
@@ -6,6 +6,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-ads-api');
@@ -130,18 +131,7 @@ export const adsAPI = {
    * List all ad jobs for a project
    */
   async listJobs(projectId: string): Promise<ListAdJobsResponse> {
-    try {
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/ad-jobs`
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list ad jobs');
-      throw error;
-    }
+    return listStudioJobsByType<AdJob>(projectId, 'ad');
   },
 
   /**

--- a/frontend/src/lib/api/studio/audio.ts
+++ b/frontend/src/lib/api/studio/audio.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-audio-api');
@@ -144,20 +145,7 @@ export const audioAPI = {
    * List all audio jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListAudioJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list jobs');
-      throw error;
-    }
+    return listStudioJobsByType<AudioJob>(projectId, 'audio', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/blogs.ts
+++ b/frontend/src/lib/api/studio/blogs.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-blogs-api');
@@ -177,20 +178,7 @@ export const blogsAPI = {
    * List all blog post jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListBlogJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/blog-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list blog jobs');
-      throw error;
-    }
+    return listStudioJobsByType<BlogJob>(projectId, 'blog', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/businessReports.ts
+++ b/frontend/src/lib/api/studio/businessReports.ts
@@ -8,6 +8,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-business-reports-api');
@@ -188,20 +189,7 @@ export const businessReportsAPI = {
    * List all business report jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListBusinessReportJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/business-report-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list business report jobs');
-      throw error;
-    }
+    return listStudioJobsByType<BusinessReportJob>(projectId, 'business_report', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/components.ts
+++ b/frontend/src/lib/api/studio/components.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-components-api');
@@ -146,20 +147,7 @@ export const componentsAPI = {
    * List all component generation jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListComponentJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/component-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list component jobs');
-      throw error;
-    }
+    return listStudioJobsByType<ComponentJob>(projectId, 'component', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/emails.ts
+++ b/frontend/src/lib/api/studio/emails.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-emails-api');
@@ -166,20 +167,7 @@ export const emailsAPI = {
    * List all email template jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListEmailJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/email-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list email jobs');
-      throw error;
-    }
+    return listStudioJobsByType<EmailJob>(projectId, 'email', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/flash-cards.ts
+++ b/frontend/src/lib/api/studio/flash-cards.ts
@@ -6,6 +6,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-flash-cards-api');
@@ -130,20 +131,7 @@ export const flashCardsAPI = {
    * List all flash card jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListFlashCardJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/flash-card-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list flash card jobs');
-      throw error;
-    }
+    return listStudioJobsByType<FlashCardJob>(projectId, 'flash_card', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/flow-diagrams.ts
+++ b/frontend/src/lib/api/studio/flow-diagrams.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-flow-diagrams-api');
@@ -137,20 +138,7 @@ export const flowDiagramsAPI = {
    * List all flow diagram jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListFlowDiagramJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/flow-diagram-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list flow diagram jobs');
-      throw error;
-    }
+    return listStudioJobsByType<FlowDiagramJob>(projectId, 'flow_diagram', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/infographics.ts
+++ b/frontend/src/lib/api/studio/infographics.ts
@@ -6,6 +6,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-infographics-api');
@@ -142,20 +143,7 @@ export const infographicsAPI = {
    * List all infographic jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListInfographicJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/infographic-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list infographic jobs');
-      throw error;
-    }
+    return listStudioJobsByType<InfographicJob>(projectId, 'infographic', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/jobGroups.ts
+++ b/frontend/src/lib/api/studio/jobGroups.ts
@@ -1,0 +1,95 @@
+import axios from 'axios';
+
+import { API_BASE_URL } from '../client';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('studio-job-groups-api');
+
+interface GroupedStudioJobsResponse {
+  success: boolean;
+  jobs_by_type?: Record<string, unknown[]>;
+  count: number;
+  error?: string;
+}
+
+interface CachedGroupedJobs {
+  fetchedAt: number;
+  promise?: Promise<Record<string, unknown[]>>;
+  jobsByType?: Record<string, unknown[]>;
+}
+
+const groupedJobsCache = new Map<string, CachedGroupedJobs>();
+const GROUPED_JOBS_CACHE_MS = 2000;
+
+async function fetchGroupedStudioJobs(projectId: string): Promise<Record<string, unknown[]>> {
+  const response = await axios.get<GroupedStudioJobsResponse>(
+    `${API_BASE_URL}/projects/${projectId}/studio/job-groups`
+  );
+  if (!response.data.success) {
+    throw new Error(response.data.error || 'Failed to list grouped studio jobs');
+  }
+  return response.data.jobs_by_type || {};
+}
+
+async function getGroupedStudioJobs(projectId: string): Promise<Record<string, unknown[]>> {
+  const cached = groupedJobsCache.get(projectId);
+  const now = Date.now();
+
+  if (cached?.jobsByType && now - cached.fetchedAt < GROUPED_JOBS_CACHE_MS) {
+    return cached.jobsByType;
+  }
+
+  if (cached?.promise) {
+    return cached.promise;
+  }
+
+  const promise = fetchGroupedStudioJobs(projectId)
+    .then((jobsByType) => {
+      groupedJobsCache.set(projectId, {
+        fetchedAt: Date.now(),
+        jobsByType,
+      });
+      return jobsByType;
+    })
+    .catch((error) => {
+      groupedJobsCache.delete(projectId);
+      log.error({ err: error, projectId }, 'failed to fetch grouped studio jobs');
+      throw error;
+    });
+
+  groupedJobsCache.set(projectId, {
+    fetchedAt: now,
+    jobsByType: cached?.jobsByType,
+    promise,
+  });
+
+  return promise;
+}
+
+export async function listStudioJobsByType<T extends object>(
+  projectId: string,
+  jobType: string,
+  sourceId?: string
+): Promise<{ success: boolean; jobs: T[]; count: number; error?: string }> {
+  try {
+    const jobsByType = await getGroupedStudioJobs(projectId);
+    const allJobs = ((jobsByType[jobType] as T[] | undefined) || []);
+    const jobs = sourceId
+      ? allJobs.filter((job) => (
+          typeof (job as { source_id?: string | null }).source_id === 'string' &&
+          (job as { source_id?: string | null }).source_id === sourceId
+        ))
+      : allJobs;
+    return {
+      success: true,
+      jobs,
+      count: jobs.length,
+    };
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.data) {
+      return error.response.data;
+    }
+    log.error({ err: error, projectId, jobType }, 'failed to list studio jobs by type');
+    throw error;
+  }
+}

--- a/frontend/src/lib/api/studio/marketingStrategies.ts
+++ b/frontend/src/lib/api/studio/marketingStrategies.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-marketing-strategies-api');
@@ -157,20 +158,7 @@ export const marketingStrategiesAPI = {
    * List all marketing strategy jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListMarketingStrategyJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/marketing-strategy-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list marketing strategy jobs');
-      throw error;
-    }
+    return listStudioJobsByType<MarketingStrategyJob>(projectId, 'marketing_strategy', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/mind-maps.ts
+++ b/frontend/src/lib/api/studio/mind-maps.ts
@@ -6,6 +6,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-mind-maps-api');
@@ -132,20 +133,7 @@ export const mindMapsAPI = {
    * List all mind map jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListMindMapJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/mind-map-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list mind map jobs');
-      throw error;
-    }
+    return listStudioJobsByType<MindMapJob>(projectId, 'mind_map', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/prds.ts
+++ b/frontend/src/lib/api/studio/prds.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-prds-api');
@@ -157,20 +158,7 @@ export const prdsAPI = {
    * List all PRD jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListPRDJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/prd-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list PRD jobs');
-      throw error;
-    }
+    return listStudioJobsByType<PRDJob>(projectId, 'prd', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/presentations.ts
+++ b/frontend/src/lib/api/studio/presentations.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-presentations-api');
@@ -201,20 +202,7 @@ export const presentationsAPI = {
    * List all presentation jobs for a project, optionally filtered by source
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListPresentationJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/presentation-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list presentation jobs');
-      throw error;
-    }
+    return listStudioJobsByType<PresentationJob>(projectId, 'presentation', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/quizzes.ts
+++ b/frontend/src/lib/api/studio/quizzes.ts
@@ -6,6 +6,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-quizzes-api');
@@ -142,20 +143,7 @@ export const quizzesAPI = {
    * List all quiz jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListQuizJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/quiz-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list quiz jobs');
-      throw error;
-    }
+    return listStudioJobsByType<QuizJob>(projectId, 'quiz', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/social-posts.ts
+++ b/frontend/src/lib/api/studio/social-posts.ts
@@ -6,6 +6,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-social-posts-api');
@@ -150,18 +151,7 @@ export const socialPostsAPI = {
    * List all social post jobs for a project
    */
   async listJobs(projectId: string): Promise<ListSocialPostJobsResponse> {
-    try {
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/social-post-jobs`
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list social post jobs');
-      throw error;
-    }
+    return listStudioJobsByType<SocialPostJob>(projectId, 'social_post');
   },
 
   /**

--- a/frontend/src/lib/api/studio/videos.ts
+++ b/frontend/src/lib/api/studio/videos.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-videos-api');
@@ -148,20 +149,7 @@ export const videosAPI = {
    * List all video jobs for a project, optionally filtered by source
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListVideoJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/videos`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list video jobs');
-      throw error;
-    }
+    return listStudioJobsByType<VideoJob>(projectId, 'video', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/websites.ts
+++ b/frontend/src/lib/api/studio/websites.ts
@@ -7,6 +7,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-websites-api');
@@ -180,20 +181,7 @@ export const websitesAPI = {
    * List all website jobs for a project, optionally filtered by source
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListWebsiteJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/website-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list website jobs');
-      throw error;
-    }
+    return listStudioJobsByType<WebsiteJob>(projectId, 'website', sourceId);
   },
 
   /**

--- a/frontend/src/lib/api/studio/wireframes.ts
+++ b/frontend/src/lib/api/studio/wireframes.ts
@@ -8,6 +8,7 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../client';
 import type { JobStatus } from './index';
+import { listStudioJobsByType } from './jobGroups';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('studio-wireframes-api');
@@ -150,20 +151,7 @@ export const wireframesAPI = {
    * List all wireframe jobs for a project
    */
   async listJobs(projectId: string, sourceId?: string): Promise<ListWireframeJobsResponse> {
-    try {
-      const params = sourceId ? { source_id: sourceId } : {};
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/studio/wireframe-jobs`,
-        { params }
-      );
-      return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        return error.response.data;
-      }
-      log.error({ err: error }, 'failed to list wireframe jobs');
-      throw error;
-    }
+    return listStudioJobsByType<WireframeJob>(projectId, 'wireframe', sourceId);
   },
 
   /**

--- a/frontend/src/lib/resourceState.ts
+++ b/frontend/src/lib/resourceState.ts
@@ -1,0 +1,29 @@
+export function patchOne<T extends { id: string }>(
+  items: T[],
+  id: string,
+  updater: Partial<T> | ((item: T) => T)
+): T[] {
+  return items.map((item) => {
+    if (item.id !== id) return item;
+    return typeof updater === 'function'
+      ? updater(item)
+      : { ...item, ...updater };
+  });
+}
+
+export function upsertOne<T extends { id: string }>(
+  items: T[],
+  nextItem: T,
+  options?: { prepend?: boolean }
+): T[] {
+  const existingIndex = items.findIndex((item) => item.id === nextItem.id);
+  if (existingIndex === -1) {
+    return options?.prepend ? [nextItem, ...items] : [...items, nextItem];
+  }
+
+  return items.map((item) => (item.id === nextItem.id ? nextItem : item));
+}
+
+export function removeOne<T extends { id: string }>(items: T[], id: string): T[] {
+  return items.filter((item) => item.id !== id);
+}

--- a/plan.md
+++ b/plan.md
@@ -1,106 +1,68 @@
-# Mixpanel Integration: What Next?
+## Smooth UX Refactor for Refresh Churn
 
-## Where we are today
+### Summary
+Refactor the app’s async state flow so mutations patch existing UI state instead of blanking and reloading whole sections. Keep the current layouts, routes, and user-facing behavior unchanged; the work is internal and aimed at removing full-section spinners, post-action remounts, redundant refetches, and delayed “catch-up” refreshes.
 
-Option A is built and sitting in an open PR, not yet merged or deployed. It adds Mixpanel as a project-scoped source with seven tools for querying events, funnels, retention, etc. Under the hood, it uses a single Mixpanel Service Account that an admin configures once in the settings page, shared by every user.
+### Implementation Changes
+- **Settings and brand areas: stop remount-driven fetch churn**
+  - Convert settings tabs in [AppSettings.tsx](/Users/adityagarud/Developer/NoobBook/frontend/src/components/dashboard/AppSettings.tsx) to a keep-alive pattern: once a section is opened, keep it mounted and hide it instead of unmounting it. Do the same for `DesignSection` sub-tabs.
+  - Split each section’s loading into `initialLoad` vs `mutationInFlight`; only show skeleton/spinner on first hydrate. After that, keep existing content rendered and show row/button-level pending states.
+  - Replace mutation-time full refetches with local reconciliation wherever APIs already return updated entities:
+    - `ApiKeysSection`: keep the edited field rendered after save/delete; do not call `loadApiKeys()` after each key save. Update only the affected key locally and silently refresh once after the batch if needed.
+    - `IntegrationsSection`: for DB/MCP create/delete/toggle, insert/remove/patch the returned item in local arrays instead of re-running `loadDatabases()` / `loadMcpConnections()` with section-wide spinners.
+    - Brand sections (`Colors`, `Typography`, `Guidelines`, `Features`, asset sections): hydrate brand config once per settings session and reuse it across sub-tabs; saves update local state and success indicators only.
+  - Reuse account-level integration data between Settings and Add Sources flows so `DatabaseTab`, `McpTab`, and Google status do not refetch separate copies of the same connection state.
 
-Mixpanel also runs a hosted MCP server (Option B) that does more and scales better. Since nothing is deployed yet, either approach is still on the table. This doc is the decision, not a retroactive justification.
+- **Chat response flow: remove broad post-send refreshes**
+  - Refactor [ChatPanel.tsx](/Users/adityagarud/Developer/NoobBook/frontend/src/components/chat/ChatPanel.tsx) so a completed AI response updates only the active chat, chat list entry, costs, usage, and studio signals that actually changed.
+  - Remove the current post-send cascade of `loadChats()`, `loadUserUsage()`, and the two delayed `getChat()` calls. Replace it with:
+    - immediate local patch from the streamed canonical user message and final assistant message,
+    - one silent metadata reconciliation only if the stream did not provide enough state,
+    - no component-level `loading` flip after a send.
+  - Extend the stream contract from [routes.py](/Users/adityagarud/Developer/NoobBook/backend/app/api/messages/routes.py) / [main_chat_service.py](/Users/adityagarud/Developer/NoobBook/backend/app/services/chat_services/main_chat_service.py) so the terminal event includes the assistant message plus sync payload needed by the UI:
+    - updated chat metadata,
+    - current studio signals,
+    - chat cost snapshot,
+    - current user usage snapshot.
+  - Keep chat auto-naming asynchronous, but stop the fixed `1s`/`4s` timeout fetches. Use a silent metadata reconciliation tied to task completion instead of hardcoded timers.
 
-## Option A: Service Account + REST (open in a PR, not yet merged)
+- **Workspace lists: mutate rows, not sections**
+  - In [SourcesPanel.tsx](/Users/adityagarud/Developer/NoobBook/frontend/src/components/sources/SourcesPanel.tsx), keep `loadSources()` for first load only. For upload/add/delete/rename/retry/cancel:
+    - use returned `source` objects to insert/update rows locally,
+    - use silent polling only for processing-state transitions,
+    - never flip the whole panel back to `loading=true` after a single row action.
+  - Preserve the existing optimistic per-chat source selection flow, but make every other source mutation follow the same pattern.
+  - Keep `refreshSources()` as the only polling path; do not reuse the initial-load spinner path for background updates.
 
-One admin adds one secret. Everyone in NoobBook can query Mixpanel.
+- **Studio: remove N-per-section bootstrap fetches**
+  - Replace the current “every section fetches its own saved jobs on mount” pattern with one shared studio jobs store.
+  - Add one grouped backend read endpoint over `studio_jobs` and hydrate Studio once when the panel first expands; existing per-tool generate/poll/delete endpoints stay unchanged.
+  - Refactor Studio sections/hooks to read/write the shared store instead of each calling `listJobs()` on mount. Generating a new job should append/update only that job type in the shared store, not trigger unrelated section work.
+  - Preserve current polling behavior for in-progress jobs, but scope it to the active job type only.
 
-```mermaid
-flowchart LR
-    A[Admin] -->|one time| B[Paste service account<br/>into API Keys]
-    U[Any user] -->|asks question in chat| C[Claude]
-    C -->|uses one of 7 tools| D[NoobBook backend]
-    D -->|Basic Auth, shared secret| E[(Mixpanel Query API)]
-    E -->|JSON result| D --> C --> U
-```
+- **Cross-cutting async rules**
+  - Standardize on one repo-wide rule: initial view loads may block, mutations may not. Mutations use optimistic or in-place updates plus silent reconciliation.
+  - Introduce small shared helpers/hooks for resource state (`hydrate`, `patchOne`, `insertOne`, `removeOne`, `silentRefresh`) instead of hand-written `load*()` loops in each section.
+  - Keep all existing public routes and visible UI unchanged; no schema migrations.
 
-**What we get:**
-- Simple. No per-user onboarding.
-- Works for users who don't have Mixpanel accounts themselves.
-- Portable. Doesn't lock us to Anthropic's API. If we swap models later, the integration keeps working.
-- Ships the minute an admin pastes a secret.
+### Internal Interface Changes
+- Extend chat stream terminal payload to carry sync metadata needed by the current view.
+- Add a grouped studio jobs read endpoint so Studio can hydrate once instead of fan-out fetching per section.
+- Add task target metadata to the active-tasks payload if needed so chat-title reconciliation can key off completed `chat_naming` work without polling arbitrary chat records.
 
-**What we give up:**
-- Shared 60 queries/hour across the whole app. Fine for a small team. Breaks down once 20+ people are using it.
-- Mixpanel's audit log shows every query as coming from the same service account. You can't tell who did what.
-- Seven handpicked tools. No dashboard creation, no session replays, no writes. If Mixpanel adds new capabilities, we have to add them by hand.
-- If a user in NoobBook shouldn't see certain Mixpanel data, we can't enforce that. The service account sees everything.
+### Test Plan
+- `frontend`: `npm run lint` and `npm run build`.
+- `backend`: `pytest`.
+- Manual regression matrix:
+  - API Keys: save 3 keys in sequence without the section blanking or losing field state.
+  - Integrations: create/delete DB and MCP connections without section-wide spinner resets.
+  - Design tabs: switch between Colors/Typography/Guidelines/Features without reloading or losing unsaved drafts.
+  - Chat: send a message and verify only message/cost/usage/title metadata updates, with no full chat skeleton flash and no delayed “catch-up” reloads.
+  - Sources: upload/add/delete/rename/retry/cancel while keeping the list visible and stable.
+  - Studio: expanding the panel should hydrate once; generating content should update only the relevant tool section.
+  - Auth/RBAC: token refresh, admin-only sections, and permissions-gated tools still behave exactly as before.
 
-## Option B: Hosted MCP + per-user OAuth
-
-Each user clicks "Connect Mixpanel" once, logs in with their Mixpanel account (or SSO), and their personal token is stored. When they ask a question in chat, Claude talks to Mixpanel's hosted MCP server using that user's token.
-
-```mermaid
-flowchart LR
-    subgraph Setup[One time per user]
-        U1[User] -->|click Connect| B1[NoobBook backend]
-        B1 -->|OAuth redirect| M1[Mixpanel login + consent]
-        M1 -->|user token| B1
-        B1 -->|store per user| DB[(users.mixpanel_tokens)]
-    end
-
-    subgraph Query[Every chat message]
-        U2[User] -->|asks question| C[Claude]
-        C -->|talks directly to MCP,<br/>using that user's token| MCP[(Mixpanel hosted MCP<br/>26 tools)]
-        MCP -->|result| C --> U2
-    end
-```
-
-**What we get:**
-- 600 queries/hour per user. A 50-person team has roughly 500x more headroom than today.
-- 26 tools instead of 7. Dashboards, tags, issues, session replays, and more.
-- Real per-user audit trail. Mixpanel sees Daisy's query as Daisy's query.
-- Permissions enforced by Mixpanel itself. If a user's Mixpanel role restricts them, the chat respects that automatically.
-- Mixpanel maintains the tools. When they add features, we get them for free.
-
-**What we give up:**
-- Every user needs a Mixpanel account. If your PMs do but your support team doesn't, the support team is out.
-- Each user goes through a one-time connect flow. Friction we don't have today.
-- Tied to Anthropic's Messages API. If we ever want to run a non-Anthropic model in chat, we'd have to wrap the MCP server ourselves.
-- Real engineering work. Roughly 2 to 3 days to build the OAuth flow, token refresh, and plumb it through the chat service. Most of the code we shipped for Option A is still reusable (source flag, processor, permissions, tab), but the query layer gets rewritten.
-
-## How to think about it
-
-Option A is correct when:
-- Only a handful of people use it
-- Everyone on the team shares the same view of Mixpanel data
-- Some NoobBook users don't have Mixpanel accounts and shouldn't need them
-
-Option B is correct when:
-- Usage grows past roughly 10 active people per day (we'll hit the rate limit)
-- Security or compliance cares about who queried what
-- Users ask for features we didn't build (dashboards, session replay, cohorts)
-- We want the integration to stay current without ongoing maintenance from us
-
-## Side by side
-
-| Dimension | Option A (in PR) | Option B (hosted MCP) |
-|---|---|---|
-| Setup burden | 1 admin, 2 minutes | 1 admin + every user, 30 seconds each |
-| Rate limit | 60/hr shared | 600/hr per user |
-| Tools available | 7 | 26 |
-| Audit trail | Shared account | Per user |
-| Works without Mixpanel accounts | Yes | No |
-| LLM provider lock-in | None | Anthropic only |
-| Dev effort from here | Merge the PR | Roughly 3 days on top of the PR |
-
-## Recommendation
-
-Merge Option A as is. It unblocks anyone who wants to try Mixpanel in chat right now, and the structural pieces (source flag, permissions, tab, processor) are the same pieces Option B would need anyway. If the team decides later to move to Option B, we keep all of that and only swap the query layer.
-
-Revisit when any of these happen:
-1. The 60/hr rate limit actually bites (users see "try again later" messages)
-2. Someone asks "who ran that query?" and we can't answer
-3. A user wants to do something in Mixpanel our seven tools don't cover
-4. Security or legal raises the shared-service-account pattern as a concern
-
-Budget roughly 3 days for the Option B migration when we commit to it.
-
-## Open question for the team
-
-Is anyone expecting heavy Mixpanel use in the next quarter? If yes, it's probably worth doing Option B proactively rather than scrambling when limits start hitting. If not, we're fine to let usage tell us.
+### Assumptions
+- “No front-end or back-end changes” means no visible UX redesign and no product behavior change; internal state-management and API-plumbing changes are allowed.
+- The refactor is a single broad pass, but acceptance is based on eliminating blocking refresh behavior, not on introducing a new state-management library.
+- Existing REST endpoints remain the source of truth; only narrow internal payload additions are allowed where the current frontend cannot avoid redundant refetching.


### PR DESCRIPTION
## Summary
- Settings pages no longer blank after a single-field save. Chain 2-3 key saves without the section resetting.
- Post-message chat flow no longer triggers `loadChats` + `loadUserUsage` + two delayed `getChat` calls. Stream terminal event carries the sync payload (chat metadata, cost, usage, studio signals) and the client patches in place.
- Studio panel hydrates once via a new grouped `/studio/job-groups` endpoint instead of 18 per-tool bootstrap fetches.
- Sources panel mutates rows locally; silent polling only for status transitions.

## Rule
Initial loads may block, mutations may not. Introduced `resourceState` helpers (`patchOne`, `upsertOne`, `removeOne`), `IntegrationsContext`, `BrandConfigContext`. No visible UX or product-behavior change.

## Backend
- `main_chat_service` builds sync payload alongside the assistant message; emitted in the stream terminal event and returned from the sync fallback path.
- New `/projects/<id>/studio/job-groups` grouped read.
- `active-tasks` payload adds `task_type` / `target_id` / `target_type` so chat title reconciliation can key off the `chat_naming` task without polling arbitrary chat records.

## Review fixes folded in
- Chat title reconcile has an 8s ceiling so a Haiku name task that finishes before we observe it in `/active-tasks` still triggers a reconcile.
- Google Drive import completion uses `refreshSources` (preserves `recentTogglesRef` guard) instead of `loadSources`.
- `LogosSection` + `IconsSection` migrated to local-patch pattern. `BrandAssetUploader.onUploaded` now returns the new asset so callers can `upsertOne` without a refetch.

## Test plan
- [ ] Settings → API Keys: save 3 keys in sequence; field state + section mount stay stable.
- [ ] Settings → Integrations: create/delete/toggle DB and MCP; no section spinners.
- [ ] Settings → Design: switch Colors/Typography/Guidelines/Features sub-tabs; no reload, no lost unsaved drafts.
- [ ] Brand assets: upload/delete/setPrimary a logo and an icon; only the affected card updates.
- [ ] Chat: first message in a new chat — title updates within ~8s; cost/usage/studio signals refresh without a skeleton flash.
- [ ] Sources: upload/add/delete/rename/retry/cancel; list stays visible. Toggle a source active while a Google Drive import is finishing; toggle does not flip back.
- [ ] Studio: expand the panel; verify one `/studio/job-groups` request in network tab instead of per-tool list calls.
- [ ] Admin permissions + RBAC still behave identically.