### PR TITLE
sync develop → main: clipboard fallback + freshdesk RPC fix

### DIFF
--- a/backend/app/services/tool_executors/freshdesk_executor.py
+++ b/backend/app/services/tool_executors/freshdesk_executor.py
@@ -184,7 +184,17 @@ class FreshdeskExecutor:
             return {"success": False, "error": str(e)}
 
     def _query_runner(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
-        """Execute a read-only SQL query against the global freshdesk_tickets table."""
+        """Execute a read-only SQL query against the global freshdesk_tickets table.
+
+        Two paths, tried in order:
+          1. Supabase REST RPC (`exec_freshdesk_query`) — works in any
+             deployment where the backend can already reach Supabase via
+             the API gateway. This is the common case, including Coolify
+             and managed-Supabase setups where direct DB access is blocked.
+          2. Direct psycopg2 — fallback for the bundled docker-compose
+             stack and for older deployments that haven't applied
+             migration 00025 yet.
+        """
         sql = (tool_input.get("sql_query") or "").strip()
         if not sql:
             return {"success": False, "error": "sql_query is required"}
@@ -197,6 +207,86 @@ class FreshdeskExecutor:
         if "freshdesk_tickets" not in sql.lower():
             return {"success": False, "error": "Query must reference freshdesk_tickets table"}
 
+        rpc_result = self._run_via_rpc(sql)
+        if rpc_result is not None:
+            return rpc_result
+        return self._run_via_psycopg2(sql)
+
+    def _run_via_rpc(self, sql: str) -> Dict[str, Any] | None:
+        """
+        Try the PostgREST `exec_freshdesk_query` RPC.
+
+        Returns the formatted result on success, or `None` *only* when the
+        RPC function itself is unavailable (PGRST202 — function not found —
+        or any non-PostgREST error like a transport failure). When the
+        function exists but the user's SQL hit a Postgres error, we return
+        the error directly so the agent can correct it on the next
+        iteration; falling back to psycopg2 there would hide the real cause
+        behind a connection-refused message in deployments that don't have
+        a direct DB route.
+        """
+        try:
+            from app.services.integrations.supabase import get_supabase
+            from postgrest.exceptions import APIError
+
+            supabase = get_supabase()
+            start = time.time()
+            resp = supabase.rpc("exec_freshdesk_query", {"sql_query": sql}).execute()
+            elapsed = round((time.time() - start) * 1000, 1)
+
+            rows = resp.data if isinstance(resp.data, list) else []
+            # Defensive: PostgREST returns None for an empty jsonb result.
+            if rows is None:
+                rows = []
+            column_names = list(rows[0].keys()) if rows and isinstance(rows[0], dict) else []
+            truncated = len(rows) >= 100
+
+            result = {
+                "success": True,
+                "query": sql,
+                "row_count": len(rows),
+                "results": rows,
+                "column_names": column_names,
+                "execution_time_ms": elapsed,
+                "truncated": truncated,
+            }
+            if truncated:
+                result["warning"] = (
+                    "Results limited to 100 rows. Use GROUP BY, COUNT, or LIMIT to get aggregated data."
+                )
+            return result
+        except APIError as api_exc:
+            code = (api_exc.code or "").upper()
+            # PGRST202 = function not found in the schema cache. PGRST200
+            # is "matching procedure not found" (signature mismatch). Both
+            # mean migration 00025 hasn't been applied — fall back.
+            if code in ("PGRST202", "PGRST200", "42883"):  # 42883 = undefined_function
+                logger.info(
+                    "Freshdesk RPC unavailable (code=%s); falling back to psycopg2", code
+                )
+                return None
+            # Real query error from inside the function (bad SQL, missing
+            # column, validation rejection). Surface it so the agent can
+            # adjust on its next iteration.
+            logger.warning("Freshdesk RPC query error: %s", api_exc)
+            return {
+                "success": False,
+                "error": api_exc.message or str(api_exc),
+                "query": sql,
+            }
+        except Exception as exc:
+            # Network / client-init issues (e.g. SUPABASE_URL unreachable).
+            # Try psycopg2 — it might be a deployment where direct DB
+            # access works even when REST doesn't.
+            logger.info(
+                "Freshdesk RPC failed at the transport layer (%s); falling back to psycopg2",
+                exc,
+            )
+            return None
+
+    def _run_via_psycopg2(self, sql: str) -> Dict[str, Any]:
+        """Direct-Postgres fallback. Requires SUPABASE_DB_URL or POSTGRES_*
+        env vars and network access to the Postgres container."""
         try:
             try:
                 conn = self._get_connection()
@@ -209,10 +299,11 @@ class FreshdeskExecutor:
                 return {
                     "success": False,
                     "error": (
-                        "Cannot reach the Freshdesk tickets database directly. "
-                        "Set SUPABASE_DB_URL (or POSTGRES_HOST + POSTGRES_PASSWORD) "
-                        "in the backend environment so the analyzer can run SQL "
-                        f"queries. Underlying error: {conn_exc}"
+                        "Cannot reach the Freshdesk tickets database. "
+                        "Apply the latest migrations (00025 adds an RPC fallback that "
+                        "needs no extra env vars) or set SUPABASE_DB_URL "
+                        "(or POSTGRES_HOST + POSTGRES_PASSWORD) in the backend "
+                        f"environment. Underlying error: {conn_exc}"
                     ),
                     "query": sql,
                 }

--- a/backend/supabase/migrations/00025_freshdesk_query_rpc.sql
+++ b/backend/supabase/migrations/00025_freshdesk_query_rpc.sql
@@ -1,0 +1,67 @@
+-- Migration: RPC for the Freshdesk analyzer's query_runner tool.
+-- Created: 2026-05-01
+--
+-- The analyzer agent generates dynamic SELECT statements against
+-- freshdesk_tickets and used to execute them via psycopg2 with
+-- SUPABASE_DB_URL. That fails in deployments where the backend talks
+-- to Supabase only through the API gateway (Coolify, separately-hosted
+-- Supabase, managed Supabase) and never gets a direct route to the
+-- Postgres container.
+--
+-- This RPC routes the same query through PostgREST/Kong, which the
+-- backend already authenticates to with SUPABASE_SERVICE_KEY for every
+-- other table call. No new env vars required for the operator.
+--
+-- Defense-in-depth: the Python executor validates SELECT-only and
+-- the freshdesk_tickets reference before calling. The function repeats
+-- those checks server-side so a future caller can't sidestep them by
+-- bypassing the executor.
+--
+-- SECURITY INVOKER (the default) means the dynamic EXECUTE runs with
+-- the *caller's* privileges, not the function-owner's. Calling with
+-- the service_role key is what gives it full read access to the
+-- table; an anon caller would simply get permission-denied on the
+-- inner SELECT, which is the desired outcome.
+
+CREATE OR REPLACE FUNCTION public.exec_freshdesk_query(sql_query text)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  cleaned_query text;
+  result jsonb;
+BEGIN
+  -- Trailing semicolons would break the wrapping subquery below.
+  cleaned_query := regexp_replace(sql_query, ';\s*$', '');
+
+  -- Reject any statement that contains a mutating keyword. Conservative
+  -- — false positives (e.g. INSERT inside a string literal) are safe;
+  -- false negatives are not.
+  IF cleaned_query ~* '\m(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE|EXEC|EXECUTE|VACUUM|COPY|REINDEX|CLUSTER|REFRESH|LOCK|SECURITY)\M' THEN
+    RAISE EXCEPTION 'Only SELECT queries are allowed';
+  END IF;
+
+  IF position('freshdesk_tickets' in lower(cleaned_query)) = 0 THEN
+    RAISE EXCEPTION 'Query must reference the freshdesk_tickets table';
+  END IF;
+
+  -- LIMIT 100 cap matches the psycopg2 path's fetchmany(100) so a runaway
+  -- query can't pull a 50k-row result back through PostgREST. Wrapping
+  -- as `SELECT * FROM (<query>) sub LIMIT 100` is valid for plain SELECT,
+  -- ORDER BY, GROUP BY, and CTE (`WITH ... SELECT`) shapes the agent
+  -- generates.
+  EXECUTE format(
+    'SELECT coalesce(jsonb_agg(to_jsonb(t)), ''[]''::jsonb) FROM (SELECT * FROM (%s) sub_q LIMIT 100) t',
+    cleaned_query
+  ) INTO result;
+
+  RETURN COALESCE(result, '[]'::jsonb);
+END;
+$$;
+
+-- service_role is what the backend uses with SUPABASE_SERVICE_KEY.
+-- authenticated/authenticator are granted so the function is callable
+-- through whichever JWT role PostgREST resolves to in deployments that
+-- proxy with a different key.
+GRANT EXECUTE ON FUNCTION public.exec_freshdesk_query(text)
+  TO service_role, authenticator, authenticated;


### PR DESCRIPTION
## Summary
- Freshdesk analyzer now routes `query_runner` through a Supabase REST RPC (`exec_freshdesk_query`) so it works in deployments without direct Postgres access (Coolify, managed Supabase). New migration `00025_freshdesk_query_rpc.sql` ships the function with SECURITY INVOKER + SELECT-only validation + `LIMIT 100` cap. Falls back to psycopg2 only when the function genuinely isn't deployed.
- Clipboard copy now falls back to `document.execCommand('copy')` when `navigator.clipboard.writeText` fails (non-HTTPS contexts, lost focus). Helper extracted to `frontend/src/lib/clipboard.ts` and applied across all 7 copy call-sites.
- CSV preview routing centralized via `getViewKind(source)` in `lib/api/sources.ts`.

## Test plan
- [ ] Customer (Coolify-hosted) Freshdesk analyzer: ask a ticket question → returns rows, no "missing database password" error
- [ ] Bundled docker-compose: same query still works (psycopg2 fallback path unchanged)
- [ ] Share-link copy works on non-HTTPS deployments
- [ ] CSV source preview renders the table view