### PR TITLE
feat: share project — read-only chat links (Roadmap #15)

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -54,6 +54,14 @@ def authenticate_request():
     if request.path.startswith('/api/v1/auth/') or request.path == '/api/v1/health':
         return None
 
+    # Share viewer routes are token-gated, not JWT-gated. The
+    # @require_share_token decorator validates the URL token and (for
+    # invited mode) requires a JWT separately. Skipping the global JWT
+    # check here is what makes public-mode share links work without a
+    # logged-in viewer.
+    if request.path.startswith('/api/v1/share/'):
+        return None
+
     user_id = validate_token()
 
     if not user_id:
@@ -80,6 +88,7 @@ from app.api.settings import settings_bp
 from app.api.sources import sources_bp
 from app.api.studio import studio_bp
 from app.api.brand import brand_bp
+from app.api.share import share_bp
 
 # Register nested blueprints with the main api blueprint
 # No url_prefix needed - routes already have full paths
@@ -94,3 +103,4 @@ api_bp.register_blueprint(settings_bp)
 api_bp.register_blueprint(sources_bp)
 api_bp.register_blueprint(studio_bp)
 api_bp.register_blueprint(brand_bp)
+api_bp.register_blueprint(share_bp)

--- a/backend/app/api/projects/__init__.py
+++ b/backend/app/api/projects/__init__.py
@@ -30,3 +30,4 @@ from app.api.projects import routes  # noqa: F401
 from app.api.projects import costs  # noqa: F401
 from app.api.projects import memory  # noqa: F401
 from app.api.projects import active_tasks  # noqa: F401
+from app.api.projects import shares  # noqa: F401

--- a/backend/app/api/projects/shares.py
+++ b/backend/app/api/projects/shares.py
@@ -1,0 +1,174 @@
+"""
+Project Shares — owner-side endpoints (Roadmap #15).
+
+The project owner manages share links here:
+
+* ``GET /projects/<id>/shares`` — list all shares for the project (active,
+  expired, revoked) so the UI can render history.
+* ``POST /projects/<id>/shares`` — create a new share link.
+* ``DELETE /projects/<id>/shares/<share_id>`` — revoke a share.
+
+Viewer-side endpoints live in ``app/api/share/routes.py`` and use a
+different auth path (token-based, no JWT requirement for public mode).
+"""
+import logging
+import os
+from typing import Optional
+
+from flask import current_app, jsonify, request
+
+from app.api.projects import projects_bp
+from app.services.auth.rbac import get_request_identity
+from app.services.data_services import project_service, share_service
+
+logger = logging.getLogger(__name__)
+
+
+# Allowed values for the user-facing expiry selector. None means never expires.
+_ALLOWED_EXPIRY_DAYS = {7, 30}
+
+
+def _build_share_url(token: str) -> str:
+    """
+    Build the full URL a viewer should open.
+
+    Tries ``PUBLIC_APP_URL`` first (set in env when the deployed origin
+    differs from request.host_url, e.g. behind a reverse proxy). Falls
+    back to the current request host so dev still works without env config.
+    """
+    base = (os.getenv("PUBLIC_APP_URL") or "").strip().rstrip("/")
+    if not base:
+        # Strip trailing slash from host_url for clean concat.
+        base = request.host_url.rstrip("/")
+    return f"{base}/share/{token}"
+
+
+def _serialize_share(row: dict) -> dict:
+    """Shape a project_shares row for the frontend.
+
+    The ``url`` field is built lazily so we don't store deployment-host
+    info in the DB."""
+    return {
+        "id": row.get("id"),
+        "project_id": row.get("project_id"),
+        "token": row.get("token"),
+        "url": _build_share_url(row.get("token", "")),
+        "mode": row.get("mode"),
+        "invited_emails": row.get("invited_emails") or [],
+        "created_by": row.get("created_by"),
+        "created_at": row.get("created_at"),
+        "expires_at": row.get("expires_at"),
+        "revoked_at": row.get("revoked_at"),
+        "is_active": share_service.is_share_usable(row),
+    }
+
+
+@projects_bp.route('/projects/<project_id>/shares', methods=['GET'])
+def list_project_shares(project_id: str):
+    """List all share links for a project (most recent first)."""
+    try:
+        identity = get_request_identity()
+        # Ownership check — get_project filters by user_id and returns None
+        # for non-owners, which we surface as 404 (don't leak existence).
+        project = project_service.get_project(project_id, user_id=identity.user_id)
+        if not project:
+            return jsonify({"success": False, "error": "Project not found"}), 404
+
+        rows = share_service.list_shares_for_project(project_id)
+        return jsonify({
+            "success": True,
+            "shares": [_serialize_share(row) for row in rows],
+        }), 200
+    except Exception as e:
+        current_app.logger.error("Failed to list shares for project %s: %s", project_id, e)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@projects_bp.route('/projects/<project_id>/shares', methods=['POST'])
+def create_project_share(project_id: str):
+    """
+    Create a new share link.
+
+    Body:
+        {
+          "mode": "public" | "invited",
+          "invited_emails": ["alice@example.com", ...],   // required for invited
+          "expires_in_days": 7 | 30 | null                // null = never
+        }
+    """
+    try:
+        identity = get_request_identity()
+        project = project_service.get_project(project_id, user_id=identity.user_id)
+        if not project:
+            return jsonify({"success": False, "error": "Project not found"}), 404
+
+        data = request.get_json(silent=True) or {}
+        mode = (data.get("mode") or "").strip().lower()
+        if mode not in share_service.VALID_MODES:
+            return jsonify({
+                "success": False,
+                "error": f"mode must be one of {sorted(share_service.VALID_MODES)}",
+            }), 400
+
+        invited_emails = data.get("invited_emails") or []
+        if mode == "invited" and not isinstance(invited_emails, list):
+            return jsonify({
+                "success": False,
+                "error": "invited_emails must be a list of strings",
+            }), 400
+
+        expires_in_days_raw = data.get("expires_in_days")
+        expires_in_days: Optional[int]
+        if expires_in_days_raw is None or expires_in_days_raw == "never":
+            expires_in_days = None
+        else:
+            try:
+                expires_in_days = int(expires_in_days_raw)
+            except (TypeError, ValueError):
+                return jsonify({
+                    "success": False,
+                    "error": "expires_in_days must be an integer or null",
+                }), 400
+            if expires_in_days not in _ALLOWED_EXPIRY_DAYS:
+                return jsonify({
+                    "success": False,
+                    "error": f"expires_in_days must be one of {sorted(_ALLOWED_EXPIRY_DAYS)} or null",
+                }), 400
+
+        try:
+            row = share_service.create_share(
+                project_id=project_id,
+                created_by=identity.user_id,
+                mode=mode,
+                invited_emails=invited_emails,
+                expires_in_days=expires_in_days,
+            )
+        except ValueError as ve:
+            return jsonify({"success": False, "error": str(ve)}), 400
+
+        return jsonify({
+            "success": True,
+            "share": _serialize_share(row),
+        }), 201
+    except Exception as e:
+        current_app.logger.error("Failed to create share for project %s: %s", project_id, e)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@projects_bp.route('/projects/<project_id>/shares/<share_id>', methods=['DELETE'])
+def revoke_project_share(project_id: str, share_id: str):
+    """Revoke a share. Returns 404 if the share doesn't belong to this project."""
+    try:
+        identity = get_request_identity()
+        project = project_service.get_project(project_id, user_id=identity.user_id)
+        if not project:
+            return jsonify({"success": False, "error": "Project not found"}), 404
+
+        ok = share_service.revoke_share(share_id, project_id)
+        if not ok:
+            return jsonify({"success": False, "error": "Share not found"}), 404
+
+        return jsonify({"success": True}), 200
+    except Exception as e:
+        current_app.logger.error("Failed to revoke share %s: %s", share_id, e)
+        return jsonify({"success": False, "error": str(e)}), 500

--- a/backend/app/api/share/__init__.py
+++ b/backend/app/api/share/__init__.py
@@ -1,0 +1,20 @@
+"""
+Share API Blueprint — viewer-side endpoints (Roadmap #15).
+
+Mounted under ``/api/v1/share/*``. Routes here are reachable WITHOUT a
+JWT for public-mode shares; the global ``before_request`` hook
+whitelists this prefix and the per-route ``@require_share_token``
+decorator runs the actual access check.
+
+Routes:
+    GET  /share/<token>                                       — share root
+    GET  /share/<token>/chats/<chat_id>                       — full chat
+    GET  /share/<token>/chats/<chat_id>/citations/<chunk_id>  — citation tooltip
+    GET  /share/<token>/studio/<kind>/<job_id>/<filename>     — studio artifact proxy
+    POST /share/<token>/chats/<chat_id>/fork                  — fork into viewer's workspace
+"""
+from flask import Blueprint
+
+share_bp = Blueprint('share', __name__)
+
+from app.api.share import routes  # noqa: F401, E402

--- a/backend/app/api/share/routes.py
+++ b/backend/app/api/share/routes.py
@@ -126,6 +126,33 @@ def get_share_citation(token: str, chat_id: str, chunk_id: str):  # noqa: ARG001
         return jsonify({"success": False, "error": str(exc)}), 500
 
 
+# Allowlisted studio job-type segments. Mirrors the values used by
+# studio_services / tool_executors when they call
+# storage_service.upload_studio_binary(...). Anything outside this set is
+# rejected at the route layer so a malformed `kind` can never reach the
+# storage path builder, regardless of how that helper evolves.
+_ALLOWED_STUDIO_KINDS = frozenset({
+    "creatives",         # ad creatives
+    "social_posts",      # social media posts
+    "infographics",      # infographic images
+    "blogs",             # blog post images
+    "emails",            # email template assets
+    "websites",          # website assets (under /assets/ subpath)
+    "audio",             # audio overviews
+    "video",             # video overviews
+    "presentations",     # presentation decks
+    "business_reports",  # business reports
+    "prds",              # PRD documents
+    "components",        # UI components
+    "wireframes",        # wireframe screens
+    "mind_maps",         # mind maps
+    "flow_diagrams",     # flow diagrams
+    "flash_cards",       # flash cards
+    "quizzes",           # quizzes
+    "marketing_strategies",  # marketing strategy docs
+})
+
+
 @share_bp.route('/share/<token>/studio/<kind>/<job_id>/<path:filename>', methods=['GET'])
 @require_share_token()
 def get_share_studio_artifact(token: str, kind: str, job_id: str, filename: str):  # noqa: ARG001
@@ -135,10 +162,14 @@ def get_share_studio_artifact(token: str, kind: str, job_id: str, filename: str)
     The viewer doesn't have a JWT in public mode, so they can't hit the
     owner-only studio routes directly. We download from Supabase Storage
     here and stream it back. Scoped to the share's project_id — files
-    outside the project are unreachable.
+    outside the project are unreachable. The `kind` segment is checked
+    against an allowlist so the URL can't synthesize unexpected storage
+    paths.
     """
     try:
         ctx = get_share_context()
+        if kind not in _ALLOWED_STUDIO_KINDS:
+            return jsonify({"success": False, "error": "Unknown studio kind"}), 404
         # Walk the Supabase Storage path the studio uploads use.
         # storage_service.upload_studio_binary writes to:
         #   project_id/{kind}/{job_id}/{filename}

--- a/backend/app/api/share/routes.py
+++ b/backend/app/api/share/routes.py
@@ -1,0 +1,208 @@
+"""
+Share viewer endpoints (Roadmap #15).
+
+Each route is gated by ``@require_share_token``. The decorator validates
+the URL token, checks expiry/revocation, enforces invited-mode email
+match, and attaches ``g.share_context`` for the route body.
+
+Owner-side endpoints (create / list / revoke) live in
+``app/api/projects/shares.py``.
+"""
+import logging
+import os
+from typing import Optional
+
+from flask import current_app, g, jsonify, request, send_file
+import io
+
+from app.api.share import share_bp
+from app.services.auth.share_token import require_share_token, get_share_context
+from app.services.data_services import (
+    chat_service,
+    message_service,
+    project_service,
+    share_service,
+)
+from app.utils.citation_utils import get_chunk_content
+from app.services.integrations.supabase import storage_service
+
+logger = logging.getLogger(__name__)
+
+
+def _public_app_url() -> str:
+    """Best-effort public URL — same logic as projects/shares.py."""
+    base = (os.getenv("PUBLIC_APP_URL") or "").strip().rstrip("/")
+    if not base:
+        base = request.host_url.rstrip("/")
+    return base
+
+
+def _share_root_payload(ctx) -> dict:
+    """Top-level metadata returned to the viewer when they open the link."""
+    project = project_service.get_project(ctx.project_id, user_id=ctx.owner_user_id)
+    chats = chat_service.list_chats(ctx.project_id)
+    return {
+        "share": {
+            "project_id": ctx.project_id,
+            "mode": ctx.mode,
+            "url": f"{_public_app_url()}/share/{request.view_args.get('token', '')}",
+        },
+        "project": {
+            "id": project.get("id") if project else ctx.project_id,
+            # Only the public-facing fields. Don't leak custom prompt,
+            # API key flags, memory, costs, or settings_overrides.
+            "name": (project or {}).get("name") or "Shared project",
+            "description": (project or {}).get("description") or "",
+        },
+        "chats": chats,
+        "viewer": {
+            "is_authenticated": bool(ctx.viewer_user_id),
+            "user_id": ctx.viewer_user_id,
+            "email": ctx.viewer_email,
+        },
+    }
+
+
+@share_bp.route('/share/<token>', methods=['GET'])
+@require_share_token()
+def get_share_root(token: str):  # noqa: ARG001 — token is consumed by the decorator
+    """Return project metadata + chat list for the share landing page."""
+    try:
+        ctx = get_share_context()
+        return jsonify({"success": True, **_share_root_payload(ctx)}), 200
+    except Exception as exc:
+        current_app.logger.error("Share root failed: %s", exc)
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+
+@share_bp.route('/share/<token>/chats/<chat_id>', methods=['GET'])
+@require_share_token()
+def get_share_chat(token: str, chat_id: str):  # noqa: ARG001
+    """Full chat — messages, citations, studio_signals, costs."""
+    try:
+        ctx = get_share_context()
+        chat = chat_service.get_chat(ctx.project_id, chat_id)
+        if not chat:
+            return jsonify({"success": False, "error": "Chat not found"}), 404
+        return jsonify({"success": True, "chat": chat}), 200
+    except Exception as exc:
+        current_app.logger.error("Share chat fetch failed (%s): %s", chat_id, exc)
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+
+@share_bp.route('/share/<token>/chats/<chat_id>/citations/<chunk_id>', methods=['GET'])
+@require_share_token()
+def get_share_citation(token: str, chat_id: str, chunk_id: str):  # noqa: ARG001
+    """
+    Citation tooltip content. Scoped to the share's project_id, so a
+    viewer can only resolve chunks that live inside the shared project.
+    """
+    try:
+        ctx = get_share_context()
+        # Verify the chat itself belongs to this project (guards against
+        # crafted chat_ids — chunks are project-scoped but the chat path
+        # should still be self-consistent).
+        chat = chat_service.get_chat(ctx.project_id, chat_id)
+        if not chat:
+            return jsonify({"success": False, "error": "Chat not found"}), 404
+
+        chunk_data = get_chunk_content(ctx.project_id, chunk_id)
+        if not chunk_data:
+            return jsonify({"success": False, "error": f"Chunk not found: {chunk_id}"}), 404
+
+        return jsonify({
+            "success": True,
+            "chunk": {
+                "content": chunk_data["content"],
+                "chunk_id": chunk_data["chunk_id"],
+                "source_id": chunk_data["source_id"],
+                "source_name": chunk_data["source_name"],
+                "page_number": chunk_data["page_number"],
+                "chunk_index": chunk_data["chunk_index"],
+            },
+        }), 200
+    except Exception as exc:
+        current_app.logger.error("Share citation lookup failed (%s): %s", chunk_id, exc)
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+
+@share_bp.route('/share/<token>/studio/<kind>/<job_id>/<path:filename>', methods=['GET'])
+@require_share_token()
+def get_share_studio_artifact(token: str, kind: str, job_id: str, filename: str):  # noqa: ARG001
+    """
+    Proxy a studio output file (image, audio, etc.) to the viewer.
+
+    The viewer doesn't have a JWT in public mode, so they can't hit the
+    owner-only studio routes directly. We download from Supabase Storage
+    here and stream it back. Scoped to the share's project_id — files
+    outside the project are unreachable.
+    """
+    try:
+        ctx = get_share_context()
+        # Walk the Supabase Storage path the studio uploads use.
+        # storage_service.upload_studio_binary writes to:
+        #   project_id/{kind}/{job_id}/{filename}
+        # The download_studio_binary helper reads from the same shape.
+        file_data = storage_service.download_studio_binary(
+            ctx.project_id, kind, job_id, filename,
+        )
+        if file_data is None:
+            return jsonify({"success": False, "error": "File not found"}), 404
+
+        # Best-effort MIME from extension. Most studio outputs are PNG / MP3.
+        ext = (filename.rsplit('.', 1)[-1] or '').lower()
+        mime = {
+            'png': 'image/png', 'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',
+            'webp': 'image/webp', 'svg': 'image/svg+xml',
+            'mp3': 'audio/mpeg', 'wav': 'audio/wav',
+            'mp4': 'video/mp4', 'webm': 'video/webm',
+            'pdf': 'application/pdf',
+        }.get(ext, 'application/octet-stream')
+
+        return send_file(io.BytesIO(file_data), mimetype=mime, as_attachment=False)
+    except Exception as exc:
+        current_app.logger.error("Share studio proxy failed (%s/%s/%s): %s", kind, job_id, filename, exc)
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+
+@share_bp.route('/share/<token>/chats/<chat_id>/fork', methods=['POST'])
+@require_share_token(require_jwt=True)
+def fork_share_chat(token: str, chat_id: str):  # noqa: ARG001
+    """
+    Copy a shared chat into the viewer's own workspace ("Shared with me"
+    auto-project). Returns the new project + chat IDs so the frontend
+    can navigate to the viewer's writable copy.
+    """
+    try:
+        ctx = get_share_context()
+        if not ctx.viewer_user_id:
+            # Decorator guarantees this with require_jwt=True, but stay defensive.
+            return jsonify({"success": False, "error": "Sign in required"}), 401
+
+        # Fetch the source chat under the SHARE's project_id (not the
+        # viewer's). This is the cross-project read the share grants.
+        source_chat = chat_service.get_chat(ctx.project_id, chat_id, include_raw=True)
+        if not source_chat:
+            return jsonify({"success": False, "error": "Chat not found"}), 404
+
+        target_project = project_service.ensure_shared_with_me_project(ctx.viewer_user_id)
+        if not target_project:
+            return jsonify({"success": False, "error": "Could not create destination project"}), 500
+
+        new_chat = chat_service.fork_chat(
+            source_project_id=ctx.project_id,
+            source_chat_id=chat_id,
+            target_project_id=target_project["id"],
+            target_user_id=ctx.viewer_user_id,
+        )
+        if not new_chat:
+            return jsonify({"success": False, "error": "Fork failed"}), 500
+
+        return jsonify({
+            "success": True,
+            "project": target_project,
+            "chat": new_chat,
+        }), 201
+    except Exception as exc:
+        current_app.logger.error("Share fork failed (%s): %s", chat_id, exc)
+        return jsonify({"success": False, "error": str(exc)}), 500

--- a/backend/app/services/auth/share_token.py
+++ b/backend/app/services/auth/share_token.py
@@ -1,0 +1,150 @@
+"""
+Share Token Auth — Roadmap #15.
+
+Validates share tokens on routes mounted under ``/api/v1/share/*``. The
+global JWT gate in ``app/api/__init__.py:authenticate_request`` whitelists
+this URL prefix, so unauthenticated viewers can reach the route. The
+``@require_share_token`` decorator then runs per-route and either:
+
+1. Resolves the share row, confirms it's not revoked / not expired, and
+   for invited mode confirms the caller is logged in with a matching
+   email — attaches the result to ``g.share_context`` and continues.
+
+2. 401 / 403 / 410 with a clear error body otherwise.
+
+Design intent: every share endpoint stays short. They read
+``g.share_context.project_id`` and treat it as a pre-authorized scope.
+They never call the regular project ownership check (``project_service``
+filters by ``user_id``, which a share viewer doesn't have).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any, Callable, Optional
+
+from flask import g, jsonify, request
+
+from app.services.auth.rbac import get_request_identity
+from app.services.data_services import share_service
+
+
+@dataclass(frozen=True)
+class ShareContext:
+    project_id: str
+    mode: str               # "public" | "invited"
+    share_id: str
+    owner_user_id: str      # the user who created the share (project owner)
+    viewer_user_id: Optional[str]   # set iff the viewer is JWT-authenticated
+    viewer_email: Optional[str]     # set iff the viewer is JWT-authenticated
+
+
+def _error(payload: dict, status: int):
+    return jsonify(payload), status
+
+
+def _resolve_token() -> Optional[str]:
+    # The route always carries the token as a path param. The decorator
+    # picks it out of ``request.view_args`` so individual routes don't need
+    # to thread it through manually.
+    view_args = request.view_args or {}
+    token = view_args.get("token")
+    if isinstance(token, str) and token:
+        return token
+    return None
+
+
+def require_share_token(*, require_jwt: bool = False) -> Callable:
+    """
+    Decorator factory.
+
+    Args:
+        require_jwt: When True, also requires the caller to be
+            JWT-authenticated. Used for the fork endpoint — we need a
+            real user_id to assign ownership of the new chat.
+
+    The decorated function receives the same arguments as before; the
+    share row + viewer identity are available via ``g.share_context``.
+    """
+    def decorator(fn: Callable) -> Callable:
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            token = _resolve_token()
+            if not token:
+                return _error(
+                    {"success": False, "error": "Share token missing in URL."},
+                    400,
+                )
+
+            row = share_service.get_share_by_token(token)
+            if not row:
+                return _error(
+                    {"success": False, "error": "Share link not found."},
+                    404,
+                )
+
+            if not share_service.is_share_usable(row):
+                # Distinguish revoked vs expired so the UI can show the
+                # right message, but use 410 Gone for both — semantically
+                # "the resource is no longer available".
+                reason = "revoked" if row.get("revoked_at") else "expired"
+                return _error(
+                    {"success": False, "error": f"This share link has {reason}."},
+                    410,
+                )
+
+            # Resolve the caller's identity. For public mode this can be
+            # anonymous; for invited mode we need a JWT.
+            identity = get_request_identity()
+            viewer_user_id = identity.user_id if identity.is_authenticated else None
+            viewer_email = identity.email if identity.is_authenticated else None
+
+            if row.get("mode") == "invited":
+                if not identity.is_authenticated:
+                    return _error(
+                        {
+                            "success": False,
+                            "error": "Sign in to view this shared project.",
+                            "code": "auth_required",
+                        },
+                        401,
+                    )
+                if not share_service.email_invited(row, viewer_email):
+                    return _error(
+                        {
+                            "success": False,
+                            "error": "Your account isn't on this share's invite list.",
+                            "code": "not_invited",
+                        },
+                        403,
+                    )
+
+            if require_jwt and not identity.is_authenticated:
+                return _error(
+                    {
+                        "success": False,
+                        "error": "Sign in to continue this conversation in your workspace.",
+                        "code": "auth_required",
+                    },
+                    401,
+                )
+
+            g.share_context = ShareContext(
+                project_id=row["project_id"],
+                mode=row["mode"],
+                share_id=row["id"],
+                owner_user_id=row["created_by"],
+                viewer_user_id=viewer_user_id,
+                viewer_email=viewer_email,
+            )
+
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def get_share_context() -> Optional[ShareContext]:
+    """Convenience accessor for routes that share helpers."""
+    return getattr(g, "share_context", None)

--- a/backend/app/services/data_services/__init__.py
+++ b/backend/app/services/data_services/__init__.py
@@ -24,6 +24,7 @@ from app.services.data_services.brand_asset_service import brand_asset_service
 from app.services.data_services.brand_config_service import brand_config_service
 from app.services.data_services.database_connection_service import database_connection_service
 from app.services.data_services.user_service import get_user_service
+from app.services.data_services import share_service
 
 # ProjectService needs to be instantiated fresh due to directory initialization
 project_service = ProjectService()
@@ -36,4 +37,5 @@ __all__ = [
     "brand_config_service",
     "database_connection_service",
     "get_user_service",
+    "share_service",
 ]

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -396,6 +396,93 @@ class ChatService:
 
         return True
 
+    def fork_chat(
+        self,
+        source_project_id: str,
+        source_chat_id: str,
+        target_project_id: str,
+        target_user_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Copy a chat (and its messages) into a target project.
+
+        Used by the "Continue in your workspace" flow on shared projects:
+        the viewer's fork lands in their own "Shared with me" project,
+        seeded with the owner's messages so the conversation can continue.
+
+        We deliberately do NOT copy:
+          * source selection (target user has different sources, or none)
+          * studio_signals (those reference the owner's source_ids)
+          * costs (the fork starts from zero)
+
+        We DO copy:
+          * the messages table contents in chronological order
+          * forked_from_* fields so the UI can show provenance
+
+        Args:
+            source_project_id: Project the source chat lives in.
+            source_chat_id:    The owner's chat being forked.
+            target_project_id: Where the fork should be created (caller
+                               passes the viewer's "Shared with me" id).
+            target_user_id:    Viewer's id, used for the title prefix.
+
+        Returns:
+            New chat dict (same shape as create_chat) or None on failure.
+        """
+        source_chat_row = (
+            self.supabase.table(self.table)
+            .select("*")
+            .eq("id", source_chat_id)
+            .eq("project_id", source_project_id)
+            .execute()
+        )
+        if not source_chat_row.data:
+            return None
+        source_chat = source_chat_row.data[0]
+
+        original_title = source_chat.get("title") or "Shared chat"
+
+        new_chat_row = {
+            "project_id": target_project_id,
+            "title": original_title,
+            "forked_from_chat_id": source_chat_id,
+            "forked_from_project_id": source_project_id,
+        }
+        insert_response = self.supabase.table(self.table).insert(new_chat_row).execute()
+        if not insert_response.data:
+            logger.error("Fork: failed to insert chat row for user %s", target_user_id)
+            return None
+        new_chat = insert_response.data[0]
+        new_chat_id = new_chat["id"]
+
+        messages_response = (
+            self.supabase.table(self.messages_table)
+            .select("role, content, model, error, tokens, created_at")
+            .eq("chat_id", source_chat_id)
+            .order("created_at", desc=False)
+            .execute()
+        )
+        for msg in messages_response.data or []:
+            self.supabase.table(self.messages_table).insert({
+                "chat_id": new_chat_id,
+                "role": msg.get("role"),
+                "content": msg.get("content"),
+                "model": msg.get("model"),
+                "error": msg.get("error"),
+                "tokens": msg.get("tokens"),
+            }).execute()
+
+        return {
+            "id": new_chat_id,
+            "title": new_chat["title"],
+            "project_id": target_project_id,
+            "created_at": new_chat.get("created_at"),
+            "updated_at": new_chat.get("updated_at"),
+            "forked_from_chat_id": source_chat_id,
+            "forked_from_project_id": source_project_id,
+            "message_count": len(messages_response.data or []),
+        }
+
     def sync_chat_to_index(self, project_id: str, chat_id: str) -> bool:
         """
         Sync a chat's metadata (no-op for Supabase version).

--- a/backend/app/services/data_services/project_service.py
+++ b/backend/app/services/data_services/project_service.py
@@ -125,6 +125,50 @@ class ProjectService:
 
         raise RuntimeError("Failed to create project")
 
+    def ensure_shared_with_me_project(
+        self, user_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Find or create the user's "Shared with me" auto-project.
+
+        Used by the share-fork flow (Roadmap #15): when a viewer of a
+        shared chat clicks "Continue in your workspace", the new chat
+        lands in this project. Per-user, created lazily on the first
+        fork.
+
+        Distinguished from regular projects by the literal name
+        "Shared with me" — case-sensitive match keeps the lookup deterministic.
+        """
+        uid = _resolve_user_id(user_id)
+        existing = (
+            self.supabase.table(self.table)
+            .select("*")
+            .eq("user_id", uid)
+            .eq("name", "Shared with me")
+            .limit(1)
+            .execute()
+        )
+        if existing.data:
+            return self._format_project_metadata(existing.data[0])
+
+        project_data = {
+            "user_id": uid,
+            "name": "Shared with me",
+            "description": "Chats forked from projects shared with you.",
+            "custom_prompt": None,
+            "memory": {},
+            "costs": {
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "total_cost_usd": 0,
+                "by_model": {},
+            },
+        }
+        response = self.supabase.table(self.table).insert(project_data).execute()
+        if response.data:
+            return self._format_project_metadata(response.data[0])
+        return None
+
     def get_project(self, project_id: str, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """
         Get full project data by ID.

--- a/backend/app/services/data_services/project_service.py
+++ b/backend/app/services/data_services/project_service.py
@@ -137,19 +137,33 @@ class ProjectService:
         fork.
 
         Distinguished from regular projects by the literal name
-        "Shared with me" — case-sensitive match keeps the lookup deterministic.
+        "Shared with me" — case-sensitive match keeps the lookup
+        deterministic.
+
+        Race-safe: two concurrent forks from the same viewer would both
+        pass a naive check-then-insert. Migration ``00021`` adds a
+        partial unique index ``(user_id) WHERE name = 'Shared with me'``
+        so the second insert raises a uniqueness violation; we catch
+        that and re-fetch the row that the first insert created.
         """
         uid = _resolve_user_id(user_id)
-        existing = (
-            self.supabase.table(self.table)
-            .select("*")
-            .eq("user_id", uid)
-            .eq("name", "Shared with me")
-            .limit(1)
-            .execute()
-        )
-        if existing.data:
-            return self._format_project_metadata(existing.data[0])
+
+        def _fetch_existing() -> Optional[Dict[str, Any]]:
+            response = (
+                self.supabase.table(self.table)
+                .select("*")
+                .eq("user_id", uid)
+                .eq("name", "Shared with me")
+                .limit(1)
+                .execute()
+            )
+            if response.data:
+                return self._format_project_metadata(response.data[0])
+            return None
+
+        existing = _fetch_existing()
+        if existing:
+            return existing
 
         project_data = {
             "user_id": uid,
@@ -164,10 +178,25 @@ class ProjectService:
                 "by_model": {},
             },
         }
-        response = self.supabase.table(self.table).insert(project_data).execute()
-        if response.data:
-            return self._format_project_metadata(response.data[0])
-        return None
+        try:
+            response = self.supabase.table(self.table).insert(project_data).execute()
+            if response.data:
+                return self._format_project_metadata(response.data[0])
+        except Exception as exc:
+            # Race: a concurrent fork inserted first. Re-fetch and return
+            # that row so both callers converge on the same project.
+            msg = str(exc).lower()
+            if "duplicate" in msg or "unique" in msg or "23505" in msg:
+                logger.info(
+                    "ensure_shared_with_me_project lost the race for user %s; re-fetching",
+                    uid,
+                )
+                fallback = _fetch_existing()
+                if fallback:
+                    return fallback
+            raise
+        # Insert returned no data and no exception — fall back one last time.
+        return _fetch_existing()
 
     def get_project(self, project_id: str, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """

--- a/backend/app/services/data_services/share_service.py
+++ b/backend/app/services/data_services/share_service.py
@@ -1,0 +1,205 @@
+"""
+Share Service — CRUD over the project_shares table (Roadmap #15).
+
+A share is a token that grants read-only access to a project's chats.
+Two modes:
+
+* **public**  — anyone with the URL gets access (no auth required).
+* **invited** — only logged-in users whose email matches a row in
+  ``invited_emails`` get access.
+
+Shares can be **revoked** (sets ``revoked_at``) or **expire** (the
+``expires_at`` timestamp passes). Either condition makes the share
+inactive — the row stays in the table for audit but lookup fails.
+
+Token generation uses ``secrets.token_urlsafe(32)`` (256 bits of entropy,
+URL-safe base64), making brute-force enumeration infeasible. Tokens are
+unique-indexed at the DB level.
+"""
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from app.services.integrations.supabase import get_supabase, is_supabase_enabled
+
+logger = logging.getLogger(__name__)
+
+# Token byte length — token_urlsafe(32) returns ~43 chars (32 bytes b64).
+_TOKEN_BYTES = 32
+
+VALID_MODES = {"public", "invited"}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _is_active(row: Dict[str, Any]) -> bool:
+    """Mirrors the SQL is_share_active() function for in-process checks."""
+    if not row:
+        return False
+    if row.get("revoked_at"):
+        return False
+    expires_at = row.get("expires_at")
+    if expires_at:
+        # Supabase returns ISO strings; normalize for comparison.
+        if isinstance(expires_at, str):
+            try:
+                expires_at = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            except Exception:
+                return False
+        if expires_at <= _now():
+            return False
+    return True
+
+
+def _generate_token() -> str:
+    return secrets.token_urlsafe(_TOKEN_BYTES)
+
+
+def _client():
+    if not is_supabase_enabled():
+        raise RuntimeError("Supabase is not configured.")
+    return get_supabase()
+
+
+def create_share(
+    project_id: str,
+    created_by: str,
+    mode: str,
+    invited_emails: Optional[List[str]] = None,
+    expires_in_days: Optional[int] = None,
+) -> Dict[str, Any]:
+    """
+    Create a new share row for a project.
+
+    Args:
+        project_id: The project being shared.
+        created_by: The owner user's id (already validated upstream).
+        mode: "public" or "invited".
+        invited_emails: Required and non-empty when mode == "invited".
+                        Lower-cased and de-duped for stable matching.
+        expires_in_days: 7, 30, or None. None means the share never expires.
+
+    Returns:
+        The inserted row (including the generated token).
+    """
+    if mode not in VALID_MODES:
+        raise ValueError(f"mode must be one of {VALID_MODES}, got {mode!r}")
+
+    normalized_emails: List[str] = []
+    if mode == "invited":
+        if not invited_emails:
+            raise ValueError("invited mode requires at least one email")
+        # Lower-case + de-dup. We compare against `users.email` which Supabase
+        # also stores lower-cased, so consistent casing avoids subtle misses.
+        seen = set()
+        for raw in invited_emails:
+            if not raw:
+                continue
+            email = raw.strip().lower()
+            if email and email not in seen:
+                seen.add(email)
+                normalized_emails.append(email)
+        if not normalized_emails:
+            raise ValueError("invited mode requires at least one valid email")
+
+    expires_at: Optional[str] = None
+    if expires_in_days is not None:
+        if expires_in_days <= 0:
+            raise ValueError("expires_in_days must be positive (or None for never)")
+        expires_at = (_now() + timedelta(days=expires_in_days)).isoformat()
+
+    row = {
+        "project_id": project_id,
+        "token": _generate_token(),
+        "mode": mode,
+        "invited_emails": normalized_emails,
+        "created_by": created_by,
+        "expires_at": expires_at,
+    }
+
+    client = _client()
+    response = client.table("project_shares").insert(row).execute()
+    if not response.data:
+        raise RuntimeError("Failed to create project share")
+    return response.data[0]
+
+
+def list_shares_for_project(project_id: str) -> List[Dict[str, Any]]:
+    """List all share rows for a project (active + revoked + expired)."""
+    client = _client()
+    response = (
+        client.table("project_shares")
+        .select("*")
+        .eq("project_id", project_id)
+        .order("created_at", desc=True)
+        .execute()
+    )
+    return response.data or []
+
+
+def get_share_by_token(token: str) -> Optional[Dict[str, Any]]:
+    """Look up a share by its token. Returns the raw row regardless of
+    active/revoked/expired status — callers decide what to do with it."""
+    if not token:
+        return None
+    client = _client()
+    response = (
+        client.table("project_shares")
+        .select("*")
+        .eq("token", token)
+        .limit(1)
+        .execute()
+    )
+    if not response.data:
+        return None
+    return response.data[0]
+
+
+def get_share_by_id(share_id: str, project_id: str) -> Optional[Dict[str, Any]]:
+    """Look up a specific share row scoped to a project (for owner ops)."""
+    client = _client()
+    response = (
+        client.table("project_shares")
+        .select("*")
+        .eq("id", share_id)
+        .eq("project_id", project_id)
+        .limit(1)
+        .execute()
+    )
+    if not response.data:
+        return None
+    return response.data[0]
+
+
+def revoke_share(share_id: str, project_id: str) -> bool:
+    """Mark a share as revoked. Idempotent — already-revoked shares
+    return True without re-stamping the timestamp."""
+    existing = get_share_by_id(share_id, project_id)
+    if not existing:
+        return False
+    if existing.get("revoked_at"):
+        return True
+    client = _client()
+    client.table("project_shares").update({
+        "revoked_at": _now().isoformat(),
+    }).eq("id", share_id).eq("project_id", project_id).execute()
+    return True
+
+
+def is_share_usable(row: Dict[str, Any]) -> bool:
+    """Public wrapper around the active check so callers don't import _is_active."""
+    return _is_active(row)
+
+
+def email_invited(row: Dict[str, Any], email: Optional[str]) -> bool:
+    """For invited mode: check that the viewer's email is in the allow-list.
+    Public mode always returns True (mode-mismatch is the caller's job)."""
+    if row.get("mode") == "public":
+        return True
+    if not email:
+        return False
+    invited = row.get("invited_emails") or []
+    return email.strip().lower() in {e.lower() for e in invited if e}

--- a/backend/supabase/migrations/00021_project_shares.sql
+++ b/backend/supabase/migrations/00021_project_shares.sql
@@ -31,9 +31,12 @@ CREATE INDEX IF NOT EXISTS project_shares_project_id_idx
   ON project_shares (project_id);
 
 -- Hot read: viewer hits /share/{token}/* and we look up by token. Already
--- UNIQUE which gives an index, but adding a partial index for active shares
--- keeps the lookup fast even with many revoked rows.
-CREATE INDEX IF NOT EXISTS project_shares_active_token_idx
+-- UNIQUE gives a btree, but a partial index over non-revoked rows keeps
+-- the lookup fast even after many revocations accumulate.
+-- Note: this index intentionally does NOT filter on `expires_at` because
+-- `now()` is not IMMUTABLE and Postgres rejects it inside index predicates.
+-- Expiry is checked at query time via is_share_active() / Python.
+CREATE INDEX IF NOT EXISTS project_shares_non_revoked_token_idx
   ON project_shares (token)
   WHERE revoked_at IS NULL;
 
@@ -67,6 +70,72 @@ BEGIN
   END IF;
   RETURN TRUE;
 END;
-$$ LANGUAGE plpgsql IMMUTABLE;
+-- STABLE (not IMMUTABLE): the function calls now(), so its value is
+-- consistent within a single statement / transaction but NOT across
+-- transactions. IMMUTABLE would let Postgres cache stale "active"
+-- evaluations indefinitely.
+$$ LANGUAGE plpgsql STABLE;
 
 COMMENT ON FUNCTION is_share_active IS 'Returns true if a project_shares row is still usable (not revoked, not expired).';
+
+-- ============================================================================
+-- Row-Level Security
+-- The Flask backend uses the service-role key (bypasses RLS), so policies
+-- here are a defense-in-depth lock against any anon-key client (or a
+-- credential leak) reading or mutating share rows directly. End users
+-- never touch this table from the frontend — they go through Flask, which
+-- enforces ownership in app code.
+-- ============================================================================
+
+ALTER TABLE project_shares ENABLE ROW LEVEL SECURITY;
+
+-- Owners can read share rows for projects they own.
+CREATE POLICY "Owners can read their project shares"
+ON project_shares FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1 FROM projects p
+    WHERE p.id = project_shares.project_id
+      AND p.user_id = auth.uid()
+  )
+);
+
+-- Owners can create share rows for projects they own.
+CREATE POLICY "Owners can create their project shares"
+ON project_shares FOR INSERT
+WITH CHECK (
+  created_by = auth.uid()
+  AND EXISTS (
+    SELECT 1 FROM projects p
+    WHERE p.id = project_shares.project_id
+      AND p.user_id = auth.uid()
+  )
+);
+
+-- Owners can update (revoke) share rows for projects they own.
+CREATE POLICY "Owners can update their project shares"
+ON project_shares FOR UPDATE
+USING (
+  EXISTS (
+    SELECT 1 FROM projects p
+    WHERE p.id = project_shares.project_id
+      AND p.user_id = auth.uid()
+  )
+);
+
+-- DELETE intentionally not granted: shares are revoked by setting
+-- revoked_at, never hard-deleted, so the audit trail stays intact.
+
+-- ============================================================================
+-- "Shared with me" idempotency guard.
+-- The fork flow auto-creates a project named "Shared with me" per user.
+-- Without a unique constraint, two concurrent forks from the same viewer
+-- can each pass the check-then-insert race and end up creating duplicate
+-- projects. A partial unique index makes the second insert raise a
+-- constraint violation that ensure_shared_with_me_project() can recover
+-- from by re-fetching.
+-- ============================================================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS projects_shared_with_me_per_user_uniq
+  ON projects (user_id)
+  WHERE name = 'Shared with me';

--- a/backend/supabase/migrations/00021_project_shares.sql
+++ b/backend/supabase/migrations/00021_project_shares.sql
@@ -1,0 +1,72 @@
+-- Migration: Project Shares (Roadmap #15)
+-- Description: Read-only shareable links for projects. Owner generates a
+--              token; viewers see chat list + full chats + citations +
+--              studio output artifacts as read-only. Sources, memory,
+--              API keys, brand config, and project-level costs stay
+--              private. Two modes: public (anyone with the link) and
+--              invited (logged-in user whose email matches a row in
+--              invited_emails).
+-- Created: 2026-04-27
+
+-- ============================================================================
+-- project_shares — one row per active or revoked share link
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS project_shares (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  mode TEXT NOT NULL CHECK (mode IN ('public', 'invited')),
+  invited_emails TEXT[] NOT NULL DEFAULT '{}',
+  created_by UUID NOT NULL REFERENCES users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- NULL means the share never expires — owner can still revoke.
+  expires_at TIMESTAMPTZ,
+  -- Set when the owner revokes the link. Row is kept (audit trail) but
+  -- the active-share check rejects it.
+  revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS project_shares_project_id_idx
+  ON project_shares (project_id);
+
+-- Hot read: viewer hits /share/{token}/* and we look up by token. Already
+-- UNIQUE which gives an index, but adding a partial index for active shares
+-- keeps the lookup fast even with many revoked rows.
+CREATE INDEX IF NOT EXISTS project_shares_active_token_idx
+  ON project_shares (token)
+  WHERE revoked_at IS NULL;
+
+-- ============================================================================
+-- chats — track fork lineage so the viewer's "continue in your workspace"
+-- copy can show a "forked from project X" breadcrumb.
+-- ============================================================================
+
+ALTER TABLE chats
+  ADD COLUMN IF NOT EXISTS forked_from_chat_id UUID
+    REFERENCES chats(id) ON DELETE SET NULL;
+
+ALTER TABLE chats
+  ADD COLUMN IF NOT EXISTS forked_from_project_id UUID
+    REFERENCES projects(id) ON DELETE SET NULL;
+
+-- ============================================================================
+-- Helper: check whether a share is currently usable. Used by app code via
+-- a SELECT, not as a constraint. Kept as a function so the rule is in one
+-- place if we add more conditions later (rate limiting, IP allowlist, etc.).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION is_share_active(share_row project_shares)
+RETURNS BOOLEAN AS $$
+BEGIN
+  IF share_row.revoked_at IS NOT NULL THEN
+    RETURN FALSE;
+  END IF;
+  IF share_row.expires_at IS NOT NULL AND share_row.expires_at <= now() THEN
+    RETURN FALSE;
+  END IF;
+  RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+COMMENT ON FUNCTION is_share_active IS 'Returns true if a project_shares row is still usable (not revoked, not expired).';

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { createLogger } from '@/lib/logger';
 import { PermissionsProvider } from './contexts/PermissionsContext';
 import { IntegrationsProvider } from './contexts/IntegrationsContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { ShareWorkspace } from './components/share/ShareWorkspace';
 
 const log = createLogger('app');
 
@@ -240,7 +241,14 @@ function App() {
     );
   }
 
-  if (authRequired && !isAuthenticated) {
+  // Share viewer routes are reachable without a JWT (public share links).
+  // Render them BEFORE the auth gate so anonymous viewers don't get
+  // bounced to the AuthPage. Invited-mode shares still surface a
+  // sign-in prompt inside ShareWorkspace when the backend returns 401.
+  const isShareRoute =
+    typeof window !== 'undefined' && window.location.pathname.startsWith('/share/');
+
+  if (authRequired && !isAuthenticated && !isShareRoute) {
     return <AuthPage onAuthenticated={refreshAuth} />;
   }
 
@@ -250,6 +258,10 @@ function App() {
         <IntegrationsProvider>
           <BrowserRouter>
             <Routes>
+            {/* Shared project (read-only). Mounted before /projects so
+                public-link viewers don't need a JWT to reach it. */}
+            <Route path="/share/:token" element={<ShareWorkspace />} />
+
             {/* Project Workspace - URL-based routing */}
             <Route
               path="/projects/:projectId"

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -33,6 +33,21 @@ interface ChatMessagesProps {
   sending: boolean;
   projectId: string;
   streamingAssistantContent?: string;
+  /**
+   * Render in read-only mode (used by the shared-project view). Currently
+   * a no-op for write affordances inside this component (the input + stop
+   * live in ChatPanel), but accepted for API symmetry and reserved for
+   * future hide-actions toggles.
+   */
+  readOnly?: boolean;
+  /**
+   * Rewrites image / asset URLs before they reach the markdown renderer.
+   * The shared-project view uses this to swap owner-only studio asset
+   * URLs (`/api/v1/projects/:pid/studio/...`) for share-token proxy URLs
+   * (`/api/v1/share/:token/studio/...`) so anonymous viewers can load the
+   * artifacts.
+   */
+  studioAssetRewriter?: (url: string) => string;
 }
 
 /**
@@ -184,6 +199,7 @@ const UserMessage: React.FC<{ content: string }> = ({ content }) => (
 interface AIMessageProps {
   content: string;
   projectId: string;
+  studioAssetRewriter?: (url: string) => string;
 }
 
 /**
@@ -290,7 +306,7 @@ const MessageActions: React.FC<MessageActionsProps> = ({ content }) => {
   );
 };
 
-const AIMessage: React.FC<AIMessageProps> = ({ content, projectId }) => {
+const AIMessage: React.FC<AIMessageProps> = ({ content, projectId, studioAssetRewriter }) => {
   // Parse citations from content to get citation numbers
   const { uniqueCitations, markerToNumber } = useMemo(
     () => parseCitations(content),
@@ -329,6 +345,16 @@ const AIMessage: React.FC<AIMessageProps> = ({ content, projectId }) => {
   // Create markdown components with citation-aware link handler
   const componentsWithCitations = useMemo(() => ({
     ...markdownComponents,
+    // Rewrite asset URLs (studio outputs etc.) when a rewriter is supplied —
+    // used by the shared-project view to redirect owner-only paths through
+    // the share-token proxy.
+    img: ({ src, alt }: { src?: string; alt?: string }) => (
+      <img
+        src={src ? (studioAssetRewriter ? studioAssetRewriter(src) : src) : src}
+        alt={alt || ''}
+        className="max-w-full h-auto rounded-lg my-2"
+      />
+    ),
     // Override 'a' to handle citation links
     a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
       // Check if this is a citation link (#cite-CHUNK_ID)
@@ -365,7 +391,7 @@ const AIMessage: React.FC<AIMessageProps> = ({ content, projectId }) => {
         </a>
       );
     },
-  }), [projectId]);
+  }), [projectId, studioAssetRewriter]);
 
   return (
     <div className="flex justify-start w-full max-w-full overflow-hidden">
@@ -452,7 +478,12 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
   sending,
   projectId,
   streamingAssistantContent = '',
+  readOnly: _readOnly,
+  studioAssetRewriter,
 }) => {
+  // _readOnly is reserved for future use; ChatMessages currently has no
+  // write affordances of its own (input + stop live in ChatPanel).
+  void _readOnly;
   const containerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -516,6 +547,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
               <AIMessage
                 content={msg.content}
                 projectId={projectId}
+                studioAssetRewriter={studioAssetRewriter}
               />
             )}
             {msg.error && (
@@ -530,6 +562,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
           <AIMessage
             content={streamingAssistantContent}
             projectId={projectId}
+            studioAssetRewriter={studioAssetRewriter}
           />
         )}
 

--- a/frontend/src/components/project/ProjectHeader.tsx
+++ b/frontend/src/components/project/ProjectHeader.tsx
@@ -35,6 +35,7 @@ import { projectsAPI, type CostTracking, type MemoryData } from '../../lib/api';
 import { ToastContainer } from '../ui/toast';
 import { useToast } from '../ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { ShareButton } from './ShareButton';
 
 const log = createLogger('project-header');
 
@@ -397,6 +398,8 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
 
       {/* Right side - Actions */}
       <div className="flex items-center gap-2">
+        <ShareButton projectId={project.id} projectName={project.name} />
+
         <Button
           variant="soft"
           size="sm"

--- a/frontend/src/components/project/ShareButton.tsx
+++ b/frontend/src/components/project/ShareButton.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Share } from '@phosphor-icons/react';
+import { Button } from '../ui/button';
+import { SharingModal } from './SharingModal';
+
+/**
+ * ShareButton
+ *
+ * Quiet, refined trigger for the project-share modal. Lives in the
+ * project header next to Memory / Settings / New Project — same visual
+ * weight as those, slightly warmer accent on hover.
+ */
+interface ShareButtonProps {
+  projectId: string;
+  projectName: string;
+}
+
+export const ShareButton: React.FC<ShareButtonProps> = ({ projectId, projectName }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant="soft"
+        size="sm"
+        onClick={() => setOpen(true)}
+        className="gap-2"
+        aria-haspopup="dialog"
+      >
+        <Share size={16} />
+        Share
+      </Button>
+      <SharingModal
+        open={open}
+        onOpenChange={setOpen}
+        projectId={projectId}
+        projectName={projectName}
+      />
+    </>
+  );
+};

--- a/frontend/src/components/project/SharingModal.tsx
+++ b/frontend/src/components/project/SharingModal.tsx
@@ -1,0 +1,551 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../ui/tooltip';
+import {
+  CheckCircle,
+  Clock,
+  Copy,
+  Globe,
+  LockKey,
+  Share,
+  Sparkle,
+  Trash,
+  X,
+} from '@phosphor-icons/react';
+import { useToast } from '../ui/use-toast';
+import { ToastContainer } from '../ui/toast';
+import { sharesAPI, type ProjectShare, type ShareExpiry, type ShareMode } from '@/lib/api/shares';
+import { upsertOne, removeOne } from '@/lib/resourceState';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('sharing-modal');
+
+interface SharingModalProps {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  projectId: string;
+  projectName: string;
+}
+
+/**
+ * SharingModal
+ *
+ * Editorial / library aesthetic — warm cream background, fine rules
+ * between sections, generous spacing. Intentional restraint: no flashy
+ * motion, no jewel tones. The most colorful element is a thin amber
+ * line under the active mode pill.
+ *
+ * Two regions:
+ *   • Top — "Create new link" form with mode + (optional) emails + expiry.
+ *   • Bottom — list of existing links with copy / revoke affordances.
+ */
+export const SharingModal: React.FC<SharingModalProps> = ({
+  open,
+  onOpenChange,
+  projectId,
+  projectName,
+}) => {
+  const { toasts, dismissToast, success, error } = useToast();
+
+  // ── List state ───────────────────────────────────────────────────
+  const [shares, setShares] = useState<ProjectShare[]>([]);
+  const [listLoading, setListLoading] = useState(true);
+
+  // ── Create form state ────────────────────────────────────────────
+  const [mode, setMode] = useState<ShareMode>('public');
+  const [emailDraft, setEmailDraft] = useState('');
+  const [emails, setEmails] = useState<string[]>([]);
+  const [expiry, setExpiry] = useState<ShareExpiry>(7);
+  const [creating, setCreating] = useState(false);
+
+  // ── Per-row state ────────────────────────────────────────────────
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const resetForm = useCallback(() => {
+    setMode('public');
+    setEmailDraft('');
+    setEmails([]);
+    setExpiry(7);
+  }, []);
+
+  const fetchShares = useCallback(async () => {
+    try {
+      setListLoading(true);
+      const res = await sharesAPI.list(projectId);
+      setShares(res.data.shares || []);
+    } catch (err) {
+      log.error({ err }, 'failed to load shares');
+      error('Failed to load shares');
+    } finally {
+      setListLoading(false);
+    }
+  }, [projectId, error]);
+
+  useEffect(() => {
+    if (!open) return;
+    fetchShares();
+  }, [open, fetchShares]);
+
+  useEffect(() => {
+    // Don't strand draft text when the modal closes.
+    if (!open) {
+      setEmailDraft('');
+      setCopiedId(null);
+    }
+  }, [open]);
+
+  const addEmail = (raw: string) => {
+    const cleaned = raw.trim().toLowerCase();
+    if (!cleaned) return;
+    if (!cleaned.includes('@') || !cleaned.includes('.')) {
+      error('That doesn’t look like an email');
+      return;
+    }
+    if (emails.includes(cleaned)) return;
+    setEmails((prev) => [...prev, cleaned]);
+    setEmailDraft('');
+  };
+
+  const handleEmailKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addEmail(emailDraft);
+    } else if (e.key === 'Backspace' && !emailDraft && emails.length > 0) {
+      setEmails((prev) => prev.slice(0, -1));
+    }
+  };
+
+  const removeEmail = (e: string) => {
+    setEmails((prev) => prev.filter((x) => x !== e));
+  };
+
+  const canSubmit = useMemo(() => {
+    if (creating) return false;
+    if (mode === 'invited' && emails.length === 0) return false;
+    return true;
+  }, [creating, mode, emails]);
+
+  const handleCreate = async () => {
+    if (!canSubmit) return;
+    try {
+      setCreating(true);
+      const res = await sharesAPI.create(projectId, {
+        mode,
+        invited_emails: mode === 'invited' ? emails : undefined,
+        expires_in_days: expiry,
+      });
+      const created = res.data.share;
+      setShares((prev) => upsertOne(prev, created, { prepend: true }));
+      // Auto-copy + toast — the moment of joy when sharing.
+      try {
+        await navigator.clipboard.writeText(created.url);
+        success('Link copied');
+      } catch {
+        success('Link created');
+      }
+      resetForm();
+    } catch (err) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      log.error({ err }, 'failed to create share');
+      error(msg || 'Failed to create share link');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleCopy = async (share: ProjectShare) => {
+    try {
+      await navigator.clipboard.writeText(share.url);
+      setCopiedId(share.id);
+      success('Link copied');
+      setTimeout(() => setCopiedId((id) => (id === share.id ? null : id)), 1600);
+    } catch {
+      error('Could not copy. Select the URL manually.');
+    }
+  };
+
+  const handleRevoke = async (share: ProjectShare) => {
+    const confirmed = window.confirm(
+      `Revoke this share? Anyone using the link will lose access immediately.`,
+    );
+    if (!confirmed) return;
+    const previous = shares;
+    setShares((prev) => removeOne(prev, share.id));
+    try {
+      await sharesAPI.revoke(projectId, share.id);
+      success('Share revoked');
+    } catch (err) {
+      log.error({ err }, 'failed to revoke share');
+      error('Failed to revoke. Restored.');
+      setShares(previous);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[540px] p-0 overflow-hidden">
+        <div className="px-7 pt-6 pb-4 border-b">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-base font-semibold">
+              <Share size={18} className="text-primary" />
+              Share &ldquo;{projectName}&rdquo;
+            </DialogTitle>
+            <DialogDescription className="text-xs leading-relaxed text-muted-foreground mt-1">
+              Anyone with the link gets <strong>read-only</strong> access to this project&apos;s chats.
+              Sources, memory, API keys, and brand stay with you.
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        {/* ── CREATE ─────────────────────────────────────────── */}
+        <div className="px-7 py-5 space-y-4">
+          <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            New link
+          </div>
+
+          {/* Mode pills */}
+          <div className="flex items-center gap-2">
+            {(['public', 'invited'] as const).map((m) => {
+              const isActive = mode === m;
+              return (
+                <button
+                  key={m}
+                  onClick={() => setMode(m)}
+                  className={[
+                    'group relative px-3.5 py-1.5 text-xs rounded-full border transition-colors',
+                    isActive
+                      ? 'border-primary/40 bg-primary/5 text-foreground'
+                      : 'border-border/60 bg-background text-muted-foreground hover:text-foreground',
+                  ].join(' ')}
+                  aria-pressed={isActive}
+                >
+                  <span className="inline-flex items-center gap-1.5">
+                    {m === 'public' ? <Globe size={13} /> : <LockKey size={13} />}
+                    {m === 'public' ? 'Anyone with link' : 'Specific people'}
+                  </span>
+                  {isActive && (
+                    <span
+                      aria-hidden
+                      className="absolute left-3.5 right-3.5 -bottom-px h-px bg-primary/60"
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Invited emails — chip-style input */}
+          {mode === 'invited' && (
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-1.5 px-2 py-1.5 rounded-md border border-border/70 bg-background min-h-9">
+                {emails.map((e) => (
+                  <span
+                    key={e}
+                    className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full text-[11px] font-medium bg-muted/70 border border-border/50"
+                  >
+                    {e}
+                    <button
+                      onClick={() => removeEmail(e)}
+                      className="rounded-full hover:bg-stone-200/70 p-0.5"
+                      aria-label={`Remove ${e}`}
+                    >
+                      <X size={10} weight="bold" />
+                    </button>
+                  </span>
+                ))}
+                <Input
+                  value={emailDraft}
+                  onChange={(ev) => setEmailDraft(ev.target.value)}
+                  onKeyDown={handleEmailKey}
+                  onBlur={() => emailDraft && addEmail(emailDraft)}
+                  placeholder={emails.length ? '' : 'name@example.com, then Enter'}
+                  className="flex-1 min-w-[160px] h-7 px-1 border-0 bg-transparent shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                />
+              </div>
+              <p className="text-[11px] text-muted-foreground leading-relaxed">
+                Invitees must already have a NoobBook account with one of these emails.
+              </p>
+            </div>
+          )}
+
+          {/* Expiry pills */}
+          <div className="space-y-1.5">
+            <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+              Expires
+            </div>
+            <div className="flex items-center gap-2">
+              {([7, 30, null] as const).map((opt) => {
+                const isActive = expiry === opt;
+                return (
+                  <button
+                    key={String(opt)}
+                    onClick={() => setExpiry(opt)}
+                    className={[
+                      'px-3 py-1 rounded-full text-xs border transition-colors',
+                      isActive
+                        ? 'border-primary/40 bg-primary/5 text-foreground'
+                        : 'border-border/60 bg-background text-muted-foreground hover:text-foreground',
+                    ].join(' ')}
+                  >
+                    {opt === 7 ? '7 days' : opt === 30 ? '30 days' : 'Never'}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="pt-1">
+            <Button
+              onClick={handleCreate}
+              disabled={!canSubmit}
+              className="w-full gap-2"
+            >
+              <Sparkle size={14} weight="fill" />
+              {creating ? 'Creating link…' : 'Create link'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="h-px bg-border/70" />
+
+        {/* ── ACTIVE LINKS ──────────────────────────────────── */}
+        <div className="px-7 py-5">
+          <div className="flex items-center justify-between mb-3">
+            <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+              Active links
+            </div>
+            {!listLoading && (
+              <span className="text-[11px] text-muted-foreground">
+                {shares.filter((s) => s.is_active).length} active
+                {shares.filter((s) => !s.is_active).length
+                  ? ` · ${shares.filter((s) => !s.is_active).length} inactive`
+                  : ''}
+              </span>
+            )}
+          </div>
+
+          {listLoading ? (
+            <div className="space-y-2.5">
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="h-[58px] rounded-lg border border-border/60 bg-muted/30 animate-pulse"
+                />
+              ))}
+            </div>
+          ) : shares.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <div className="space-y-2 max-h-[280px] overflow-y-auto pr-1 -mr-1">
+              {shares.map((share, idx) => (
+                <ShareRow
+                  key={share.id}
+                  share={share}
+                  copied={copiedId === share.id}
+                  onCopy={handleCopy}
+                  onRevoke={handleRevoke}
+                  staggerMs={idx * 30}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Sub-components
+// ──────────────────────────────────────────────────────────────────
+
+const EmptyState: React.FC = () => (
+  <div className="flex flex-col items-center justify-center py-8 px-6 text-center rounded-lg border border-dashed border-border/70">
+    <div className="text-stone-400 mb-2.5">
+      <Sparkle size={20} weight="duotone" />
+    </div>
+    <p className="text-sm font-medium text-foreground">No share links yet</p>
+    <p className="text-xs text-muted-foreground mt-1 max-w-[280px] leading-relaxed">
+      Create one to give read-only access to this project&apos;s chats.
+    </p>
+  </div>
+);
+
+interface ShareRowProps {
+  share: ProjectShare;
+  copied: boolean;
+  onCopy: (s: ProjectShare) => void;
+  onRevoke: (s: ProjectShare) => void;
+  staggerMs: number;
+}
+
+const ShareRow: React.FC<ShareRowProps> = ({ share, copied, onCopy, onRevoke, staggerMs }) => {
+  const inactive = !share.is_active;
+  const inactiveLabel = share.revoked_at ? 'Revoked' : 'Expired';
+  const expiryLabel = formatExpiry(share);
+
+  return (
+    <div
+      style={{ animation: `share-row-in 320ms ${staggerMs}ms both ease-out` }}
+      className={[
+        'group relative rounded-lg border bg-card px-3 py-2.5 transition-colors',
+        inactive
+          ? 'border-border/40 opacity-60 hover:opacity-80'
+          : 'border-border/70 hover:border-primary/30',
+      ].join(' ')}
+    >
+      <style>{shareRowKeyframes}</style>
+      <div className="flex items-center gap-3">
+        {/* Mode pill */}
+        <span
+          className={[
+            'inline-flex items-center justify-center h-7 w-7 rounded-md flex-shrink-0',
+            share.mode === 'public'
+              ? 'bg-primary/10 text-primary'
+              : 'bg-stone-200/70 text-stone-700 dark:bg-stone-800/70 dark:text-stone-300',
+          ].join(' ')}
+          title={share.mode === 'public' ? 'Anyone with the link' : 'Specific people'}
+        >
+          {share.mode === 'public' ? (
+            <Globe size={14} weight="bold" />
+          ) : (
+            <LockKey size={14} weight="bold" />
+          )}
+        </span>
+
+        {/* URL + metadata */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span className="font-mono truncate" title={share.url}>
+              {compactUrl(share.url)}
+            </span>
+            {inactive && (
+              <span className="px-1.5 py-px rounded text-[10px] font-medium uppercase tracking-wide bg-stone-200/70 text-stone-700 dark:bg-stone-800/70 dark:text-stone-300">
+                {inactiveLabel}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 mt-1 text-[10px] text-muted-foreground">
+            <span className="inline-flex items-center gap-1">
+              <Clock size={11} />
+              {expiryLabel}
+            </span>
+            {share.mode === 'invited' && share.invited_emails.length > 0 && (
+              <>
+                <span aria-hidden>·</span>
+                <span
+                  className="truncate"
+                  title={share.invited_emails.join(', ')}
+                >
+                  {share.invited_emails.length === 1
+                    ? share.invited_emails[0]
+                    : `${share.invited_emails.length} people`}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-0.5 flex-shrink-0">
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onCopy(share)}
+                  disabled={inactive}
+                  className="h-7 w-7"
+                  aria-label="Copy link"
+                >
+                  {copied ? (
+                    <CheckCircle size={14} weight="fill" className="text-primary" />
+                  ) : (
+                    <Copy size={14} />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                {copied ? 'Copied' : 'Copy link'}
+              </TooltipContent>
+            </Tooltip>
+            {!inactive && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => onRevoke(share)}
+                    className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                    aria-label="Revoke link"
+                  >
+                    <Trash size={14} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="text-xs">
+                  Revoke
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </TooltipProvider>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Formatting helpers
+// ──────────────────────────────────────────────────────────────────
+
+const shareRowKeyframes = `
+@keyframes share-row-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+`;
+
+function compactUrl(url: string): string {
+  // Show only the last meaningful segment so the row stays tidy at any width.
+  // e.g. https://app.example.com/share/AbC123 → /share/AbC123
+  try {
+    const u = new URL(url);
+    return `${u.host}${u.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
+function formatExpiry(share: ProjectShare): string {
+  if (share.revoked_at) return 'Revoked';
+  if (!share.expires_at) return 'Never expires';
+  const ms = new Date(share.expires_at).getTime() - Date.now();
+  if (ms <= 0) return 'Expired';
+  const days = Math.round(ms / (24 * 60 * 60 * 1000));
+  if (days <= 0) {
+    const hours = Math.max(1, Math.round(ms / (60 * 60 * 1000)));
+    return `Expires in ${hours}h`;
+  }
+  if (days === 1) return 'Expires tomorrow';
+  if (days < 30) return `Expires in ${days}d`;
+  const date = new Date(share.expires_at);
+  return `Expires ${date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`;
+}
+

--- a/frontend/src/components/share/ContinueInWorkspaceButton.tsx
+++ b/frontend/src/components/share/ContinueInWorkspaceButton.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowSquareOut, CircleNotch, Sparkle } from '@phosphor-icons/react';
+import { Button } from '../ui/button';
+import { useToast } from '../ui/use-toast';
+import { ToastContainer } from '../ui/toast';
+import { shareAPI } from '@/lib/api/share';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('share-fork');
+
+interface ContinueInWorkspaceButtonProps {
+  token: string;
+  chatId: string | null;
+  isAuthenticated: boolean;
+  /**
+   * Optional override for where to redirect logged-out viewers. Defaults
+   * to `/auth?redirect=<current url>` so the AuthPage can bounce them
+   * back to the share view after sign-in.
+   */
+  signInHref?: string;
+}
+
+/**
+ * ContinueInWorkspaceButton
+ *
+ * Pinned to the bottom of the chat detail pane in share mode, in place
+ * of the input area. Soft amber ring, generous padding, friendly tone:
+ * "Want to continue this conversation?" — not "Limited access".
+ *
+ * For logged-in viewers: forks the shared chat into their "Shared with
+ * me" workspace and navigates them straight into the writable copy.
+ * For anonymous viewers: changes the CTA to a sign-in link that
+ * round-trips back to the share URL after auth.
+ */
+export const ContinueInWorkspaceButton: React.FC<ContinueInWorkspaceButtonProps> = ({
+  token,
+  chatId,
+  isAuthenticated,
+  signInHref,
+}) => {
+  const { toasts, dismissToast, error } = useToast();
+  const navigate = useNavigate();
+  const [forking, setForking] = useState(false);
+
+  const disabled = !chatId || forking;
+
+  const handleFork = async () => {
+    if (!chatId) return;
+    try {
+      setForking(true);
+      const res = await shareAPI.fork(token, chatId);
+      const result = res.data;
+      navigate(`/projects/${result.project.id}/chats/${result.chat.id}`);
+    } catch (err) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      log.error({ err }, 'fork failed');
+      error(msg || 'Could not continue this chat. Try again?');
+      setForking(false);
+    }
+  };
+
+  const fallbackSignIn = (() => {
+    if (signInHref) return signInHref;
+    if (typeof window === 'undefined') return '/auth';
+    const here = window.location.pathname + window.location.hash;
+    return `/auth?redirect=${encodeURIComponent(here)}`;
+  })();
+
+  return (
+    <div className="px-6 pt-4 pb-6">
+      <div className="relative rounded-2xl border border-primary/25 bg-primary/[0.04] px-5 py-4">
+        {/* Hairline accent — the only saturated brand mark on the page */}
+        <span
+          aria-hidden
+          className="absolute left-5 right-5 -top-px h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent"
+        />
+        <div className="flex items-start gap-3.5">
+          <div className="flex-shrink-0 mt-0.5 text-primary">
+            <Sparkle size={18} weight="fill" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-foreground leading-snug">
+              Want to continue this conversation?
+            </p>
+            <p className="text-[12.5px] text-muted-foreground leading-relaxed mt-1">
+              We&apos;ll create a copy in your workspace where you can keep chatting with your own sources.
+            </p>
+            <div className="mt-3">
+              {isAuthenticated ? (
+                <Button
+                  onClick={handleFork}
+                  disabled={disabled}
+                  size="sm"
+                  className="gap-2 h-8"
+                >
+                  {forking ? (
+                    <>
+                      <CircleNotch size={14} className="animate-spin" />
+                      Creating your copy…
+                    </>
+                  ) : (
+                    <>
+                      Continue in your workspace
+                      <ArrowSquareOut size={14} weight="bold" />
+                    </>
+                  )}
+                </Button>
+              ) : (
+                <Button asChild size="sm" className="gap-2 h-8">
+                  <a href={fallbackSignIn}>
+                    Sign in to continue
+                    <ArrowSquareOut size={14} weight="bold" />
+                  </a>
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </div>
+  );
+};

--- a/frontend/src/components/share/ShareWorkspace.tsx
+++ b/frontend/src/components/share/ShareWorkspace.tsx
@@ -1,0 +1,546 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  ArrowSquareOut,
+  CircleNotch,
+  DownloadSimple,
+  Hash,
+  Info,
+  LockKey,
+  ChatCircle,
+  Globe,
+} from '@phosphor-icons/react';
+import { ChatMessages } from '../chat/ChatMessages';
+import { Button } from '../ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../ui/tooltip';
+import { ToastContainer } from '../ui/toast';
+import { useToast } from '../ui/use-toast';
+import { ContinueInWorkspaceButton } from './ContinueInWorkspaceButton';
+import { shareAPI, type ShareRoot } from '@/lib/api/share';
+import type { Chat, ChatMetadata } from '@/lib/api/chats';
+import { exportChatAsPdf } from '@/lib/exportChatPdf';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('share-workspace');
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; root: ShareRoot }
+  | { kind: 'error'; status: number; message: string; code?: string };
+
+const HASH_KEY = 'chat=';
+
+function readChatFromHash(): string | null {
+  if (typeof window === 'undefined') return null;
+  const hash = window.location.hash.replace(/^#/, '');
+  if (!hash.startsWith(HASH_KEY)) return null;
+  return hash.slice(HASH_KEY.length) || null;
+}
+
+function writeChatToHash(chatId: string | null) {
+  if (typeof window === 'undefined') return;
+  if (chatId) {
+    history.replaceState(null, '', `${window.location.pathname}#${HASH_KEY}${chatId}`);
+  } else {
+    history.replaceState(null, '', window.location.pathname);
+  }
+}
+
+/**
+ * ShareWorkspace
+ *
+ * The shared, read-only counterpart to ProjectWorkspace. Single-page
+ * layout: a quiet top bar, a slim left rail of chats, and the chat
+ * detail at the right with a fork CTA at the bottom in place of the
+ * input. No project chrome, no navigation to other surfaces.
+ *
+ * Aesthetic: editorial / library. Generous spacing, fine rules,
+ * one accent color. Treat the page like a Notion shared view —
+ * inviting to read, never apologetic about being read-only.
+ */
+export const ShareWorkspace: React.FC = () => {
+  const { token } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+  const { toasts, dismissToast, error } = useToast();
+
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const [activeChatId, setActiveChatId] = useState<string | null>(readChatFromHash());
+  const [activeChat, setActiveChat] = useState<Chat | null>(null);
+  const [chatLoading, setChatLoading] = useState(false);
+  const [exportingChat, setExportingChat] = useState(false);
+
+  // ── Load share root ──────────────────────────────────────────
+  useEffect(() => {
+    if (!token) {
+      setState({ kind: 'error', status: 404, message: 'Missing share token.' });
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await shareAPI.getRoot(token);
+        if (cancelled) return;
+        const root = res.data;
+        setState({ kind: 'ready', root });
+        const initial = readChatFromHash() ?? root.chats[0]?.id ?? null;
+        setActiveChatId(initial);
+      } catch (err) {
+        if (cancelled) return;
+        const status = (err as { response?: { status?: number } })?.response?.status ?? 500;
+        const data = (err as { response?: { data?: { error?: string; code?: string } } })?.response?.data;
+        log.warn({ err, status }, 'share root failed');
+        setState({
+          kind: 'error',
+          status,
+          message: data?.error || 'Could not load this share link.',
+          code: data?.code,
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  // ── Load active chat detail when selection changes ───────────
+  useEffect(() => {
+    if (!token || !activeChatId) {
+      setActiveChat(null);
+      return;
+    }
+    let cancelled = false;
+    setChatLoading(true);
+    (async () => {
+      try {
+        const res = await shareAPI.getChat(token, activeChatId);
+        if (cancelled) return;
+        setActiveChat(res.data.chat);
+      } catch (err) {
+        if (cancelled) return;
+        log.error({ err, activeChatId }, 'share chat fetch failed');
+        error('Could not load that chat.');
+        setActiveChat(null);
+      } finally {
+        if (!cancelled) setChatLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token, activeChatId, error]);
+
+  // Persist selection in the URL hash so refresh restores it.
+  useEffect(() => {
+    writeChatToHash(activeChatId);
+  }, [activeChatId]);
+
+  // Rewrite studio asset URLs so <img> tags inside chat messages
+  // resolve through the share-token proxy instead of the owner-only
+  // /api/v1/projects path (which would 401 without a JWT).
+  const studioAssetRewriter = useMemo(() => {
+    if (!token) return undefined;
+    const re = /\/api\/v1\/projects\/[^/]+\/studio\/([^/]+)\/([^/]+)\/(.+)$/;
+    return (url: string): string => {
+      const m = url.match(re);
+      if (!m) return url;
+      const [, kind, jobId, file] = m;
+      return shareAPI.studioAssetUrl(token, kind, jobId, file);
+    };
+  }, [token]);
+
+  // ── Branches ────────────────────────────────────────────────
+  if (state.kind === 'loading') {
+    return <SplashLoading />;
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <SplashError
+        status={state.status}
+        message={state.message}
+        code={state.code}
+        token={token}
+        onSignIn={() => navigate(`/auth?redirect=${encodeURIComponent(window.location.pathname + window.location.hash)}`)}
+        onHome={() => navigate('/')}
+      />
+    );
+  }
+
+  const { root } = state;
+  const chats = root.chats;
+  const isAuthed = root.viewer.is_authenticated;
+
+  const handleExport = useCallback(async () => {
+    if (!activeChat) return;
+    try {
+      setExportingChat(true);
+      await exportChatAsPdf({
+        chat: activeChat,
+        projectId: root.project.id,
+        projectName: root.project.name,
+      });
+    } catch (err) {
+      log.error({ err }, 'export failed');
+      error('PDF export failed');
+    } finally {
+      setExportingChat(false);
+    }
+  }, [activeChat, root.project.id, root.project.name, error]);
+
+  return (
+    <div className="min-h-screen bg-stone-50/40">
+      <TopBar
+        root={root}
+        token={token!}
+        canExport={!!activeChat}
+        exportingChat={exportingChat}
+        onExport={handleExport}
+        onSignIn={() => navigate(`/auth?redirect=${encodeURIComponent(window.location.pathname + window.location.hash)}`)}
+      />
+
+      <div className="mx-auto max-w-[1180px] px-4 sm:px-6 lg:px-8 pb-10">
+        <div className="grid grid-cols-12 gap-6">
+          <aside className="col-span-12 md:col-span-4 lg:col-span-3">
+            <ChatRail
+              chats={chats}
+              activeChatId={activeChatId}
+              onSelect={setActiveChatId}
+            />
+          </aside>
+
+          <main className="col-span-12 md:col-span-8 lg:col-span-9">
+            {activeChatId ? (
+              <ChatPane
+                chat={activeChat}
+                loading={chatLoading}
+                token={token!}
+                isAuthed={isAuthed}
+                studioAssetRewriter={studioAssetRewriter}
+                projectId={root.project.id}
+              />
+            ) : (
+              <EmptyChatState />
+            )}
+          </main>
+        </div>
+      </div>
+
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────
+// Top bar
+// ─────────────────────────────────────────────────────────────────
+
+interface TopBarProps {
+  root: ShareRoot;
+  token: string;
+  canExport: boolean;
+  exportingChat: boolean;
+  onExport: () => void;
+  onSignIn: () => void;
+}
+
+const TopBar: React.FC<TopBarProps> = ({ root, canExport, exportingChat, onExport, onSignIn }) => {
+  const isAuthed = root.viewer.is_authenticated;
+  return (
+    <header className="border-b bg-background/80 backdrop-blur-sm sticky top-0 z-20">
+      <div className="mx-auto max-w-[1180px] px-4 sm:px-6 lg:px-8 h-14 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="inline-flex items-center justify-center h-7 w-7 rounded-md bg-primary/10 text-primary">
+            {root.share.mode === 'public' ? (
+              <Globe size={14} weight="bold" />
+            ) : (
+              <LockKey size={14} weight="bold" />
+            )}
+          </span>
+          <div className="min-w-0">
+            <h1 className="text-sm font-semibold leading-tight truncate">
+              {root.project.name}
+            </h1>
+            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide bg-primary/8 text-primary border border-primary/15">
+                Read-only
+              </span>
+              {root.viewer.email ? (
+                <span className="truncate">Signed in as {root.viewer.email}</span>
+              ) : (
+                <span>Shared via link</span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onExport}
+                  disabled={!canExport || exportingChat}
+                  className="gap-1.5 h-8"
+                >
+                  {exportingChat ? (
+                    <CircleNotch size={14} className="animate-spin" />
+                  ) : (
+                    <DownloadSimple size={14} />
+                  )}
+                  <span className="hidden sm:inline">PDF</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                Download chat as PDF
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
+          {!isAuthed && (
+            <Button variant="outline" size="sm" onClick={onSignIn} className="gap-1.5 h-8">
+              Sign in
+              <ArrowSquareOut size={13} />
+            </Button>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────
+// Left rail: chats
+// ─────────────────────────────────────────────────────────────────
+
+interface ChatRailProps {
+  chats: ChatMetadata[];
+  activeChatId: string | null;
+  onSelect: (id: string) => void;
+}
+
+const ChatRail: React.FC<ChatRailProps> = ({ chats, activeChatId, onSelect }) => (
+  <div className="sticky top-[calc(56px+24px)]">
+    <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground mb-2 px-2">
+      Chats
+    </div>
+    {chats.length === 0 ? (
+      <div className="rounded-lg border border-dashed border-border/70 p-4 text-xs text-muted-foreground text-center">
+        No chats in this project.
+      </div>
+    ) : (
+      <nav className="space-y-1 max-h-[calc(100vh-160px)] overflow-y-auto pr-1 -mr-1">
+        {chats.map((chat) => {
+          const isActive = chat.id === activeChatId;
+          return (
+            <button
+              key={chat.id}
+              onClick={() => onSelect(chat.id)}
+              className={[
+                'w-full text-left rounded-md px-2.5 py-2 transition-colors group',
+                isActive
+                  ? 'bg-primary/10 ring-1 ring-primary/20'
+                  : 'hover:bg-muted/60',
+              ].join(' ')}
+            >
+              <div className="flex items-start gap-2">
+                <Hash
+                  size={13}
+                  className={[
+                    'mt-0.5 flex-shrink-0',
+                    isActive ? 'text-primary' : 'text-muted-foreground/70',
+                  ].join(' ')}
+                />
+                <div className="flex-1 min-w-0">
+                  <div className={[
+                    'text-[13px] truncate',
+                    isActive ? 'font-medium text-foreground' : 'text-foreground/85',
+                  ].join(' ')}>
+                    {chat.title || 'Untitled'}
+                  </div>
+                  <div className="text-[10.5px] text-muted-foreground mt-0.5 flex items-center gap-1.5">
+                    <span>{chat.message_count} {chat.message_count === 1 ? 'message' : 'messages'}</span>
+                    {chat.updated_at && (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>{relativeTime(chat.updated_at)}</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </nav>
+    )}
+  </div>
+);
+
+// ─────────────────────────────────────────────────────────────────
+// Right pane: chat detail
+// ─────────────────────────────────────────────────────────────────
+
+interface ChatPaneProps {
+  chat: Chat | null;
+  loading: boolean;
+  token: string;
+  isAuthed: boolean;
+  studioAssetRewriter?: (url: string) => string;
+  projectId: string;
+}
+
+const ChatPane: React.FC<ChatPaneProps> = ({
+  chat,
+  loading,
+  token,
+  isAuthed,
+  studioAssetRewriter,
+  projectId,
+}) => {
+  if (loading && !chat) {
+    return (
+      <div className="rounded-2xl border bg-card overflow-hidden">
+        <div className="border-b px-6 py-4">
+          <div className="h-4 w-48 bg-muted/60 rounded animate-pulse" />
+          <div className="h-3 w-24 bg-muted/40 rounded mt-2 animate-pulse" />
+        </div>
+        <div className="px-6 py-8 space-y-4">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="space-y-2">
+              <div className="h-3 w-40 bg-muted/50 rounded animate-pulse" />
+              <div className="h-3 w-3/4 bg-muted/40 rounded animate-pulse" />
+              <div className="h-3 w-2/3 bg-muted/40 rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!chat) {
+    return <EmptyChatState />;
+  }
+
+  return (
+    <article className="rounded-2xl border bg-card overflow-hidden flex flex-col min-h-[calc(100vh-140px)]">
+      <header className="border-b px-6 py-4 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold truncate">{chat.title}</h2>
+          <p className="text-[11px] text-muted-foreground mt-0.5">
+            {chat.messages?.length ?? 0} {(chat.messages?.length ?? 0) === 1 ? 'message' : 'messages'}
+          </p>
+        </div>
+      </header>
+
+      <div className="flex-1 min-h-0">
+        <ChatMessages
+          messages={chat.messages || []}
+          sending={false}
+          projectId={projectId}
+          readOnly
+          studioAssetRewriter={studioAssetRewriter}
+        />
+      </div>
+
+      <ContinueInWorkspaceButton
+        token={token}
+        chatId={chat.id}
+        isAuthenticated={isAuthed}
+      />
+    </article>
+  );
+};
+
+const EmptyChatState: React.FC = () => (
+  <div className="rounded-2xl border border-dashed bg-card/40 px-6 py-16 flex flex-col items-center justify-center text-center">
+    <div className="text-stone-400 mb-2.5">
+      <ChatCircle size={28} weight="duotone" />
+    </div>
+    <p className="text-sm font-medium">Select a chat from the left to read it</p>
+    <p className="text-xs text-muted-foreground mt-1 max-w-[300px] leading-relaxed">
+      Citations, studio outputs, and conversation history are all here in read-only form.
+    </p>
+  </div>
+);
+
+// ─────────────────────────────────────────────────────────────────
+// Splash states (loading / error)
+// ─────────────────────────────────────────────────────────────────
+
+const SplashLoading: React.FC = () => (
+  <div className="min-h-screen flex items-center justify-center bg-stone-50/60">
+    <div className="flex flex-col items-center gap-3 text-muted-foreground">
+      <CircleNotch size={22} className="animate-spin text-primary" />
+      <p className="text-xs uppercase tracking-[0.12em]">Loading shared project</p>
+    </div>
+  </div>
+);
+
+interface SplashErrorProps {
+  status: number;
+  message: string;
+  code?: string;
+  token: string | undefined;
+  onSignIn: () => void;
+  onHome: () => void;
+}
+
+const SplashError: React.FC<SplashErrorProps> = ({ status, message, code, onSignIn, onHome }) => {
+  const wantsSignIn = status === 401 || code === 'auth_required' || code === 'not_invited';
+  const isGone = status === 410 || status === 404;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-stone-50/60 px-6">
+      <div className="max-w-md w-full text-center">
+        <div className="mx-auto mb-5 inline-flex items-center justify-center h-12 w-12 rounded-full bg-stone-200/60 text-stone-500">
+          {isGone ? (
+            <Info size={20} weight="duotone" />
+          ) : (
+            <LockKey size={20} weight="duotone" />
+          )}
+        </div>
+        <h1 className="text-base font-semibold text-foreground">
+          {isGone ? 'This share link is no longer active' : 'Access required'}
+        </h1>
+        <p className="text-[13px] text-muted-foreground mt-2 leading-relaxed">
+          {message}
+        </p>
+        <div className="mt-6 flex items-center justify-center gap-2">
+          {wantsSignIn && (
+            <Button onClick={onSignIn} size="sm">
+              Sign in
+            </Button>
+          )}
+          <Button variant="outline" size="sm" onClick={onHome}>
+            Go home
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return 'just now';
+  const m = Math.round(ms / 60_000);
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.round(h / 24);
+  if (d < 7) return `${d}d`;
+  const w = Math.round(d / 7);
+  if (w < 5) return `${w}w`;
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}

--- a/frontend/src/lib/api/share.ts
+++ b/frontend/src/lib/api/share.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared Project — viewer-side API client (Roadmap #15).
+ *
+ * Hits `/api/v1/share/{token}/...` which is the only URL space the
+ * backend exposes without a JWT. Public-mode shares work for
+ * anonymous viewers; invited-mode shares attach the viewer's JWT
+ * (via `api`'s default Authorization header) so the backend can match
+ * email against the invite list.
+ *
+ * Returned types are intentionally minimal — we mirror the shapes the
+ * existing chat components already consume so they can be reused with
+ * a single `readOnly` flag.
+ */
+import { api } from './client';
+import type { Chat, ChatMetadata } from './chats';
+
+export interface ShareViewer {
+  is_authenticated: boolean;
+  user_id: string | null;
+  email: string | null;
+}
+
+export interface ShareRoot {
+  share: {
+    project_id: string;
+    mode: 'public' | 'invited';
+    url: string;
+  };
+  project: {
+    id: string;
+    name: string;
+    description: string;
+  };
+  chats: ChatMetadata[];
+  viewer: ShareViewer;
+}
+
+export interface SharedCitationChunk {
+  content: string;
+  chunk_id: string;
+  source_id: string;
+  source_name: string;
+  page_number: number;
+  chunk_index: number;
+}
+
+export interface ForkResult {
+  project: { id: string; name: string };
+  chat: {
+    id: string;
+    title: string;
+    project_id: string;
+    forked_from_chat_id: string;
+    forked_from_project_id: string;
+  };
+}
+
+export const shareAPI = {
+  getRoot: (token: string) =>
+    api.get<{ success: boolean } & ShareRoot>(`/share/${token}`),
+
+  getChat: (token: string, chatId: string) =>
+    api.get<{ success: boolean; chat: Chat }>(
+      `/share/${token}/chats/${chatId}`,
+    ),
+
+  getCitation: (token: string, chatId: string, chunkId: string) =>
+    api.get<{ success: boolean; chunk: SharedCitationChunk }>(
+      `/share/${token}/chats/${chatId}/citations/${encodeURIComponent(chunkId)}`,
+    ),
+
+  /**
+   * Build the URL the frontend should set on `<img>` / `<audio>` /
+   * `<video>` etc. for studio output thumbnails inside the share view.
+   * The browser fetches it directly (no auth header needed because the
+   * route is whitelisted in the global JWT gate and the token is in the
+   * path).
+   */
+  studioAssetUrl: (
+    token: string,
+    kind: string,
+    jobId: string,
+    filename: string,
+  ): string =>
+    `/api/v1/share/${token}/studio/${encodeURIComponent(kind)}/${encodeURIComponent(jobId)}/${filename
+      .split('/')
+      .map(encodeURIComponent)
+      .join('/')}`,
+
+  fork: (token: string, chatId: string) =>
+    api.post<{ success: boolean } & ForkResult>(
+      `/share/${token}/chats/${chatId}/fork`,
+      {},
+    ),
+};

--- a/frontend/src/lib/api/shares.ts
+++ b/frontend/src/lib/api/shares.ts
@@ -1,0 +1,54 @@
+/**
+ * Project Shares API — owner side (Roadmap #15).
+ *
+ * Owner-side client for managing share links on a project they own.
+ * The viewer-side client lives in `share.ts` (no `s`) and uses a
+ * separate URL space (`/api/v1/share/...`) that doesn't require a JWT.
+ */
+import { api } from './client';
+
+export type ShareMode = 'public' | 'invited';
+
+/**
+ * `expires_in_days` accepts 7, 30, or null (never). The backend
+ * validates the value; we type it loosely for forward compatibility.
+ */
+export type ShareExpiry = 7 | 30 | null;
+
+export interface ProjectShare {
+  id: string;
+  project_id: string;
+  token: string;
+  url: string;
+  mode: ShareMode;
+  invited_emails: string[];
+  created_by: string;
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+  is_active: boolean;
+}
+
+export interface CreateShareInput {
+  mode: ShareMode;
+  invited_emails?: string[];
+  expires_in_days?: ShareExpiry;
+}
+
+export const sharesAPI = {
+  list: (projectId: string) =>
+    api.get<{ success: boolean; shares: ProjectShare[] }>(
+      `/projects/${projectId}/shares`,
+    ),
+
+  create: (projectId: string, input: CreateShareInput) =>
+    api.post<{ success: boolean; share: ProjectShare }>(
+      `/projects/${projectId}/shares`,
+      input,
+    ),
+
+  revoke: (projectId: string, shareId: string) =>
+    api.delete<{ success: boolean }>(
+      `/projects/${projectId}/shares/${shareId}`,
+    ),
+};


### PR DESCRIPTION
## Summary
- New shareable project links surface chats only — sources, memory, API keys, brand config, and project-level costs stay private to the owner.
- Two modes: **public link** (anyone with the URL) and **invited** (logged-in viewer whose email is on an allowlist).
- Per-share expiry: 7 days / 30 days / never. Revocable from the owner UI.
- Viewer can hit **Continue in your workspace** to fork the chat into their own account (auto-created _Shared with me_ project), original untouched.
- Studio output artifacts referenced inside chats render correctly for viewers via a share-token proxy; sources, memory, and brand config are physically unreachable through the share URL space.

## How it works
**Owner side**: Share button in `ProjectHeader` (also a Sharing tab if you want to add one later) → `SharingModal` to create / copy / revoke links.

**Viewer side**: `/share/:token` mounts `ShareWorkspace` — single-page Notion-style read-only view. Chats on the left, chat detail on the right with citations, studio outputs, PDF download, and a "Continue in your workspace" CTA at the bottom.

**Auth path**: new `/api/v1/share/*` blueprint, whitelisted in the global JWT gate. `@require_share_token` decorator validates the URL token, enforces invited-mode email match, and attaches `g.share_context`. Public mode works for anonymous viewers; invited mode requires a JWT and matches `users.email`.

## Architecture
- **New table** `project_shares` (`token` 32-byte url-safe random, `mode`, `invited_emails`, `expires_at`, `revoked_at`). Migration `00021_project_shares.sql` also adds optional `forked_from_chat_id` / `forked_from_project_id` to `chats` for fork lineage.
- **New backend modules**:
  - `services/data_services/share_service.py` — CRUD over `project_shares`.
  - `services/auth/share_token.py` — `require_share_token` decorator.
  - `api/projects/shares.py` — owner CRUD endpoints.
  - `api/share/routes.py` — viewer endpoints (chat list, full chat, citation tooltip, studio artifact proxy, fork).
  - `services/data_services/chat_service.fork_chat` + `project_service.ensure_shared_with_me_project` for cross-project forking.
- **New frontend modules**:
  - `lib/api/shares.ts` (owner client), `lib/api/share.ts` (viewer client).
  - `components/project/ShareButton.tsx`, `components/project/SharingModal.tsx`.
  - `components/share/ShareWorkspace.tsx`, `components/share/ContinueInWorkspaceButton.tsx`.
  - `ChatMessages` gets `readOnly` + `studioAssetRewriter` props so the share view can rewrite studio URLs (`/api/v1/projects/.../studio/...` → `/api/v1/share/:token/studio/...`).

## Test plan
- [ ] Run migration `00021_project_shares.sql` cleanly.
- [ ] Owner creates a public share (7d expiry). Link copies to clipboard. Row appears in Active links with mode pill, copy button, "Expires in 7d" pill, revoke button.
- [ ] Open the link in incognito → chat list visible, full chat opens, citations resolve, studio output thumbnails load, PDF download works. Sources panel does not appear; DevTools shows no calls to `/sources`, `/memory`, `/settings/api-keys`.
- [ ] Direct fetch to `/api/v1/projects/{id}/sources` from the viewer's incognito session → 401 (global JWT gate still active for non-share routes).
- [ ] Owner creates an invited share with `alice@example.com`. Open URL while logged in as `bob@example.com` → 403 with "not on invite list" message. Log out and open → 401 with sign-in CTA. Log in as Alice → access granted.
- [ ] Manually `UPDATE project_shares SET expires_at = now() - interval '1 minute'` on a share → viewer hits 410 Gone with "no longer active" splash. Owner UI shows the row at half opacity with an "Expired" badge.
- [ ] Owner revokes a share → the viewer's existing tab shows 410 on next request. Row stays in the list as "Revoked".
- [ ] Logged-in viewer clicks **Continue in your workspace** → new chat appears in their _Shared with me_ project seeded with the owner's messages. Owner's chat untouched.
- [ ] Anonymous viewer sees "Sign in to continue" instead; clicking it lands on `/auth?redirect=/share/{token}#chat={chatId}`.
- [ ] PDF download works in the share view (citation backfill is best-effort and silently skipped for shares — chat content still exports).
- [ ] Studio artifact gating: a crafted URL `/api/v1/share/{token}/studio/.../some-other-file.png` for a file not in this project's storage path returns 404.
- [ ] After deploy: update `ROADMAP.md` row 15 ⬜ → ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)