### PR TITLE
admin-editable system prompts (Roadmap #16)

### DIFF
--- a/backend/app/api/settings/__init__.py
+++ b/backend/app/api/settings/__init__.py
@@ -41,3 +41,4 @@ from app.api.settings import databases  # noqa: F401
 from app.api.settings import mcp  # noqa: F401
 from app.api.settings import users  # noqa: F401
 from app.api.settings import models  # noqa: F401
+from app.api.settings import prompts  # noqa: F401

--- a/backend/app/api/settings/prompts.py
+++ b/backend/app/api/settings/prompts.py
@@ -29,7 +29,8 @@ link.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+import re
+from typing import Any, Dict, List, Optional, Tuple
 
 from flask import current_app, jsonify, request
 
@@ -44,6 +45,38 @@ from app.utils.prompt_var_utils import extract_vars, required_vars, validate_edi
 # leave any subset out of the PUT body — only the keys present are
 # overridden, the rest fall back to the shipped default.
 _EDITABLE_FIELDS = ("system_prompt", "user_message", "user_message_template", "max_tokens", "temperature")
+
+
+# Path-traversal guard. Every prompt_name flows from the URL into
+# pathlib joins (``data/prompt_overrides/<name>_prompt.json`` and
+# ``data/prompts/<name>_prompt.json``); ``pathlib`` happily resolves
+# ``..`` components, so a crafted ``../prompts/default`` would route
+# write_override straight into the shipped-defaults directory and
+# clobber files we never meant to touch.
+#
+# Matching shipped prompt filenames: lowercase, digits, underscore. No
+# dots, no slashes, no path separators of any platform. Routes admin-
+# gating is defense in depth; this gate is the actual fix.
+_SAFE_NAME_RE = re.compile(r"^[a-z0-9_]+$")
+
+
+def _validate_prompt_name(prompt_name: str) -> Optional[Tuple[Dict[str, Any], int]]:
+    """
+    Return ``None`` if ``prompt_name`` is safe, else an
+    ``(error_payload, status)`` tuple suitable for direct ``jsonify``.
+    """
+    if not prompt_name or not _SAFE_NAME_RE.match(prompt_name):
+        return (
+            {
+                "success": False,
+                "error": (
+                    "Invalid prompt name. Names must be lowercase letters, "
+                    "digits, and underscores only."
+                ),
+            },
+            400,
+        )
+    return None
 
 
 def _summarize(prompt_name: str, base: Dict[str, Any], effective: Dict[str, Any]) -> Dict[str, Any]:
@@ -120,6 +153,9 @@ def list_prompts():
 @require_admin
 def get_prompt(prompt_name: str):
     """Return the full editor payload for one prompt."""
+    bad = _validate_prompt_name(prompt_name)
+    if bad:
+        return jsonify(bad[0]), bad[1]
     try:
         detail = _detail(prompt_name)
         if detail is None:
@@ -146,7 +182,16 @@ def update_prompt(prompt_name: str):
       * ``temperature`` must be a number in [0, 2].
       * Any required ``.format()`` token in the shipped default must
         still be present in the merged effective body.
+
+    Persistence semantics: incoming fields are *merged* on top of the
+    existing override file, not replacing it. The frontend sends only
+    the fields that changed since it loaded the config, so a naive
+    full-file rewrite would silently erase any field the admin saved
+    earlier in a previous session.
     """
+    bad = _validate_prompt_name(prompt_name)
+    if bad:
+        return jsonify(bad[0]), bad[1]
     try:
         base = prompt_loader.get_prompt_default_config(prompt_name)
         if base is None:
@@ -163,34 +208,41 @@ def update_prompt(prompt_name: str):
                 "error": "Request body must be a JSON object",
             }), 400
 
-        # Build the override from the editable subset of the body.
-        override: Dict[str, Any] = {}
+        # Build the patch from the editable subset of the body.
+        patch: Dict[str, Any] = {}
         for field in _EDITABLE_FIELDS:
             if field in body:
-                override[field] = body[field]
+                patch[field] = body[field]
 
         # Per-field type checks — one pass before persisting so a single
         # bad field doesn't leave a half-written override on disk.
-        if "max_tokens" in override:
-            v = override["max_tokens"]
+        if "max_tokens" in patch:
+            v = patch["max_tokens"]
             if not isinstance(v, int) or isinstance(v, bool) or v <= 0 or v > 65536:
                 return jsonify({
                     "success": False,
                     "error": "max_tokens must be a positive integer ≤ 65536",
                 }), 400
-        if "temperature" in override:
-            v = override["temperature"]
+        if "temperature" in patch:
+            v = patch["temperature"]
             if not isinstance(v, (int, float)) or isinstance(v, bool) or v < 0 or v > 2:
                 return jsonify({
                     "success": False,
                     "error": "temperature must be a number between 0 and 2",
                 }), 400
         for field in ("system_prompt", "user_message", "user_message_template"):
-            if field in override and not isinstance(override[field], str):
+            if field in patch and not isinstance(patch[field], str):
                 return jsonify({
                     "success": False,
                     "error": f"{field} must be a string",
                 }), 400
+
+        # Merge the patch on top of any existing override so previously
+        # saved fields are preserved when this save only touches a
+        # different field. Without this merge, save A → save B silently
+        # erases A.
+        existing_override = prompt_loader._load_override(prompt_name) or {}  # noqa: SLF001
+        override = {**existing_override, **patch}
 
         # Compute the effective config as it would be after this save,
         # then check that no required var has gone missing.
@@ -207,8 +259,9 @@ def update_prompt(prompt_name: str):
                 "extra_vars": extra,
             }), 400
 
-        # If the override is empty (admin sent no fields, or sent a body
-        # identical to base) it's effectively a reset — clear instead of
+        # If the merged override is empty (e.g. admin sent fields all
+        # equal to base, OR there was no prior override and this PUT
+        # carries nothing) it's effectively a reset — clear instead of
         # writing an empty file.
         if not override:
             prompt_loader.clear_override(prompt_name)
@@ -234,6 +287,9 @@ def update_prompt(prompt_name: str):
 @require_admin
 def reset_prompt(prompt_name: str):
     """Drop the override file. Returns the now-effective (shipped) config."""
+    bad = _validate_prompt_name(prompt_name)
+    if bad:
+        return jsonify(bad[0]), bad[1]
     try:
         if prompt_loader.get_prompt_default_config(prompt_name) is None:
             return jsonify({

--- a/backend/app/api/settings/prompts.py
+++ b/backend/app/api/settings/prompts.py
@@ -1,0 +1,252 @@
+"""
+Admin Prompts settings endpoints (Roadmap #16).
+
+Surface every shipped prompt config under ``backend/data/prompts/`` to
+admins through Settings → Prompts. Admins can rewrite the body, change
+``max_tokens`` / ``temperature``, and reset back to the shipped default.
+Critical ``.format()`` placeholders (e.g. ``{current_memory}`` in
+``memory_prompt``) are auto-detected from the shipped default and the
+PUT validator rejects any save that drops one — preventing a stale
+admin edit from blowing up a downstream service with KeyError at
+runtime.
+
+Persistence: edits land in ``data/prompt_overrides/<name>_prompt.json``,
+sibling of the shipped defaults. The container entrypoint's
+``cp /app/_prompts_staging/* data/prompts/`` doesn't touch this
+sibling directory, so admin edits survive redeploys.
+
+Routes:
+  GET    /settings/prompts                      — list summaries
+  GET    /settings/prompts/<name>               — full config + required vars
+  PUT    /settings/prompts/<name>               — update; validate; write override
+  DELETE /settings/prompts/<name>/override      — reset to shipped default
+
+``model`` is intentionally NOT writable here — the existing
+``/settings/models`` endpoint owns per-category model overrides via env
+vars, and dual-writing the model would create two competing sources of
+truth. The editor surfaces ``model`` read-only with a "Edit in Models →"
+link.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from flask import current_app, jsonify, request
+
+from app.api.settings import settings_bp
+from app.config import prompt_loader
+from app.config.prompt_referenced_by import referenced_by
+from app.services.auth.rbac import require_admin
+from app.utils.prompt_var_utils import extract_vars, required_vars, validate_edit
+
+
+# Only these fields are writable through this endpoint. The admin can
+# leave any subset out of the PUT body — only the keys present are
+# overridden, the rest fall back to the shipped default.
+_EDITABLE_FIELDS = ("system_prompt", "user_message", "user_message_template", "max_tokens", "temperature")
+
+
+def _summarize(prompt_name: str, base: Dict[str, Any], effective: Dict[str, Any]) -> Dict[str, Any]:
+    """Shape a list-row payload — what the left-rail in the UI shows."""
+    return {
+        "prompt_name": prompt_name,
+        "name": effective.get("name") or prompt_name,
+        "description": effective.get("description") or "",
+        "model": effective.get("model"),
+        "default_model": base.get("model"),
+        "max_tokens": effective.get("max_tokens"),
+        "temperature": effective.get("temperature"),
+        "has_override": bool(prompt_loader.has_override(prompt_name)),
+        "required_vars": required_vars(base),
+    }
+
+
+def _detail(prompt_name: str) -> Optional[Dict[str, Any]]:
+    """Shape a full editor-detail payload — what the right pane shows."""
+    base = prompt_loader.get_prompt_default_config(prompt_name)
+    if base is None:
+        return None
+    override = prompt_loader._load_override(prompt_name)  # noqa: SLF001 — same module family
+    effective = prompt_loader.get_prompt_config(prompt_name) or base
+
+    base_dict = dict(base)
+    effective_dict = dict(effective)
+
+    return {
+        "prompt_name": prompt_name,
+        "base": base_dict,
+        "override": override,
+        "effective": effective_dict,
+        "required_vars": required_vars(base_dict),
+        "current_vars": extract_vars(
+            "\n".join(
+                str(effective_dict.get(f) or "")
+                for f in ("system_prompt", "user_message", "user_message_template")
+            )
+        ),
+        "referenced_by": referenced_by(prompt_name),
+        "editable_fields": list(_EDITABLE_FIELDS),
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Routes
+# ─────────────────────────────────────────────────────────────────────
+
+@settings_bp.route('/settings/prompts', methods=['GET'])
+@require_admin
+def list_prompts():
+    """Return one row per shipped prompt — for the left rail."""
+    try:
+        rows: List[Dict[str, Any]] = []
+        for effective in prompt_loader.list_all_prompts():
+            prompt_name = effective.get("prompt_name")
+            if not prompt_name:
+                continue
+            base = prompt_loader.get_prompt_default_config(prompt_name)
+            if base is None:
+                continue
+            rows.append(_summarize(prompt_name, dict(base), effective))
+        # Stable ordering — alphabetical on prompt_name. The list_all_prompts
+        # call above already sorts by filename, but be explicit.
+        rows.sort(key=lambda r: r["prompt_name"])
+        return jsonify({"success": True, "prompts": rows, "count": len(rows)}), 200
+    except Exception as e:
+        current_app.logger.error("Error listing prompts: %s", e)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@settings_bp.route('/settings/prompts/<prompt_name>', methods=['GET'])
+@require_admin
+def get_prompt(prompt_name: str):
+    """Return the full editor payload for one prompt."""
+    try:
+        detail = _detail(prompt_name)
+        if detail is None:
+            return jsonify({
+                "success": False,
+                "error": f"Unknown prompt: {prompt_name}",
+            }), 404
+        return jsonify({"success": True, "prompt": detail}), 200
+    except Exception as e:
+        current_app.logger.error("Error fetching prompt %s: %s", prompt_name, e)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@settings_bp.route('/settings/prompts/<prompt_name>', methods=['PUT'])
+@require_admin
+def update_prompt(prompt_name: str):
+    """
+    Apply an admin edit. Body keys that aren't in ``_EDITABLE_FIELDS`` are
+    silently ignored (conservative — easier than a 400 for a benign client
+    that bundles read-only fields it just received from GET).
+
+    Validation:
+      * ``max_tokens`` must be a positive int (cap at 64k just to be safe).
+      * ``temperature`` must be a number in [0, 2].
+      * Any required ``.format()`` token in the shipped default must
+        still be present in the merged effective body.
+    """
+    try:
+        base = prompt_loader.get_prompt_default_config(prompt_name)
+        if base is None:
+            return jsonify({
+                "success": False,
+                "error": f"Unknown prompt: {prompt_name}",
+            }), 404
+        base_dict = dict(base)
+
+        body = request.get_json(silent=True) or {}
+        if not isinstance(body, dict):
+            return jsonify({
+                "success": False,
+                "error": "Request body must be a JSON object",
+            }), 400
+
+        # Build the override from the editable subset of the body.
+        override: Dict[str, Any] = {}
+        for field in _EDITABLE_FIELDS:
+            if field in body:
+                override[field] = body[field]
+
+        # Per-field type checks — one pass before persisting so a single
+        # bad field doesn't leave a half-written override on disk.
+        if "max_tokens" in override:
+            v = override["max_tokens"]
+            if not isinstance(v, int) or isinstance(v, bool) or v <= 0 or v > 65536:
+                return jsonify({
+                    "success": False,
+                    "error": "max_tokens must be a positive integer ≤ 65536",
+                }), 400
+        if "temperature" in override:
+            v = override["temperature"]
+            if not isinstance(v, (int, float)) or isinstance(v, bool) or v < 0 or v > 2:
+                return jsonify({
+                    "success": False,
+                    "error": "temperature must be a number between 0 and 2",
+                }), 400
+        for field in ("system_prompt", "user_message", "user_message_template"):
+            if field in override and not isinstance(override[field], str):
+                return jsonify({
+                    "success": False,
+                    "error": f"{field} must be a string",
+                }), 400
+
+        # Compute the effective config as it would be after this save,
+        # then check that no required var has gone missing.
+        merged = {**base_dict, **override}
+        ok, missing, extra = validate_edit(base_dict, merged)
+        if not ok:
+            return jsonify({
+                "success": False,
+                "error": (
+                    "Edit removes required template variables. "
+                    "Re-insert them from the chip strip and try again."
+                ),
+                "missing_vars": missing,
+                "extra_vars": extra,
+            }), 400
+
+        # If the override is empty (admin sent no fields, or sent a body
+        # identical to base) it's effectively a reset — clear instead of
+        # writing an empty file.
+        if not override:
+            prompt_loader.clear_override(prompt_name)
+        else:
+            ok = prompt_loader.write_override(prompt_name, override)
+            if not ok:
+                return jsonify({
+                    "success": False,
+                    "error": "Failed to write override file (check disk perms / logs)",
+                }), 500
+
+        return jsonify({
+            "success": True,
+            "prompt": _detail(prompt_name),
+            "extra_vars": extra,  # surfaced as a yellow-warning toast in the UI
+        }), 200
+    except Exception as e:
+        current_app.logger.error("Error updating prompt %s: %s", prompt_name, e)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@settings_bp.route('/settings/prompts/<prompt_name>/override', methods=['DELETE'])
+@require_admin
+def reset_prompt(prompt_name: str):
+    """Drop the override file. Returns the now-effective (shipped) config."""
+    try:
+        if prompt_loader.get_prompt_default_config(prompt_name) is None:
+            return jsonify({
+                "success": False,
+                "error": f"Unknown prompt: {prompt_name}",
+            }), 404
+        ok = prompt_loader.clear_override(prompt_name)
+        if not ok:
+            return jsonify({
+                "success": False,
+                "error": "Failed to delete override file",
+            }), 500
+        return jsonify({"success": True, "prompt": _detail(prompt_name)}), 200
+    except Exception as e:
+        current_app.logger.error("Error resetting prompt %s: %s", prompt_name, e)
+        return jsonify({"success": False, "error": str(e)}), 500

--- a/backend/app/config/prompt_loader.py
+++ b/backend/app/config/prompt_loader.py
@@ -100,31 +100,118 @@ class PromptLoader:
         """Initialize the prompt service."""
         self.prompts_dir = Config.DATA_DIR / "prompts"
         self.projects_dir = Config.PROJECTS_DIR
+        # Sibling of prompts_dir. Persisted via the same `backend-data`
+        # Docker volume but **not** clobbered by entrypoint.sh's
+        # `cp /app/_prompts_staging/* data/prompts/`. Admin edits land
+        # here so they survive container redeploys.
+        self.overrides_dir = Config.DATA_DIR / "prompt_overrides"
 
-        # Ensure prompts directory exists
+        # Ensure both directories exist
         self.prompts_dir.mkdir(exist_ok=True, parents=True)
+        self.overrides_dir.mkdir(exist_ok=True, parents=True)
+
+    # ────────────────────────────────────────────────────────────────
+    # Override resolution helpers (Roadmap #16 — admin-editable prompts).
+    # Overrides live alongside the shipped defaults but in a sibling
+    # directory that the container entrypoint doesn't clobber. The
+    # resolver merges {**base, **override} so an override file only
+    # needs the fields the admin actually changed.
+    # ────────────────────────────────────────────────────────────────
+
+    def _override_path(self, prompt_name: str) -> Path:
+        return self.overrides_dir / f"{prompt_name}_prompt.json"
+
+    def _load_override(self, prompt_name: str) -> Optional[Dict[str, Any]]:
+        """Read the override file for ``prompt_name``, or return ``None``."""
+        path = self._override_path(prompt_name)
+        if not path.exists():
+            return None
+        try:
+            with open(path, 'r') as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                logger.warning("Override %s is not a JSON object — ignoring", path)
+                return None
+            return data
+        except (json.JSONDecodeError, IOError) as e:
+            logger.error("Failed to read override %s: %s", path, e)
+            return None
+
+    def has_override(self, prompt_name: str) -> bool:
+        """True iff an admin override file exists for this prompt."""
+        return self._override_path(prompt_name).exists()
+
+    def write_override(self, prompt_name: str, override: Dict[str, Any]) -> bool:
+        """
+        Persist an admin override. Caller is responsible for validation
+        (see ``prompt_var_utils.validate_edit``) — this just writes to disk.
+        """
+        path = self._override_path(prompt_name)
+        try:
+            with open(path, 'w') as f:
+                json.dump(override, f, indent=2)
+            return True
+        except IOError as e:
+            logger.error("Failed to write override %s: %s", path, e)
+            return False
+
+    def clear_override(self, prompt_name: str) -> bool:
+        """Delete the override file. Returns False only on a real I/O error."""
+        path = self._override_path(prompt_name)
+        if not path.exists():
+            return True
+        try:
+            path.unlink()
+            return True
+        except IOError as e:
+            logger.error("Failed to delete override %s: %s", path, e)
+            return False
+
+    def _load_base(self, prompt_name: str) -> Optional[Dict[str, Any]]:
+        """Load the shipped default for ``prompt_name``, no merge."""
+        prompt_file = self.prompts_dir / f"{prompt_name}_prompt.json"
+        try:
+            with open(prompt_file, 'r') as f:
+                data = json.load(f)
+            # Legacy format compat
+            if "prompt" in data and "system_prompt" not in data:
+                data["system_prompt"] = data.pop("prompt")
+            return data
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+
+    def get_prompt_default_config(self, prompt_name: str) -> Optional[Dict[str, Any]]:
+        """
+        Return the shipped default for a prompt, ignoring any admin override.
+
+        Used by the Admin Settings → Prompts editor to show a "compare to
+        default" diff and to compute the canonical required-variable list.
+        """
+        base = self._load_base(prompt_name)
+        if base is None:
+            return None
+        return PromptConfig(base, prompt_name=prompt_name)
 
     def get_default_prompt_config(self) -> Dict[str, Any]:
         """
         Load the full default prompt configuration.
 
         Educational Note: Returns the complete prompt config including
-        model, max_tokens, temperature, and system_prompt. This allows
-        services to use consistent settings from a single source.
+        model, max_tokens, temperature, and system_prompt. Resolves
+        admin overrides — same path ``get_prompt_config`` uses.
 
         Returns:
             Dict with all prompt config fields
         """
-        default_prompt_file = self.prompts_dir / "default_prompt.json"
-
-        with open(default_prompt_file, 'r') as f:
-            prompt_data = json.load(f)
-
-            # Handle legacy format where "prompt" was used instead of "system_prompt"
-            if "prompt" in prompt_data and "system_prompt" not in prompt_data:
-                prompt_data["system_prompt"] = prompt_data.pop("prompt")
-
-            return PromptConfig(prompt_data, prompt_name="default")
+        config = self.get_prompt_config("default")
+        if config is None:
+            # Should never happen — default_prompt.json ships with the repo
+            # — but if it ever does, fail loudly rather than returning None
+            # silently and breaking every chat downstream.
+            raise FileNotFoundError(
+                "default_prompt.json missing from prompts directory"
+            )
+        return config
 
     def get_default_prompt(self) -> str:
         """
@@ -291,35 +378,31 @@ class PromptLoader:
 
     def get_prompt_config(self, prompt_name: str) -> Optional[Dict[str, Any]]:
         """
-        Load full prompt configuration by name.
+        Load full prompt configuration by name, with admin override merged.
 
-        Educational Note: Loads the complete prompt config including
-        model, max_tokens, temperature, system_prompt, and user_message.
-        Used by services like memory_service, summary_service for
-        specialized AI tasks.
-
-        Args:
-            prompt_name: Name of the prompt file (without _prompt.json suffix)
-                        e.g., "memory" loads "memory_prompt.json"
+        Resolution order:
+          1. ``data/prompts/<name>_prompt.json``  (shipped default)
+          2. ``data/prompt_overrides/<name>_prompt.json`` (admin override,
+             merged on top — only fields the admin edited need to be
+             present in the override file)
 
         Returns:
-            Full prompt config dict, or None if not found
+            Full prompt config dict, or None if neither file exists.
         """
-        prompt_file = self.prompts_dir / f"{prompt_name}_prompt.json"
-
-        try:
-            with open(prompt_file, 'r') as f:
-                return PromptConfig(json.load(f), prompt_name=prompt_name)
-        except (FileNotFoundError, json.JSONDecodeError):
+        base = self._load_base(prompt_name)
+        if base is None:
             return None
+        override = self._load_override(prompt_name) or {}
+        merged = {**base, **override}
+        return PromptConfig(merged, prompt_name=prompt_name)
 
     def list_all_prompts(self) -> list[Dict[str, Any]]:
         """
         List all prompt configurations from the prompts directory.
 
-        Educational Note: This dynamically reads all *_prompt.json files
-        from the prompts directory, making it easy to add new prompts
-        without code changes.
+        Each entry is the *effective* config (base merged with any admin
+        override) plus a ``has_override`` boolean and a ``prompt_name``
+        suitable for the admin editor URL.
 
         Returns:
             List of prompt config dicts with all fields
@@ -332,16 +415,27 @@ class PromptLoader:
         for prompt_file in prompt_files:
             try:
                 with open(prompt_file, 'r') as f:
-                    prompt_data = json.load(f)
+                    base_data = json.load(f)
 
                     # Handle legacy format where "prompt" was used instead of "system_prompt"
-                    if "prompt" in prompt_data and "system_prompt" not in prompt_data:
-                        prompt_data["system_prompt"] = prompt_data.pop("prompt")
+                    if "prompt" in base_data and "system_prompt" not in base_data:
+                        base_data["system_prompt"] = base_data.pop("prompt")
 
-                    # Add filename for reference
-                    prompt_data["filename"] = prompt_file.name
+                    # `prompt_name` is the filename stripped of "_prompt.json"
+                    # — this is what every other API in this module uses
+                    # as the lookup key.
+                    prompt_name = prompt_file.stem
+                    if prompt_name.endswith("_prompt"):
+                        prompt_name = prompt_name[: -len("_prompt")]
 
-                    prompts.append(prompt_data)
+                    override = self._load_override(prompt_name) or {}
+                    effective = {**base_data, **override}
+
+                    effective["filename"] = prompt_file.name
+                    effective["prompt_name"] = prompt_name
+                    effective["has_override"] = bool(override)
+
+                    prompts.append(effective)
             except (json.JSONDecodeError, IOError) as e:
                 logger.error("Failed to load prompt %s: %s", prompt_file, e)
                 continue

--- a/backend/app/config/prompt_referenced_by.py
+++ b/backend/app/config/prompt_referenced_by.py
@@ -1,0 +1,65 @@
+"""
+Static map of prompt name → service file paths that consume it.
+
+Surfaced in the admin Prompts editor so an operator editing
+``memory_prompt`` can see at a glance "this affects
+``memory_service.merge_memory()``" instead of guessing.
+
+Maintained by hand — when a new prompt is added or moved, update this map.
+The list is informational; an empty array just hides the breadcrumb in the
+UI, nothing else breaks.
+
+Tip when editing: ``grep -r "get_prompt_config(\"<prompt_name>\")"
+backend/app/services/`` will show every caller.
+"""
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+PROMPT_REFERENCED_BY: Dict[str, List[str]] = {
+    # Chat
+    "default": ["app/services/chat_services/main_chat_service.py"],
+    "chat_naming": ["app/services/data_services/chat_naming_service.py"],
+    "memory": ["app/services/data_services/memory_service.py"],
+
+    # Source extraction
+    "pdf_extraction": ["app/services/ai_services/pdf_service.py"],
+    "pptx_extraction": ["app/services/ai_services/pptx_service.py"],
+    "image_extraction": ["app/services/ai_services/image_service.py"],
+    "csv_processor": ["app/services/source_services/source_processing/csv_processor.py"],
+    "summary": ["app/services/data_services/summary_service.py"],
+
+    # Studio — content generation
+    "ad_creative": ["app/services/studio_services/ad_creative_service.py"],
+    "audio_script": ["app/services/studio_services/audio_overview_service.py"],
+    "blog_agent": ["app/services/studio_services/blog_service.py"],
+    "business_report_agent": ["app/services/studio_services/business_report_service.py"],
+    "component_agent": ["app/services/studio_services/component_service.py"],
+    "email_agent": ["app/services/studio_services/email_service.py"],
+    "flash_cards": ["app/services/studio_services/flash_cards_service.py"],
+    "flow_diagram": ["app/services/studio_services/flow_diagram_service.py"],
+    "infographic": ["app/services/studio_services/infographic_service.py"],
+    "marketing_strategy_agent": ["app/services/studio_services/marketing_strategy_service.py"],
+    "mind_map": ["app/services/studio_services/mind_map_service.py"],
+    "prd_agent": ["app/services/studio_services/prd_service.py"],
+    "presentation_agent": ["app/services/studio_services/presentation_service.py"],
+    "quiz": ["app/services/studio_services/quiz_service.py"],
+    "social_posts": ["app/services/studio_services/social_posts_service.py"],
+    "video": ["app/services/studio_services/video_service.py"],
+    "website_agent": ["app/services/studio_services/website_service.py"],
+    "wireframe": ["app/services/studio_services/wireframe_service.py"],
+    "wireframe_agent": ["app/services/studio_services/wireframe_service.py"],
+
+    # Query / data agents
+    "csv_analyzer_agent": ["app/services/ai_agents/csv_analyzer_agent.py"],
+    "database_analyzer_agent": ["app/services/ai_agents/database_analyzer_agent.py"],
+    "freshdesk_analyzer_agent": ["app/services/ai_agents/freshdesk_analyzer_agent.py"],
+    "deep_research_agent": ["app/services/ai_agents/deep_research_agent.py"],
+    "web_agent": ["app/services/ai_agents/web_agent_service.py"],
+}
+
+
+def referenced_by(prompt_name: str) -> List[str]:
+    """Return the list of file paths that consume this prompt, or []."""
+    return list(PROMPT_REFERENCED_BY.get(prompt_name, []))

--- a/backend/app/utils/prompt_var_utils.py
+++ b/backend/app/utils/prompt_var_utils.py
@@ -1,0 +1,110 @@
+"""
+Prompt variable utilities (Roadmap #16).
+
+The admin-editable prompts feature lets operators rewrite the body of any
+shipped prompt. A handful of those prompts are templates consumed by
+``str.format(...)`` calls inside services — e.g. ``memory_service`` does
+``user_message.format(memory_type=..., current_memory=..., new_memory=...,
+reason=...)``. If an admin removes one of those tokens during an edit, the
+``.format`` call raises ``KeyError`` at runtime and the feature breaks
+silently for end users.
+
+This module provides:
+
+* ``extract_vars(text)``   — pull single-token ``{var_name}`` placeholders
+                             out of a prompt body, ignoring multi-token /
+                             JSON-shaped curly braces.
+* ``required_vars(base)``  — compute the set of vars that *must* remain in
+                             a given prompt config (system_prompt +
+                             user_message + user_message_template).
+* ``validate_edit(...)``   — used by the PUT handler to reject saves that
+                             would drop required tokens.
+"""
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Tuple
+
+# Single-token placeholder. Lowercase + underscore + digits, must start
+# with a letter or underscore — matches Python identifier conventions, so
+# JSON shapes like ``{"key": "value"}`` (which contain colons and quotes)
+# don't accidentally match.
+_VAR_PATTERN = re.compile(r"\{([a-z_][a-z0-9_]*)\}")
+
+
+# Fields we look at when computing required vars / validating edits. Some
+# prompts use ``user_message``, others ``user_message_template`` — accept
+# both.
+_TEMPLATED_FIELDS = ("system_prompt", "user_message", "user_message_template")
+
+
+def extract_vars(text: str) -> List[str]:
+    """
+    Return the deduped list of placeholder names in document order.
+
+    Empty input or a non-string returns an empty list. Duplicates are
+    collapsed but order of first occurrence is preserved so messages
+    like "Missing: {a}, {b}" are stable across runs.
+    """
+    if not isinstance(text, str) or not text:
+        return []
+    seen: List[str] = []
+    in_set: set[str] = set()
+    for match in _VAR_PATTERN.finditer(text):
+        name = match.group(1)
+        if name not in in_set:
+            in_set.add(name)
+            seen.append(name)
+    return seen
+
+
+def _combined_template_text(config: Dict[str, object]) -> str:
+    """Concatenate the templated fields of a prompt config for var scanning."""
+    parts: List[str] = []
+    for field in _TEMPLATED_FIELDS:
+        value = config.get(field)
+        if isinstance(value, str) and value:
+            parts.append(value)
+    return "\n".join(parts)
+
+
+def required_vars(base_config: Dict[str, object]) -> List[str]:
+    """
+    Return the variables that must remain in any edited version of this prompt.
+
+    "Required" = present in the *base* config (i.e., the shipped default).
+    Adding new variables in an override is fine — only removing existing
+    ones is a problem because some service in the codebase already calls
+    ``.format(**that_var=...)`` and would crash on KeyError.
+    """
+    return extract_vars(_combined_template_text(base_config))
+
+
+def validate_edit(
+    base_config: Dict[str, object],
+    edited_config: Dict[str, object],
+) -> Tuple[bool, List[str], List[str]]:
+    """
+    Compare the edited prompt against the base and report differences.
+
+    Returns ``(ok, missing, extra)``:
+      * ``missing`` — required vars that have disappeared from the edit.
+        Non-empty ⇒ ``ok`` is False; the save must be rejected.
+      * ``extra``   — new vars the admin introduced that the base didn't
+                      have. Informational only — admins are free to add
+                      placeholders, with the caveat that the consuming
+                      service has to supply them. Surfaced in the UI as a
+                      yellow warning.
+    """
+    required = set(required_vars(base_config))
+
+    # For "present" we look at the merged effective config (base ∪ override
+    # for the templated fields the admin touched). The caller passes
+    # ``edited_config`` which is the merged result — already contains the
+    # fields the admin updated, falling through to base for the rest.
+    present = set(extract_vars(_combined_template_text(edited_config)))
+
+    missing = sorted(required - present)
+    extra = sorted(present - required)
+    ok = not missing
+    return ok, missing, extra

--- a/frontend/src/components/dashboard/AppSettings.tsx
+++ b/frontend/src/components/dashboard/AppSettings.tsx
@@ -4,7 +4,7 @@
  * Features: Profile, Team Management, API Keys, Integrations, System Settings.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -20,6 +20,7 @@ import {
   SystemSection,
   DesignSection,
   ModelsSection,
+  PromptsSection,
 } from '../settings/sections';
 
 interface AppSettingsProps {
@@ -47,7 +48,7 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
 
   // Handle section change with admin check
   const handleSectionChange = (section: SettingsSection) => {
-    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'design', 'system'];
+    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'prompts', 'design', 'system'];
     if (!isAdmin && adminOnlySections.includes(section)) {
       return; // Prevent non-admins from switching to admin sections
     }
@@ -59,6 +60,23 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
     });
     setActiveSection(section);
   };
+
+  // Cross-section navigation hook — PromptEditor's "Edit in Models →"
+  // link dispatches this event so the user jumps from prompt editing
+  // straight to the model picker without closing the dialog.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const next = (e as CustomEvent<SettingsSection>).detail;
+      if (!next) return;
+      handleSectionChange(next);
+    };
+    window.addEventListener('noobbook:settings:switch-section', handler);
+    return () => window.removeEventListener('noobbook:settings:switch-section', handler);
+    // handleSectionChange is stable for our purposes (closes over isAdmin
+    // which doesn't change during a single dialog session). Re-listening
+    // on every isAdmin flip is fine and rare.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdmin]);
 
   // Reset to profile when closing (so next open starts fresh)
   const handleOpenChange = (isOpen: boolean) => {
@@ -78,6 +96,8 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
         return isAdmin ? <ApiKeysSection /> : null;
       case 'models':
         return isAdmin ? <ModelsSection /> : null;
+      case 'prompts':
+        return isAdmin ? <PromptsSection /> : null;
       case 'integrations':
         return <IntegrationsSection isAdmin={isAdmin} />;
       case 'design':
@@ -90,7 +110,7 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
   };
 
   const visibleSections = Array.from(mountedSections).filter((section) => {
-    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'design', 'system'];
+    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'prompts', 'design', 'system'];
     return isAdmin || !adminOnlySections.includes(section);
   });
 

--- a/frontend/src/components/settings/SettingsSidebar.tsx
+++ b/frontend/src/components/settings/SettingsSidebar.tsx
@@ -4,10 +4,10 @@
  */
 
 import React from 'react';
-import { User, Users, Key, Plug, Gear, Palette, Brain } from '@phosphor-icons/react';
+import { User, Users, Key, Plug, Gear, Palette, Brain, TextAa } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
 
-export type SettingsSection = 'profile' | 'team' | 'api-keys' | 'models' | 'integrations' | 'design' | 'system';
+export type SettingsSection = 'profile' | 'team' | 'api-keys' | 'models' | 'prompts' | 'integrations' | 'design' | 'system';
 
 interface SettingsSidebarProps {
   activeSection: SettingsSection;
@@ -28,6 +28,7 @@ const sidebarItems: SidebarItem[] = [
   { id: 'team', label: 'Team', icon: <Users size={18} />, category: 'workspace', adminOnly: true },
   { id: 'api-keys', label: 'API Keys', icon: <Key size={18} />, category: 'workspace', adminOnly: true },
   { id: 'models', label: 'Models', icon: <Brain size={18} />, category: 'workspace', adminOnly: true },
+  { id: 'prompts', label: 'Prompts', icon: <TextAa size={18} />, category: 'workspace', adminOnly: true },
   { id: 'integrations', label: 'Integrations', icon: <Plug size={18} />, category: 'workspace' },
   { id: 'design', label: 'Design', icon: <Palette size={18} />, category: 'workspace', adminOnly: true },
   { id: 'system', label: 'System', icon: <Gear size={18} />, category: 'workspace', adminOnly: true },

--- a/frontend/src/components/settings/sections/PromptEditor.tsx
+++ b/frontend/src/components/settings/sections/PromptEditor.tsx
@@ -144,7 +144,14 @@ export const PromptEditor: React.FC<PromptEditorProps> = ({
   );
 
   const dirty = useMemo(() => isDirty(form, detail), [form, detail]);
-  const canSave = dirty && missing.length === 0 && !saving;
+  // Empty numerics are not a valid save state. With the backend's merge
+  // semantics, a PUT that omits max_tokens/temperature preserves the
+  // existing override value — meaning a "cleared" input would silently
+  // no-op while showing a success toast. The "use default" link on
+  // each NumericKnob is the real path to un-override; we point at it
+  // when the admin lands here.
+  const numericsBlank = form.max_tokens === '' || form.temperature === '';
+  const canSave = dirty && missing.length === 0 && !numericsBlank && !saving;
 
   // Refs for the textareas so we can insert chip tokens at the caret.
   const systemRef = useRef<HTMLTextAreaElement | null>(null);
@@ -380,7 +387,18 @@ export const PromptEditor: React.FC<PromptEditorProps> = ({
           )}
 
           {/* Validation indicator */}
-          <ValidationLine missing={missing} extras={extras} requiredCount={requiredVars.length} />
+          <ValidationLine
+            missing={missing}
+            extras={extras}
+            requiredCount={requiredVars.length}
+            blankNumeric={
+              form.max_tokens === ''
+                ? 'max_tokens'
+                : form.temperature === ''
+                  ? 'temperature'
+                  : null
+            }
+          />
 
           {/* Diff / view default */}
           <DiffPanel
@@ -589,13 +607,34 @@ interface ValidationLineProps {
   missing: string[];
   extras: string[];
   requiredCount: number;
+  /** Name of the cleared numeric field, if any — drives the hint pointing
+   * at the "use default" link, since saving an empty numeric would be
+   * a silent no-op under the backend's merge semantics. */
+  blankNumeric: 'max_tokens' | 'temperature' | null;
 }
 
 const ValidationLine: React.FC<ValidationLineProps> = ({
   missing,
   extras,
   requiredCount,
+  blankNumeric,
 }) => {
+  // Blank numeric is a hard save block — surface it before everything
+  // else so the admin knows what to fix.
+  if (blankNumeric) {
+    return (
+      <div className="flex items-start gap-2 text-[12.5px] text-rose-700">
+        <WarningCircle size={14} weight="fill" className="mt-0.5 flex-shrink-0" />
+        <div>
+          <span className="font-medium">{blankNumeric} is empty.</span>{' '}
+          Type a value, or use the{' '}
+          <span className="font-mono text-[12px]">use default</span>{' '}
+          link above the field to clear your override.
+        </div>
+      </div>
+    );
+  }
+
   if (requiredCount === 0 && extras.length === 0) {
     return (
       <div className="text-[12px] text-stone-400 italic">

--- a/frontend/src/components/settings/sections/PromptEditor.tsx
+++ b/frontend/src/components/settings/sections/PromptEditor.tsx
@@ -1,0 +1,751 @@
+/**
+ * PromptEditor — Admin Settings → Prompts detail pane (Roadmap #16).
+ *
+ * Aesthetic. Editorial / library: warm cream backdrop, fine rules,
+ * generous breathing room. The required-variable chips are the only
+ * saturated accent — small monospace pills that hover-glow to invite a
+ * click. Validation indicator stays tiny and confident, never alarmed.
+ *
+ * Information hierarchy.
+ *   1. Header strip   — name, category-bucket pill, model meta + "Edit
+ *                       in Models →" link, "Reset" button if overridden.
+ *   2. Numerics       — max_tokens + temperature side-by-side; both
+ *                       show the shipped default as ghost text and a
+ *                       "use default" link when changed.
+ *   3. Body           — system_prompt textarea (always) with chip strip
+ *                       above it. user_message / user_message_template
+ *                       only when the base has it (chip strip again).
+ *   4. Validation     — single-line indicator under the body. Green
+ *                       check / red dot / yellow extra-vars warning.
+ *   5. Footer         — Save + Discard, only when dirty.
+ *   6. Diff           — collapsible "View shipped default" at the bottom.
+ *                       Side-by-side stacked when overridden.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ArrowSquareOut,
+  Check,
+  CircleNotch,
+  Sparkle,
+  Warning,
+  WarningCircle,
+} from '@phosphor-icons/react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  promptsAPI,
+  type PromptDetail,
+  type UpdatePromptInput,
+} from '@/lib/api/admin/prompts';
+import { categoryFor, CATEGORY_LABELS, extractVars, insertAtCursor, missingVars } from './promptsLib';
+import { createLogger } from '@/lib/logger';
+import axios from 'axios';
+
+const log = createLogger('prompt-editor');
+
+interface PromptEditorProps {
+  detail: PromptDetail;
+  /** Bubble updated detail upward so the list rail can refresh its "Edited" pill. */
+  onChange: (next: PromptDetail) => void;
+  /** Switch the parent Settings dialog to a different section (used by "Edit in Models →"). */
+  onSwitchSection?: (section: 'models') => void;
+}
+
+interface FormState {
+  system_prompt: string;
+  user_message: string;
+  user_message_template: string;
+  max_tokens: number | '';
+  temperature: number | '';
+}
+
+const stringField = (value: unknown): string =>
+  typeof value === 'string' ? value : '';
+
+const numberField = (value: unknown): number | '' =>
+  typeof value === 'number' && Number.isFinite(value) ? value : '';
+
+function formFromDetail(detail: PromptDetail): FormState {
+  const eff = detail.effective || {};
+  return {
+    system_prompt: stringField(eff.system_prompt),
+    user_message: stringField(eff.user_message),
+    user_message_template: stringField(eff.user_message_template),
+    max_tokens: numberField(eff.max_tokens),
+    temperature: numberField(eff.temperature),
+  };
+}
+
+/** True iff the form differs from `detail.effective`. */
+function isDirty(form: FormState, detail: PromptDetail): boolean {
+  const eff = formFromDetail(detail);
+  return (
+    form.system_prompt !== eff.system_prompt ||
+    form.user_message !== eff.user_message ||
+    form.user_message_template !== eff.user_message_template ||
+    form.max_tokens !== eff.max_tokens ||
+    form.temperature !== eff.temperature
+  );
+}
+
+export const PromptEditor: React.FC<PromptEditorProps> = ({
+  detail,
+  onChange,
+  onSwitchSection,
+}) => {
+  const { success, error } = useToast();
+
+  const [form, setForm] = useState<FormState>(() => formFromDetail(detail));
+  const [saving, setSaving] = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [diffOpen, setDiffOpen] = useState(false);
+
+  // Re-seed when the loaded detail changes (admin clicked a different prompt).
+  useEffect(() => {
+    setForm(formFromDetail(detail));
+    setDiffOpen(false);
+  }, [detail.prompt_name, detail.effective]);
+
+  const base = detail.base || {};
+  const requiredVars = detail.required_vars;
+  const hasUserMessage = typeof base.user_message === 'string';
+  const hasUserMessageTemplate = typeof base.user_message_template === 'string';
+
+  // Live-extract present vars from the merged edited body so the chip
+  // strip + validation indicator stay in sync as the admin types.
+  const presentVars = useMemo(() => {
+    return extractVars(
+      [form.system_prompt, form.user_message, form.user_message_template]
+        .filter(Boolean)
+        .join('\n'),
+    );
+  }, [form.system_prompt, form.user_message, form.user_message_template]);
+
+  const missing = useMemo(
+    () => missingVars(requiredVars, presentVars),
+    [requiredVars, presentVars],
+  );
+  const extras = useMemo(
+    () => presentVars.filter((v) => !requiredVars.includes(v)),
+    [presentVars, requiredVars],
+  );
+
+  const dirty = useMemo(() => isDirty(form, detail), [form, detail]);
+  const canSave = dirty && missing.length === 0 && !saving;
+
+  // Refs for the textareas so we can insert chip tokens at the caret.
+  const systemRef = useRef<HTMLTextAreaElement | null>(null);
+  const userMsgRef = useRef<HTMLTextAreaElement | null>(null);
+  const userTplRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const handleChipInsert = (
+    field: 'system_prompt' | 'user_message' | 'user_message_template',
+    varName: string,
+  ) => {
+    const ref =
+      field === 'system_prompt'
+        ? systemRef.current
+        : field === 'user_message'
+          ? userMsgRef.current
+          : userTplRef.current;
+    if (!ref) return;
+    const cursor = ref.selectionStart ?? form[field].length;
+    const { value: nextValue, cursor: nextCursor } = insertAtCursor(
+      form[field],
+      varName,
+      cursor,
+    );
+    setForm((prev) => ({ ...prev, [field]: nextValue }));
+    // Restore focus + caret after React commits.
+    requestAnimationFrame(() => {
+      ref.focus();
+      ref.setSelectionRange(nextCursor, nextCursor);
+    });
+  };
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    const body: UpdatePromptInput = {};
+    const eff = formFromDetail(detail);
+    if (form.system_prompt !== eff.system_prompt) body.system_prompt = form.system_prompt;
+    if (hasUserMessage && form.user_message !== eff.user_message) {
+      body.user_message = form.user_message;
+    }
+    if (hasUserMessageTemplate && form.user_message_template !== eff.user_message_template) {
+      body.user_message_template = form.user_message_template;
+    }
+    if (form.max_tokens !== eff.max_tokens && form.max_tokens !== '') {
+      body.max_tokens = Number(form.max_tokens);
+    }
+    if (form.temperature !== eff.temperature && form.temperature !== '') {
+      body.temperature = Number(form.temperature);
+    }
+
+    try {
+      setSaving(true);
+      const res = await promptsAPI.update(detail.prompt_name, body);
+      onChange(res.data.prompt);
+      if (res.data.extra_vars && res.data.extra_vars.length > 0) {
+        success(
+          `Saved. Heads up: new variables added (${res.data.extra_vars
+            .map((v) => `{${v}}`)
+            .join(', ')}) — make sure the consuming service supplies them.`,
+        );
+      } else {
+        success('Prompt saved');
+      }
+    } catch (err) {
+      const msg = axios.isAxiosError(err)
+        ? (err.response?.data as { error?: string; missing_vars?: string[] })?.error
+        : null;
+      log.error({ err, prompt: detail.prompt_name }, 'save failed');
+      error(msg || 'Save failed — please try again');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDiscard = () => {
+    setForm(formFromDetail(detail));
+  };
+
+  const handleReset = async () => {
+    try {
+      setResetting(true);
+      const res = await promptsAPI.reset(detail.prompt_name);
+      onChange(res.data.prompt);
+      setResetOpen(false);
+      success('Prompt reset to shipped default');
+    } catch (err) {
+      log.error({ err, prompt: detail.prompt_name }, 'reset failed');
+      error('Reset failed — please try again');
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  const category = categoryFor(detail.prompt_name);
+  const displayName = (base.name as string | undefined) || detail.prompt_name;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* ── Header strip ─────────────────────────────────────────── */}
+      <div className="flex-shrink-0 border-b border-stone-200 px-6 py-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-[10px] uppercase tracking-[0.14em] text-stone-500 font-medium">
+                {CATEGORY_LABELS[category]}
+              </span>
+              {detail.override && (
+                <span className="inline-flex items-center gap-1 px-1.5 py-px rounded-full text-[10px] uppercase tracking-wider font-medium bg-amber-50 text-amber-800 border border-amber-200/80">
+                  <Sparkle size={9} weight="fill" />
+                  Edited
+                </span>
+              )}
+            </div>
+            <h2 className="text-lg font-semibold text-stone-900 leading-tight font-serif">
+              {displayName}
+            </h2>
+            {base.description ? (
+              <p className="text-[13px] text-stone-600 mt-1.5 leading-relaxed max-w-2xl">
+                {String(base.description)}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex-shrink-0 flex items-center gap-2">
+            {detail.override && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setResetOpen(true)}
+                className="text-xs text-stone-600 hover:text-stone-900"
+              >
+                Reset to default
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Model + referenced-by line */}
+        <div className="mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-[11.5px] text-stone-500">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="text-stone-400">Model</span>
+            <span className="font-mono text-stone-700">
+              {detail.effective.model ?? base.model ?? '—'}
+            </span>
+            {onSwitchSection && (
+              <button
+                type="button"
+                onClick={() => onSwitchSection('models')}
+                className="ml-1 inline-flex items-center gap-0.5 text-amber-700 hover:text-amber-800 underline-offset-2 hover:underline"
+              >
+                Edit in Models
+                <ArrowSquareOut size={11} />
+              </button>
+            )}
+          </span>
+          {detail.referenced_by.length > 0 && (
+            <span className="inline-flex items-center gap-1.5 min-w-0">
+              <span className="text-stone-400">Used by</span>
+              <span className="font-mono text-stone-700 truncate">
+                {detail.referenced_by[0].split('/').slice(-1)[0]}
+                {detail.referenced_by.length > 1
+                  ? ` +${detail.referenced_by.length - 1}`
+                  : ''}
+              </span>
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* ── Body ─────────────────────────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="px-6 py-6 space-y-7 max-w-3xl">
+          {/* Numerics */}
+          <div className="grid grid-cols-2 gap-4">
+            <NumericKnob
+              label="max_tokens"
+              value={form.max_tokens}
+              defaultValue={numberField(base.max_tokens)}
+              integer
+              onChange={(v) => setForm((p) => ({ ...p, max_tokens: v }))}
+            />
+            <NumericKnob
+              label="temperature"
+              value={form.temperature}
+              defaultValue={numberField(base.temperature)}
+              step={0.1}
+              min={0}
+              max={2}
+              onChange={(v) => setForm((p) => ({ ...p, temperature: v }))}
+            />
+          </div>
+
+          {/* system_prompt */}
+          <PromptField
+            label="system_prompt"
+            description="The instructions Claude reads first. Sets behavior, tone, output format."
+            value={form.system_prompt}
+            requiredVars={requiredVars}
+            currentVars={presentVars}
+            textareaRef={systemRef}
+            onChange={(v) => setForm((p) => ({ ...p, system_prompt: v }))}
+            onChipClick={(v) => handleChipInsert('system_prompt', v)}
+            minRows={16}
+          />
+
+          {/* user_message */}
+          {hasUserMessage && (
+            <PromptField
+              label="user_message"
+              description="Templated message body. Variables in curly braces are filled at runtime by the consuming service."
+              value={form.user_message}
+              requiredVars={requiredVars}
+              currentVars={presentVars}
+              textareaRef={userMsgRef}
+              onChange={(v) => setForm((p) => ({ ...p, user_message: v }))}
+              onChipClick={(v) => handleChipInsert('user_message', v)}
+              minRows={6}
+            />
+          )}
+
+          {/* user_message_template */}
+          {hasUserMessageTemplate && (
+            <PromptField
+              label="user_message_template"
+              description="Template body with runtime variables."
+              value={form.user_message_template}
+              requiredVars={requiredVars}
+              currentVars={presentVars}
+              textareaRef={userTplRef}
+              onChange={(v) => setForm((p) => ({ ...p, user_message_template: v }))}
+              onChipClick={(v) => handleChipInsert('user_message_template', v)}
+              minRows={6}
+            />
+          )}
+
+          {/* Validation indicator */}
+          <ValidationLine missing={missing} extras={extras} requiredCount={requiredVars.length} />
+
+          {/* Diff / view default */}
+          <DiffPanel
+            open={diffOpen}
+            onToggle={() => setDiffOpen((v) => !v)}
+            base={base}
+            override={detail.override}
+            hasUserMessage={hasUserMessage}
+            hasUserMessageTemplate={hasUserMessageTemplate}
+          />
+        </div>
+      </div>
+
+      {/* ── Footer ───────────────────────────────────────────────── */}
+      {dirty && (
+        <div className="flex-shrink-0 border-t border-stone-200 bg-stone-50/60 px-6 py-3 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={handleDiscard}
+            disabled={saving}
+            className="text-xs text-stone-600 hover:text-stone-900 underline-offset-4 hover:underline disabled:opacity-50"
+          >
+            Discard changes
+          </button>
+          <Button onClick={handleSave} disabled={!canSave} size="sm" className="gap-1.5">
+            {saving ? <CircleNotch size={14} className="animate-spin" /> : null}
+            Save changes
+          </Button>
+        </div>
+      )}
+
+      {/* Reset confirm dialog */}
+      <Dialog open={resetOpen} onOpenChange={setResetOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Reset to shipped default?</DialogTitle>
+            <DialogDescription className="text-[13px] leading-relaxed">
+              This will delete your override for{' '}
+              <span className="font-mono text-stone-800">{detail.prompt_name}</span>{' '}
+              and revert the prompt to whatever ships with the current release.
+              You can re-apply your edits manually afterwards if needed.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setResetOpen(false)}
+              disabled={resetting}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleReset} disabled={resetting} className="gap-1.5">
+              {resetting ? <CircleNotch size={14} className="animate-spin" /> : null}
+              Reset
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+// ────────────────────────────────────────────────────────────────────
+// Subcomponents
+// ────────────────────────────────────────────────────────────────────
+
+interface NumericKnobProps {
+  label: string;
+  value: number | '';
+  defaultValue: number | '';
+  integer?: boolean;
+  step?: number;
+  min?: number;
+  max?: number;
+  onChange: (v: number | '') => void;
+}
+
+const NumericKnob: React.FC<NumericKnobProps> = ({
+  label,
+  value,
+  defaultValue,
+  integer = false,
+  step = 1,
+  min,
+  max,
+  onChange,
+}) => {
+  const isOverridden = value !== '' && value !== defaultValue;
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1.5">
+        <Label className="text-[11px] uppercase tracking-wider font-medium text-stone-500 font-mono">
+          {label}
+        </Label>
+        {isOverridden && defaultValue !== '' && (
+          <button
+            type="button"
+            onClick={() => onChange(defaultValue)}
+            className="text-[10.5px] text-amber-700 hover:text-amber-800 underline-offset-2 hover:underline"
+          >
+            use default ({defaultValue})
+          </button>
+        )}
+      </div>
+      <Input
+        type="number"
+        value={value}
+        step={integer ? 1 : step}
+        min={min}
+        max={max}
+        onChange={(e) => {
+          const raw = e.target.value;
+          if (raw === '') return onChange('');
+          const parsed = integer ? parseInt(raw, 10) : parseFloat(raw);
+          onChange(Number.isFinite(parsed) ? parsed : '');
+        }}
+        className="font-mono text-sm h-9"
+        placeholder={defaultValue !== '' ? `default: ${defaultValue}` : undefined}
+      />
+    </div>
+  );
+};
+
+interface PromptFieldProps {
+  label: string;
+  description: string;
+  value: string;
+  requiredVars: string[];
+  currentVars: string[];
+  textareaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
+  onChange: (v: string) => void;
+  onChipClick: (v: string) => void;
+  minRows: number;
+}
+
+const PromptField: React.FC<PromptFieldProps> = ({
+  label,
+  description,
+  value,
+  requiredVars,
+  currentVars,
+  textareaRef,
+  onChange,
+  onChipClick,
+  minRows,
+}) => {
+  const presentSet = new Set(currentVars);
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-1.5">
+        <Label className="text-[11px] uppercase tracking-wider font-medium text-stone-500 font-mono">
+          {label}
+        </Label>
+      </div>
+      <p className="text-[12px] text-stone-500 leading-relaxed mb-2.5">
+        {description}
+      </p>
+
+      {/* Required-variable chip strip — the design accent. */}
+      {requiredVars.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5 mb-2">
+          <span className="text-[10.5px] text-stone-400 mr-0.5">
+            Required:
+          </span>
+          {requiredVars.map((v) => {
+            const present = presentSet.has(v);
+            return (
+              <button
+                key={v}
+                type="button"
+                onClick={() => onChipClick(v)}
+                title={
+                  present
+                    ? `Insert another {${v}} at cursor`
+                    : `Missing — click to insert {${v}}`
+                }
+                className={[
+                  'group inline-flex items-center gap-1 px-2 py-0.5 rounded-md',
+                  'font-mono text-[11px] transition-all border cursor-pointer',
+                  present
+                    ? 'bg-amber-50/70 text-amber-900 border-amber-200/80 hover:bg-amber-100 hover:border-amber-300'
+                    : 'bg-rose-50 text-rose-700 border-rose-200 hover:bg-rose-100 hover:border-rose-300 ring-1 ring-rose-200/40',
+                ].join(' ')}
+              >
+                {!present && <WarningCircle size={10} weight="fill" className="opacity-80" />}
+                <span>{`{${v}}`}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={minRows}
+        spellCheck={false}
+        className="font-mono text-[12.5px] leading-[1.55] resize-y min-h-[8rem]"
+      />
+    </div>
+  );
+};
+
+interface ValidationLineProps {
+  missing: string[];
+  extras: string[];
+  requiredCount: number;
+}
+
+const ValidationLine: React.FC<ValidationLineProps> = ({
+  missing,
+  extras,
+  requiredCount,
+}) => {
+  if (requiredCount === 0 && extras.length === 0) {
+    return (
+      <div className="text-[12px] text-stone-400 italic">
+        No template variables in this prompt.
+      </div>
+    );
+  }
+
+  if (missing.length > 0) {
+    return (
+      <div className="flex items-start gap-2 text-[12.5px] text-rose-700">
+        <WarningCircle size={14} weight="fill" className="mt-0.5 flex-shrink-0" />
+        <div>
+          <span className="font-medium">Missing required variables: </span>
+          <span className="font-mono">
+            {missing.map((v) => `{${v}}`).join(', ')}
+          </span>
+          <p className="text-[11.5px] text-rose-600/90 mt-0.5">
+            Removing these would crash the consuming service at runtime. Click a
+            chip above to re-insert.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2 text-[12.5px] text-emerald-700">
+        <Check size={14} weight="bold" />
+        <span>
+          {requiredCount === 0
+            ? 'All required variables present'
+            : `All ${requiredCount} required variable${requiredCount === 1 ? '' : 's'} present`}
+        </span>
+      </div>
+      {extras.length > 0 && (
+        <div className="flex items-start gap-2 text-[11.5px] text-amber-700">
+          <Warning size={12} weight="fill" className="mt-0.5 flex-shrink-0" />
+          <span>
+            New variable{extras.length === 1 ? '' : 's'}{' '}
+            <span className="font-mono">
+              {extras.map((v) => `{${v}}`).join(', ')}
+            </span>{' '}
+            — make sure the consuming service supplies {extras.length === 1 ? 'it' : 'them'}.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface DiffPanelProps {
+  open: boolean;
+  onToggle: () => void;
+  base: PromptDetail['base'];
+  override: PromptDetail['override'];
+  hasUserMessage: boolean;
+  hasUserMessageTemplate: boolean;
+}
+
+const DiffPanel: React.FC<DiffPanelProps> = ({
+  open,
+  onToggle,
+  base,
+  override,
+  hasUserMessage,
+  hasUserMessageTemplate,
+}) => {
+  return (
+    <div className="border-t border-stone-200/80 pt-5 mt-2">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="text-[11.5px] uppercase tracking-[0.12em] text-stone-500 hover:text-stone-800 font-medium transition-colors inline-flex items-center gap-1.5"
+      >
+        <span>{open ? 'Hide' : 'View'} shipped default</span>
+        <span className="text-stone-400">{open ? '−' : '+'}</span>
+      </button>
+
+      {open && (
+        <div className="mt-4 space-y-4">
+          <DiffSection
+            label="system_prompt"
+            base={String(base.system_prompt ?? '')}
+            override={typeof override?.system_prompt === 'string' ? override.system_prompt : null}
+          />
+          {hasUserMessage && (
+            <DiffSection
+              label="user_message"
+              base={String(base.user_message ?? '')}
+              override={typeof override?.user_message === 'string' ? override.user_message : null}
+            />
+          )}
+          {hasUserMessageTemplate && (
+            <DiffSection
+              label="user_message_template"
+              base={String(base.user_message_template ?? '')}
+              override={
+                typeof override?.user_message_template === 'string'
+                  ? override.user_message_template
+                  : null
+              }
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface DiffSectionProps {
+  label: string;
+  base: string;
+  /** Null when no override has been written for this field. */
+  override: string | null;
+}
+
+const DiffSection: React.FC<DiffSectionProps> = ({ label, base, override }) => {
+  if (override === null) {
+    // No override for this field — just show the default.
+    return (
+      <div>
+        <div className="text-[11px] uppercase tracking-wider text-stone-500 font-mono mb-1.5">
+          {label} <span className="text-stone-400 normal-case tracking-normal">(default)</span>
+        </div>
+        <pre className="text-[11.5px] font-mono leading-[1.55] text-stone-700 bg-stone-50/70 border border-stone-200/70 rounded-md p-3 overflow-x-auto whitespace-pre-wrap">
+          {base || <span className="text-stone-400 italic">(empty)</span>}
+        </pre>
+      </div>
+    );
+  }
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <div>
+        <div className="text-[11px] uppercase tracking-wider text-stone-500 font-mono mb-1.5">
+          {label} <span className="text-stone-400 normal-case tracking-normal">(default)</span>
+        </div>
+        <pre className="text-[11.5px] font-mono leading-[1.55] text-stone-600 bg-stone-50/70 border border-stone-200/70 rounded-md p-3 overflow-x-auto whitespace-pre-wrap min-h-[6rem]">
+          {base || <span className="text-stone-400 italic">(empty)</span>}
+        </pre>
+      </div>
+      <div>
+        <div className="text-[11px] uppercase tracking-wider text-amber-800 font-mono mb-1.5">
+          {label} <span className="text-amber-700/80 normal-case tracking-normal">(your edit)</span>
+        </div>
+        <pre className="text-[11.5px] font-mono leading-[1.55] text-stone-800 bg-amber-50/40 border border-amber-200/70 rounded-md p-3 overflow-x-auto whitespace-pre-wrap min-h-[6rem]">
+          {override}
+        </pre>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/settings/sections/PromptsSection.tsx
+++ b/frontend/src/components/settings/sections/PromptsSection.tsx
@@ -1,0 +1,319 @@
+/**
+ * PromptsSection — Admin Settings → Prompts (Roadmap #16).
+ *
+ * Two-pane layout: filterable list of all 32 shipped prompts on the
+ * left, full editor on the right. The list is grouped by category
+ * (Chat / Studio / Extraction / Agents) with thin uppercase headers —
+ * subtle so the eye is drawn to prompt names, not the dividers.
+ *
+ * Aesthetic. Library/index page: monospace prompt names sit in tight
+ * rows, descriptions wrap once and truncate, the "Edited" pill is the
+ * only saturated mark in the rail. Empty state on the right has a
+ * single ghost icon + tagline — no busy work.
+ *
+ * Interaction.
+ *   - Click a row → fetch detail, hand off to the editor.
+ *   - Save / reset in the editor → bubble updated detail back so the
+ *     "Edited" pill in the rail stays in sync without a full refetch.
+ *   - "Edit in Models →" link in the editor dispatches a
+ *     `noobbook:settings:switch-section` event, which AppSettings
+ *     listens to and routes to the Models tab.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { CircleNotch, Code, MagnifyingGlass, Sparkle, X } from '@phosphor-icons/react';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  promptsAPI,
+  type PromptDetail,
+  type PromptSummary,
+} from '@/lib/api/admin/prompts';
+import { categoryFor, CATEGORY_LABELS, CATEGORY_ORDER, type PromptCategory } from './promptsLib';
+import { PromptEditor } from './PromptEditor';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('prompts-section');
+
+export const PromptsSection: React.FC = () => {
+  const { error } = useToast();
+
+  const [summaries, setSummaries] = useState<PromptSummary[]>([]);
+  const [listLoading, setListLoading] = useState(true);
+
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [detail, setDetail] = useState<PromptDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const [filter, setFilter] = useState('');
+
+  // Load list once on mount.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setListLoading(true);
+        const res = await promptsAPI.list();
+        if (cancelled) return;
+        setSummaries(res.data.prompts || []);
+      } catch (err) {
+        log.error({ err }, 'failed to load prompts');
+        if (!cancelled) error('Failed to load prompts');
+      } finally {
+        if (!cancelled) setListLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [error]);
+
+  // Load detail when selection changes.
+  useEffect(() => {
+    if (!selectedName) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        setDetailLoading(true);
+        const res = await promptsAPI.get(selectedName);
+        if (cancelled) return;
+        setDetail(res.data.prompt);
+      } catch (err) {
+        log.error({ err, selectedName }, 'failed to load prompt detail');
+        if (!cancelled) error('Failed to load prompt');
+      } finally {
+        if (!cancelled) setDetailLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedName, error]);
+
+  // Bubble editor changes back to the list rail so the "Edited" pill stays accurate.
+  const handleDetailChange = (next: PromptDetail) => {
+    setDetail(next);
+    setSummaries((prev) =>
+      prev.map((row) =>
+        row.prompt_name === next.prompt_name
+          ? {
+              ...row,
+              has_override: Boolean(next.override),
+              max_tokens:
+                typeof next.effective.max_tokens === 'number'
+                  ? next.effective.max_tokens
+                  : row.max_tokens,
+              temperature:
+                typeof next.effective.temperature === 'number'
+                  ? next.effective.temperature
+                  : row.temperature,
+            }
+          : row,
+      ),
+    );
+  };
+
+  // Filter + group for the left rail.
+  const filtered = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return summaries;
+    return summaries.filter(
+      (row) =>
+        row.prompt_name.toLowerCase().includes(needle) ||
+        row.name.toLowerCase().includes(needle) ||
+        row.description.toLowerCase().includes(needle),
+    );
+  }, [summaries, filter]);
+
+  const grouped = useMemo(() => {
+    const buckets: Record<PromptCategory, PromptSummary[]> = {
+      chat: [],
+      studio: [],
+      extraction: [],
+      agents: [],
+    };
+    filtered.forEach((row) => buckets[categoryFor(row.prompt_name)].push(row));
+    // Within each bucket, alphabetize by display name.
+    Object.values(buckets).forEach((bucket) =>
+      bucket.sort((a, b) => a.name.localeCompare(b.name)),
+    );
+    return buckets;
+  }, [filtered]);
+
+  const totalEdited = summaries.filter((s) => s.has_override).length;
+
+  // Bridge to the parent dialog for "Edit in Models →".
+  const handleSwitchSection = (section: 'models') => {
+    window.dispatchEvent(
+      new CustomEvent('noobbook:settings:switch-section', { detail: section }),
+    );
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* ── Section header ───────────────────────────────────────── */}
+      <div className="flex-shrink-0 mb-5">
+        <div className="flex items-baseline justify-between gap-4">
+          <div>
+            <h2 className="text-base font-medium text-stone-900 mb-1">Prompts</h2>
+            <p className="text-sm text-muted-foreground max-w-xl">
+              Edit any system prompt without a release. Locked variables are required by
+              the consuming service — leaving them in keeps everything wired up.
+            </p>
+          </div>
+          {totalEdited > 0 && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10.5px] uppercase tracking-wider font-medium bg-amber-50 text-amber-800 border border-amber-200/80 flex-shrink-0">
+              <Sparkle size={10} weight="fill" />
+              {totalEdited} edited
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* ── Two-pane body ────────────────────────────────────────── */}
+      <div className="flex-1 min-h-0 grid grid-cols-12 gap-0 border border-stone-200 rounded-lg overflow-hidden bg-white">
+        {/* Left rail */}
+        <aside className="col-span-12 md:col-span-4 lg:col-span-4 xl:col-span-3 border-r border-stone-200 bg-stone-50/40 flex flex-col min-h-0">
+          <div className="px-3 py-3 border-b border-stone-200/80 flex-shrink-0">
+            <div className="relative">
+              <MagnifyingGlass
+                size={13}
+                className="absolute left-2.5 top-1/2 -translate-y-1/2 text-stone-400"
+              />
+              <Input
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Filter prompts…"
+                className="pl-7 pr-7 h-8 text-[12.5px] bg-white"
+              />
+              {filter && (
+                <button
+                  type="button"
+                  onClick={() => setFilter('')}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-700"
+                  aria-label="Clear filter"
+                >
+                  <X size={12} weight="bold" />
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-y-auto py-2">
+            {listLoading ? (
+              <div className="flex items-center justify-center py-8 text-stone-400">
+                <CircleNotch size={20} className="animate-spin" />
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="px-3 py-8 text-center text-[12px] text-stone-500">
+                No prompts match <span className="font-mono">"{filter}"</span>.
+              </div>
+            ) : (
+              CATEGORY_ORDER.map((cat) => {
+                const rows = grouped[cat];
+                if (rows.length === 0) return null;
+                return (
+                  <div key={cat} className="mb-3 last:mb-0">
+                    <div className="px-3 pt-1.5 pb-1 text-[10px] uppercase tracking-[0.14em] font-semibold text-stone-400">
+                      {CATEGORY_LABELS[cat]}
+                    </div>
+                    <div className="space-y-px">
+                      {rows.map((row) => {
+                        const isActive = selectedName === row.prompt_name;
+                        return (
+                          <button
+                            key={row.prompt_name}
+                            type="button"
+                            onClick={() => setSelectedName(row.prompt_name)}
+                            className={[
+                              'w-full text-left px-3 py-1.5 transition-colors group',
+                              isActive
+                                ? 'bg-amber-50 border-l-2 border-amber-500 -ml-px pl-[calc(0.75rem-1px)]'
+                                : 'border-l-2 border-transparent hover:bg-stone-100/70',
+                            ].join(' ')}
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <span
+                                className={[
+                                  'font-mono text-[11.5px] truncate',
+                                  isActive
+                                    ? 'text-amber-900 font-medium'
+                                    : 'text-stone-800 group-hover:text-stone-900',
+                                ].join(' ')}
+                              >
+                                {row.prompt_name}
+                              </span>
+                              {row.has_override && (
+                                <Sparkle
+                                  size={10}
+                                  weight="fill"
+                                  className={
+                                    isActive ? 'text-amber-600' : 'text-amber-500/80'
+                                  }
+                                />
+                              )}
+                            </div>
+                            {row.description && (
+                              <div
+                                className={[
+                                  'text-[11px] truncate mt-0.5 leading-snug',
+                                  isActive
+                                    ? 'text-amber-800/70'
+                                    : 'text-stone-500 group-hover:text-stone-600',
+                                ].join(' ')}
+                              >
+                                {row.description}
+                              </div>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </aside>
+
+        {/* Right pane */}
+        <section className="col-span-12 md:col-span-8 lg:col-span-8 xl:col-span-9 min-h-0 flex flex-col">
+          {!selectedName ? (
+            <EmptyState />
+          ) : detailLoading || !detail ? (
+            <div className="flex-1 flex items-center justify-center text-stone-400">
+              <CircleNotch size={22} className="animate-spin" />
+            </div>
+          ) : (
+            <PromptEditor
+              detail={detail}
+              onChange={handleDetailChange}
+              onSwitchSection={handleSwitchSection}
+            />
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+const EmptyState: React.FC = () => (
+  <div className="flex-1 flex items-center justify-center px-8">
+    <div className="text-center max-w-sm">
+      <div className="mx-auto mb-4 inline-flex items-center justify-center h-12 w-12 rounded-full bg-stone-100 text-stone-400">
+        <Code size={22} weight="duotone" />
+      </div>
+      <h3 className="text-sm font-medium text-stone-700 mb-1">
+        Pick a prompt to edit
+      </h3>
+      <p className="text-[12.5px] text-stone-500 leading-relaxed">
+        Every prompt that ships with NoobBook is here. Edits land in
+        <span className="font-mono text-stone-600"> data/prompt_overrides/</span>
+        and survive container redeploys.
+      </p>
+    </div>
+  </div>
+);

--- a/frontend/src/components/settings/sections/index.ts
+++ b/frontend/src/components/settings/sections/index.ts
@@ -5,3 +5,4 @@ export { IntegrationsSection } from './IntegrationsSection';
 export { SystemSection } from './SystemSection';
 export { DesignSection } from './DesignSection';
 export { ModelsSection } from './ModelsSection';
+export { PromptsSection } from './PromptsSection';

--- a/frontend/src/components/settings/sections/promptsLib.ts
+++ b/frontend/src/components/settings/sections/promptsLib.ts
@@ -8,24 +8,22 @@
  */
 
 /**
+ * Pull deduped placeholder names out of `text` in document order.
+ * Empty / non-string input returns an empty array.
+ *
  * Single-token placeholder, matching Python identifier rules:
  *   `{var_name}` ✓     `{varName}` ✗ (uppercase rejected)
  *   `{ x }` ✗           `{"key": "value"}` ✗
  *
- * Lowercase + underscore + digits, must start with a letter/underscore.
- */
-const VAR_RE = /\{([a-z_][a-z0-9_]*)\}/g;
-
-/**
- * Pull deduped placeholder names out of `text` in document order.
- * Empty / non-string input returns an empty array.
+ * The regex is created fresh inside the function rather than at module
+ * scope, since a stateful global regex can leak `lastIndex` between
+ * calls if reused.
  */
 export function extractVars(text: string | null | undefined): string[] {
   if (!text || typeof text !== 'string') return [];
+  const VAR_RE = /\{([a-z_][a-z0-9_]*)\}/g;
   const seen = new Set<string>();
   const ordered: string[] = [];
-  // Reset lastIndex defensively even though we re-create with /g each call.
-  VAR_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = VAR_RE.exec(text)) !== null) {
     const name = match[1];

--- a/frontend/src/components/settings/sections/promptsLib.ts
+++ b/frontend/src/components/settings/sections/promptsLib.ts
@@ -1,0 +1,116 @@
+/**
+ * Prompt-editor helpers (Roadmap #16).
+ *
+ * Mirrors the backend's `prompt_var_utils.py`. The two regexes MUST stay
+ * in sync — the editor uses this for instant client-side validation
+ * (no round trip on each keystroke) and the backend uses its copy as
+ * the actual save-time gate.
+ */
+
+/**
+ * Single-token placeholder, matching Python identifier rules:
+ *   `{var_name}` ✓     `{varName}` ✗ (uppercase rejected)
+ *   `{ x }` ✗           `{"key": "value"}` ✗
+ *
+ * Lowercase + underscore + digits, must start with a letter/underscore.
+ */
+const VAR_RE = /\{([a-z_][a-z0-9_]*)\}/g;
+
+/**
+ * Pull deduped placeholder names out of `text` in document order.
+ * Empty / non-string input returns an empty array.
+ */
+export function extractVars(text: string | null | undefined): string[] {
+  if (!text || typeof text !== 'string') return [];
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  // Reset lastIndex defensively even though we re-create with /g each call.
+  VAR_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = VAR_RE.exec(text)) !== null) {
+    const name = match[1];
+    if (!seen.has(name)) {
+      seen.add(name);
+      ordered.push(name);
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Compute the set of required vars that have gone missing from an edit.
+ * Used by the editor's live validation indicator. Returns the missing
+ * names in document order from `required` so error text reads stable.
+ */
+export function missingVars(required: string[], present: string[]): string[] {
+  const presentSet = new Set(present);
+  return required.filter((v) => !presentSet.has(v));
+}
+
+/**
+ * Insert `{var_name}` at the textarea's current cursor position.
+ * Returns the new value and the new cursor offset (caller should set
+ * the textarea's `selectionStart`/`selectionEnd` after React updates).
+ *
+ * If the cursor is outside the value (negative or past the end) we
+ * append at the end — defensive for the rare case the selection is
+ * unset on a fresh textarea.
+ */
+export function insertAtCursor(
+  current: string,
+  varName: string,
+  cursor: number,
+): { value: string; cursor: number } {
+  const token = `{${varName}}`;
+  const safeCursor = Math.max(0, Math.min(cursor ?? current.length, current.length));
+  const next = current.slice(0, safeCursor) + token + current.slice(safeCursor);
+  return { value: next, cursor: safeCursor + token.length };
+}
+
+/**
+ * Bucket a prompt into a UI category for the left-rail grouping.
+ *
+ * Buckets (matching plan + plan-mode rationale):
+ *   - chat        — main conversation surfaces (default, chat_naming, memory)
+ *   - extraction  — background source processing (anything ending in _extraction
+ *                   or csv_processor / summary)
+ *   - agents      — query / analyzer / web agents
+ *   - studio      — content generation; the catch-all
+ *
+ * Order returned matches the order categories appear in the rail.
+ */
+export type PromptCategory = 'chat' | 'studio' | 'extraction' | 'agents';
+
+const CHAT_PROMPTS = new Set(['default', 'chat_naming', 'memory']);
+
+export function categoryFor(promptName: string): PromptCategory {
+  if (CHAT_PROMPTS.has(promptName)) return 'chat';
+  if (
+    promptName.endsWith('_extraction') ||
+    promptName === 'csv_processor' ||
+    promptName === 'summary'
+  ) {
+    return 'extraction';
+  }
+  if (
+    promptName.endsWith('_analyzer_agent') ||
+    promptName === 'web_agent' ||
+    promptName === 'deep_research_agent'
+  ) {
+    return 'agents';
+  }
+  return 'studio';
+}
+
+/**
+ * Display order for category headers in the rail. Chat first because
+ * it's the most-edited; agents last because they're the most-niche.
+ */
+export const CATEGORY_ORDER: PromptCategory[] = ['chat', 'studio', 'extraction', 'agents'];
+
+export const CATEGORY_LABELS: Record<PromptCategory, string> = {
+  chat: 'Chat',
+  studio: 'Studio',
+  extraction: 'Extraction',
+  agents: 'Agents',
+};

--- a/frontend/src/lib/api/admin/prompts.ts
+++ b/frontend/src/lib/api/admin/prompts.ts
@@ -1,0 +1,112 @@
+/**
+ * Admin Prompts API client (Roadmap #16).
+ *
+ * Wraps the four backend endpoints under `/api/v1/settings/prompts/...`.
+ * All routes are admin-gated server-side; the client just relays.
+ *
+ * Backend lives at `backend/app/api/settings/prompts.py`. Shapes are
+ * mirrored verbatim — if you tweak one side, tweak the other.
+ */
+import { api } from '../client';
+
+/** Editable templated fields. Mirrors `_TEMPLATED_FIELDS` on the backend. */
+export const TEMPLATED_FIELDS = [
+  'system_prompt',
+  'user_message',
+  'user_message_template',
+] as const;
+
+export type TemplatedField = (typeof TEMPLATED_FIELDS)[number];
+
+/**
+ * One row in the left rail. Just enough to render a list item.
+ */
+export interface PromptSummary {
+  prompt_name: string;
+  name: string;
+  description: string;
+  model: string | null;
+  default_model: string | null;
+  max_tokens: number | null;
+  temperature: number | null;
+  has_override: boolean;
+  required_vars: string[];
+}
+
+/**
+ * Full editor payload. `base` is the shipped default, `effective` is
+ * what the system actually uses right now (base merged with override).
+ * `override` is the raw delta — null when no admin edit has been made.
+ */
+export interface PromptDetail {
+  prompt_name: string;
+  base: PromptConfigBody;
+  override: Partial<PromptConfigBody> | null;
+  effective: PromptConfigBody;
+  required_vars: string[];
+  current_vars: string[];
+  referenced_by: string[];
+  editable_fields: string[];
+}
+
+/**
+ * Shape of a single prompt config — base, effective, and PUT bodies all
+ * share these fields. Fields beyond the editable subset are ignored on PUT.
+ */
+export interface PromptConfigBody {
+  name?: string;
+  description?: string;
+  model?: string | null;
+  max_tokens?: number;
+  temperature?: number;
+  system_prompt?: string;
+  user_message?: string;
+  user_message_template?: string;
+  version?: string;
+  // Allow forward-compatibility with future JSON keys
+  [key: string]: unknown;
+}
+
+/** Body for `PUT /settings/prompts/<name>`. */
+export interface UpdatePromptInput {
+  system_prompt?: string;
+  user_message?: string;
+  user_message_template?: string;
+  max_tokens?: number;
+  temperature?: number;
+}
+
+/**
+ * Backend returns a structured 400 when the edit drops a required var.
+ * Surfaced in the editor as the failure toast + per-var hint.
+ */
+export interface PromptValidationError {
+  success: false;
+  error: string;
+  missing_vars?: string[];
+  extra_vars?: string[];
+}
+
+export const promptsAPI = {
+  list: () =>
+    api.get<{ success: boolean; prompts: PromptSummary[]; count: number }>(
+      '/settings/prompts',
+    ),
+
+  get: (promptName: string) =>
+    api.get<{ success: boolean; prompt: PromptDetail }>(
+      `/settings/prompts/${encodeURIComponent(promptName)}`,
+    ),
+
+  update: (promptName: string, body: UpdatePromptInput) =>
+    api.put<{
+      success: boolean;
+      prompt: PromptDetail;
+      extra_vars?: string[];
+    }>(`/settings/prompts/${encodeURIComponent(promptName)}`, body),
+
+  reset: (promptName: string) =>
+    api.delete<{ success: boolean; prompt: PromptDetail }>(
+      `/settings/prompts/${encodeURIComponent(promptName)}/override`,
+    ),
+};


### PR DESCRIPTION
## Summary

Settings → **Prompts** tab. Admins can rewrite the body of any of the 32 shipped prompt configs (chat default, memory merge, every studio agent, freshdesk analyzer, extraction prompts, etc.), tune `max_tokens`/`temperature`, and reset back to the shipped default. No release required, no restart needed, edits survive container redeploys.

Resolution layers (top wins): per-project `custom_prompt` → workspace admin override → shipped default. Existing dynamic model resolution via `/settings/models` is untouched — `model` is intentionally read-only on this surface so there's a single source of truth for model selection.

## How it works

1. Admin opens Settings → Prompts. Left rail lists all 32 configs grouped by category (Chat / Studio / Extraction / Agents) with an "Edited" pill on any prompt that has an override.
2. Click a row → editor loads. Critical `.format()` placeholders auto-detected from the shipped default render as **clickable chips** above each textarea — click one to insert `{var_name}` at the cursor.
3. Live validation under the body: green check when all required vars are present, red list with a one-click fix when any go missing. **Save button stays disabled until valid**, so a broken edit can't be persisted.
4. Save → PUT writes only the diff to `data/prompt_overrides/<name>_prompt.json`. `prompt_loader.get_prompt_config` merges `{**base, **override}` on every call. Services pick up changes on the next prompt fetch with no restart.
5. "Reset to default" → DELETE the override file, fall back to shipped default. One-click, with a confirm dialog.
6. "View shipped default" expandable section at the bottom — side-by-side diff when overridden, plain block view when not.

## Why a sibling overrides directory

`backend/entrypoint.sh:15` runs `cp /app/_prompts_staging/* data/prompts/` on every container start, which would clobber direct edits to shipped JSON files. Overrides live in the sibling `data/prompt_overrides/` (still on the persistent `backend-data` volume) so admin edits survive redeploys. Empty saves auto-clear the override file rather than persisting a no-op.

## Validation guarantees

`prompt_var_utils.validate_edit` checks the **merged effective body** (base + override) against the **base required vars**. Missing any required var ⇒ structured 400 with `{missing_vars: [...]}` and no override is written. Adding new vars is allowed (informational `extra_vars` warning) since admins might genuinely want to introduce new templating — surfaced as a yellow toast.

Per-field type checks before persistence:
- `max_tokens` — positive int ≤ 65536
- `temperature` — number in [0, 2]
- string fields — must be strings

## Test plan

- [ ] **Backend list endpoint.** `curl /api/v1/settings/prompts` as admin returns 32 entries; without admin auth returns 401/403.
- [ ] **Save happy path.** PUT `memory` with `{temperature: 0.1}`. Override file appears at `data/prompt_overrides/memory_prompt.json` with only `{"temperature": 0.1}`. Trigger a memory-merge in chat — Claude call succeeds at the new temperature.
- [ ] **Save validation.** PUT `memory` with `{user_message: "Just merge them please"}` (drops all four required vars). 400 with `{missing_vars: ["memory_type", "current_memory", "new_memory", "reason"]}`. No override file written.
- [ ] **Reset.** DELETE `/settings/prompts/memory/override`. Override file deleted. GET returns shipped defaults.
- [ ] **Restart safety.** Stop and restart backend container. Override files survive (sibling of `prompts/`, not touched by the entrypoint's `cp`).
- [ ] **Cross-prompt regression.** Run a normal chat that hits `default_prompt` (no override touched). Output unchanged from baseline.
- [ ] **Curly-brace edge case.** Edit a prompt body with multi-token JSON examples like `{"key": "value"}`. The regex `{[a-z_][a-z0-9_]*}` requires single-token names so JSON shapes don't accidentally count as required.
- [ ] **Frontend live validation.** Type in the editor and remove `{new_memory}`. Save button disables and indicator turns red within ~50ms (no round trip).
- [ ] **Chip insert.** Click a missing chip → `{var_name}` appears at the cursor and focus stays in the textarea.
- [ ] **"Edit in Models →"** link on the editor header switches the dialog to the Models tab without closing.
- [ ] **Diff view.** Edit a prompt, save, expand "View shipped default" — see side-by-side default vs your edit. Reset → expandable shows just the default.
- [ ] **Filter + grouping.** Left rail filter narrows to matching prompts; category headers (Chat / Studio / Extraction / Agents) hide when their bucket is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)