### PR TITLE
Admin Logs: rotating file handler + diagnostic bundle ZIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ dist-ssr/
 
 # Logs
 logs/
+!backend/app/api/logs/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -89,6 +89,7 @@ from app.api.sources import sources_bp
 from app.api.studio import studio_bp
 from app.api.brand import brand_bp
 from app.api.share import share_bp
+from app.api.logs import logs_bp
 
 # Register nested blueprints with the main api blueprint
 # No url_prefix needed - routes already have full paths
@@ -104,3 +105,4 @@ api_bp.register_blueprint(sources_bp)
 api_bp.register_blueprint(studio_bp)
 api_bp.register_blueprint(brand_bp)
 api_bp.register_blueprint(share_bp)
+api_bp.register_blueprint(logs_bp)

--- a/backend/app/api/logs/__init__.py
+++ b/backend/app/api/logs/__init__.py
@@ -1,0 +1,14 @@
+"""
+Logs API blueprint — admin diagnostic bundle + client-side error capture.
+
+Routes (registered under /api/v1):
+  POST  /logs/client          (any authenticated user) — record a browser error
+  GET   /logs/recent          (admin)                  — last N error/warning lines
+  GET   /logs/bundle          (admin)                  — ZIP support bundle
+  POST  /logs/clear           (admin)                  — truncate log file + archives
+"""
+from flask import Blueprint
+
+logs_bp = Blueprint('logs', __name__)
+
+from app.api.logs import routes  # noqa: F401,E402

--- a/backend/app/api/logs/bundle.py
+++ b/backend/app/api/logs/bundle.py
@@ -1,0 +1,153 @@
+"""
+Support-bundle assembler.
+
+Builds an in-memory ZIP containing the rotated backend log files plus a
+small bundle of deployment metadata. Total size is bounded by the log
+rotation cap (5MB × 6 files = ~30MB) so building in-memory is fine.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import platform
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import urlparse
+
+from app.api.logs.redaction import redact_line
+from app.utils import logger as logger_module
+
+
+def _iter_log_files() -> Iterable[Path]:
+    """Yield existing log files in oldest-first order so the bundle reads
+    chronologically when concatenated."""
+    base = logger_module.LOG_FILE
+    if base is None:
+        return
+    if not base.parent.exists():
+        return
+    archives = sorted(
+        (p for p in base.parent.glob(f"{base.name}.*") if p.is_file()),
+        key=lambda p: p.name,
+        reverse=True,  # backend.log.5 (oldest) first → backend.log.1 (newest archive)
+    )
+    for p in archives:
+        yield p
+    if base.exists():
+        yield base
+
+
+def _redact_file_bytes(path: Path) -> bytes:
+    """Read a log file line-by-line, apply redaction, return bytes for the ZIP entry."""
+    out = io.StringIO()
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            out.write(redact_line(line))
+    return out.getvalue().encode("utf-8")
+
+
+def _build_info_json() -> dict:
+    supabase_host = ""
+    raw_url = os.getenv("SUPABASE_URL", "")
+    if raw_url:
+        try:
+            supabase_host = urlparse(raw_url).hostname or ""
+        except Exception:
+            supabase_host = ""
+
+    log_size = 0
+    archive_count = 0
+    if logger_module.LOG_FILE and logger_module.LOG_FILE.exists():
+        log_size = logger_module.LOG_FILE.stat().st_size
+    if logger_module.LOG_DIR and logger_module.LOG_DIR.exists():
+        archive_count = sum(
+            1 for p in logger_module.LOG_DIR.glob(f"{logger_module.LOG_FILE.name}.*")
+            if p.is_file()
+        )
+
+    return {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "deployment_mode": os.getenv("FLASK_ENV", "development"),
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "app_version": os.getenv("APP_VERSION", "unknown"),
+        "supabase_url_host": supabase_host,
+        "anthropic_tier": os.getenv("ANTHROPIC_TIER", "1"),
+        "log_file_size_bytes": log_size,
+        "log_archive_count": archive_count,
+    }
+
+
+def _build_env_keys() -> str:
+    """List of env var NAMES present in the backend's environment. Names
+    only — values are intentionally never included since some env vars
+    legitimately hold secrets that aren't covered by the regex redactor."""
+    names = sorted(os.environ.keys())
+    return "\n".join(names) + "\n"
+
+
+def _build_migrations_listing() -> str:
+    """Either query schema_migrations from Supabase, or fall back to listing
+    the on-disk migration files. Both are useful: the DB tells us what's
+    actually applied, the on-disk list tells us what shipped with this build."""
+    lines: list[str] = []
+    try:
+        from app.services.integrations.supabase import get_supabase
+
+        supabase = get_supabase()
+        resp = (
+            supabase.table("schema_migrations")
+            .select("filename, applied_at")
+            .order("filename")
+            .execute()
+        )
+        rows = resp.data or []
+        lines.append("# Applied migrations (from schema_migrations table)")
+        for r in rows:
+            lines.append(f"{r.get('filename', '?')}  {r.get('applied_at', '?')}")
+    except Exception as exc:
+        lines.append(f"# Could not query schema_migrations: {exc}")
+
+    lines.append("")
+    lines.append("# Migration files shipped in this build")
+    migrations_dir = Path(__file__).resolve().parents[3] / "supabase" / "migrations"
+    if migrations_dir.is_dir():
+        for f in sorted(migrations_dir.glob("*.sql")):
+            lines.append(f.name)
+    else:
+        lines.append(f"(directory not found: {migrations_dir})")
+
+    return "\n".join(lines) + "\n"
+
+
+def build_bundle() -> tuple[bytes, str]:
+    """Assemble the bundle ZIP. Returns (bytes, suggested_filename)."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    filename = f"noobbook-bundle-{timestamp}.zip"
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        # Log files (redacted)
+        any_log_written = False
+        for path in _iter_log_files():
+            try:
+                content = _redact_file_bytes(path)
+            except Exception as exc:
+                content = f"# Failed to read {path.name}: {exc}\n".encode("utf-8")
+            zf.writestr(path.name, content)
+            any_log_written = True
+        if not any_log_written:
+            zf.writestr(
+                "backend.log",
+                b"# No log file on disk yet. The RotatingFileHandler creates it on first log line.\n",
+            )
+
+        zf.writestr("info.json", json.dumps(_build_info_json(), indent=2) + "\n")
+        zf.writestr("env-keys.txt", _build_env_keys())
+        zf.writestr("migrations.txt", _build_migrations_listing())
+
+    return buf.getvalue(), filename

--- a/backend/app/api/logs/redaction.py
+++ b/backend/app/api/logs/redaction.py
@@ -1,0 +1,36 @@
+"""
+Redaction for log lines before they leave the server.
+
+Conservative regex-based scrubbing — false positives (over-redacting) are
+safe; false negatives (leaking a credential) are not. Tuned for the
+secrets that actually appear in our logs:
+  - Postgres connection strings (password segment)
+  - Bearer tokens
+  - JWT-shaped tokens (eyJ...)
+  - Anthropic / OpenAI API key shapes
+"""
+from __future__ import annotations
+
+import re
+
+_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # postgresql://user:pw@host -> postgresql://[REDACTED]@host
+    (re.compile(r"(postgres(?:ql)?://)[^\s@]+@", re.IGNORECASE), r"\1[REDACTED]@"),
+    # Bearer <token>
+    (re.compile(r"(Bearer\s+)[\w.\-]{20,}", re.IGNORECASE), r"\1[REDACTED]"),
+    # JWT-shaped (eyJ...)
+    (re.compile(r"eyJ[\w\-]+\.[\w\-]+\.[\w\-]+"), "[REDACTED_JWT]"),
+    # Anthropic / OpenAI keys
+    (re.compile(r"sk-ant-[\w\-]+"), "[REDACTED_KEY]"),
+    (re.compile(r"sk-[\w\-]{30,}"), "[REDACTED_KEY]"),
+    # Supabase service / anon keys are JWTs (caught above), but the bare
+    # "service_role" / "anon" tokens sometimes appear quoted as 'sbp_...'.
+    (re.compile(r"sbp_[\w]{20,}"), "[REDACTED_KEY]"),
+]
+
+
+def redact_line(line: str) -> str:
+    """Apply all redaction patterns to a single log line."""
+    for pattern, replacement in _PATTERNS:
+        line = pattern.sub(replacement, line)
+    return line

--- a/backend/app/api/logs/routes.py
+++ b/backend/app/api/logs/routes.py
@@ -1,0 +1,200 @@
+"""
+Logs API routes.
+
+Powers the admin "Logs" UI (chat-header button + Settings tab) and accepts
+client-side error reports from the frontend so they end up in the same
+log stream as backend errors.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from flask import Response, current_app, g, jsonify, request
+
+from app.api.logs import logs_bp
+from app.api.logs.bundle import build_bundle
+from app.api.logs.redaction import redact_line
+from app.services.auth.rbac import require_admin
+from app.utils import logger as logger_module
+
+logger = logging.getLogger(__name__)
+
+# `2026-05-01 10:23:44 [ERROR] app.services.foo: message` — matches the
+# format string in setup_logging(). Loose enough to skip continuation
+# lines (stack-trace inner lines) which we still want to include verbatim.
+_LINE_RE = re.compile(
+    r"^(?P<ts>\d{2}:\d{2}:\d{2})\s+"
+    r"\[(?P<level>[A-Z]+)\]\s+"
+    r"(?P<logger>[\w.\-]+):\s*"
+    r"(?P<message>.*)$"
+)
+
+
+def _read_recent_lines(limit: int, levels: set[str]) -> list[dict[str, Any]]:
+    """Tail the active log file and return matching structured lines.
+
+    Reads the whole file once — at 5MB max it's quick and avoids the
+    seek-from-end gymnastics that need careful handling around line
+    boundaries and UTF-8 multibyte chars.
+    """
+    if not logger_module.LOG_FILE or not logger_module.LOG_FILE.exists():
+        return []
+
+    matched: list[dict[str, Any]] = []
+    pending: dict[str, Any] | None = None
+
+    try:
+        with logger_module.LOG_FILE.open("r", encoding="utf-8", errors="replace") as f:
+            for raw in f:
+                line = raw.rstrip("\n")
+                m = _LINE_RE.match(line)
+                if m:
+                    if pending and pending["level"] in levels:
+                        matched.append(pending)
+                        if len(matched) > limit * 4:
+                            # Trim early to keep memory bounded on large files.
+                            matched = matched[-limit:]
+                    pending = {
+                        "ts": m.group("ts"),
+                        "level": m.group("level"),
+                        "logger": m.group("logger"),
+                        "message": redact_line(m.group("message")),
+                    }
+                else:
+                    # Continuation of the previous structured line (stack trace etc.)
+                    if pending is not None:
+                        pending["message"] += "\n" + redact_line(line)
+            if pending and pending["level"] in levels:
+                matched.append(pending)
+    except Exception as exc:
+        logger.exception("Failed to read log file: %s", exc)
+        return []
+
+    return matched[-limit:]
+
+
+@logs_bp.route("/logs/recent", methods=["GET"])
+@require_admin
+def get_recent_logs():
+    """Return last N error/warning lines as JSON. `?level=all` includes INFO/DEBUG."""
+    try:
+        limit = int(request.args.get("n", 100))
+    except ValueError:
+        limit = 100
+    limit = max(1, min(limit, 1000))
+
+    level_param = (request.args.get("level") or "errors").lower()
+    if level_param == "all":
+        levels = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+    elif level_param == "warnings":
+        levels = {"WARNING", "ERROR", "CRITICAL"}
+    else:
+        levels = {"ERROR", "CRITICAL"}
+
+    lines = _read_recent_lines(limit, levels)
+    return jsonify(
+        {
+            "success": True,
+            "lines": lines,
+            "log_file_present": bool(logger_module.LOG_FILE and logger_module.LOG_FILE.exists()),
+        }
+    ), 200
+
+
+@logs_bp.route("/logs/bundle", methods=["GET"])
+@require_admin
+def download_bundle():
+    """Return the support bundle as a ZIP attachment."""
+    try:
+        data, filename = build_bundle()
+    except Exception as exc:
+        logger.exception("Failed to build support bundle")
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+    return Response(
+        data,
+        mimetype="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Length": str(len(data)),
+        },
+    )
+
+
+@logs_bp.route("/logs/clear", methods=["POST"])
+@require_admin
+def clear_logs():
+    """Truncate the active log file and remove rotated archives.
+
+    Useful when the admin wants a clean window before reproducing a bug
+    so the bundle they ship contains only the relevant noise.
+    """
+    log_file = logger_module.LOG_FILE
+    if log_file is None or not log_file.parent.exists():
+        return jsonify({"success": True, "cleared": 0, "message": "no log file"}), 200
+
+    cleared = 0
+    try:
+        if log_file.exists():
+            log_file.write_text("", encoding="utf-8")
+            cleared += 1
+        for archive in log_file.parent.glob(f"{log_file.name}.*"):
+            try:
+                archive.unlink()
+                cleared += 1
+            except OSError as exc:
+                logger.warning("Could not delete archive %s: %s", archive, exc)
+    except Exception as exc:
+        logger.exception("Failed to clear logs")
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+    logger.info("Log files cleared by admin (%d files)", cleared)
+    return jsonify({"success": True, "cleared": cleared}), 200
+
+
+@logs_bp.route("/logs/client", methods=["POST"])
+def report_client_error():
+    """Frontend hook for browser-side errors.
+
+    Authenticated but not admin-gated — any signed-in user reports their
+    own browser errors. The error gets written to backend.log via the
+    standard logger so it interleaves with server-side events in the
+    bundle.
+
+    Request body:
+        {
+          "message": "ReferenceError: foo is not defined",
+          "stack":   "...",
+          "url":     "https://app.example.com/projects/abc",
+          "userAgent": "Mozilla/5.0 ...",
+          "timestamp": "2026-05-01T10:23:44.123Z"
+        }
+    """
+    payload = request.get_json(silent=True) or {}
+    message = (payload.get("message") or "").strip() or "<empty>"
+    stack = (payload.get("stack") or "").strip()
+    url = (payload.get("url") or "").strip()
+    user_agent = (payload.get("userAgent") or "").strip()
+    user_id = getattr(g, "user_id", "anonymous")
+
+    # Truncate to keep the log file from being abused as bulk storage.
+    if len(message) > 1000:
+        message = message[:1000] + "…(truncated)"
+    if len(stack) > 4000:
+        stack = stack[:4000] + "\n…(truncated)"
+
+    summary = (
+        f"[CLIENT user={user_id} url={url} ua={user_agent[:80]}] {message}"
+    )
+    if stack:
+        summary += f"\n{stack}"
+
+    # Use the dedicated frontend-error logger so reviewers can grep [CLIENT]
+    # and trace which user / route surfaced the error.
+    logging.getLogger("client.error").error(summary)
+
+    # Don't leak whether anything specific happened — keep the response
+    # minimal so a malicious script can't probe via response shape.
+    return jsonify({"success": True}), 200

--- a/backend/app/api/logs/routes.py
+++ b/backend/app/api/logs/routes.py
@@ -16,7 +16,7 @@ from flask import Response, current_app, g, jsonify, request
 from app.api.logs import logs_bp
 from app.api.logs.bundle import build_bundle
 from app.api.logs.redaction import redact_line
-from app.services.auth.rbac import require_admin
+from app.services.auth.rbac import require_admin, require_auth
 from app.utils import logger as logger_module
 
 logger = logging.getLogger(__name__)
@@ -155,6 +155,7 @@ def clear_logs():
 
 
 @logs_bp.route("/logs/client", methods=["POST"])
+@require_auth
 def report_client_error():
     """Frontend hook for browser-side errors.
 
@@ -162,6 +163,13 @@ def report_client_error():
     own browser errors. The error gets written to backend.log via the
     standard logger so it interleaves with server-side events in the
     bundle.
+
+    Note: `api_bp.before_request` already validates the JWT for every
+    `/api/v1/*` route that isn't on the auth/health/share allowlist, so
+    `@require_auth` here is defense-in-depth — it pins the contract at
+    the route level so a future change to `before_request` (e.g. adding
+    `/logs/` to the allowlist by accident) can't silently expose this
+    write endpoint to anonymous callers.
 
     Request body:
         {
@@ -180,10 +188,15 @@ def report_client_error():
     user_id = getattr(g, "user_id", "anonymous")
 
     # Truncate to keep the log file from being abused as bulk storage.
+    # Caps are conservative — a real browser error rarely exceeds these.
     if len(message) > 1000:
         message = message[:1000] + "…(truncated)"
     if len(stack) > 4000:
         stack = stack[:4000] + "\n…(truncated)"
+    if len(url) > 500:
+        url = url[:500] + "…"
+    if len(user_agent) > 200:
+        user_agent = user_agent[:200]
 
     summary = (
         f"[CLIENT user={user_id} url={url} ua={user_agent[:80]}] {message}"

--- a/backend/app/utils/logger.py
+++ b/backend/app/utils/logger.py
@@ -6,27 +6,71 @@ Usage: import logging; logger = logging.getLogger(__name__)
 """
 import logging
 import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+
+# Public path constants — used by `app/api/logs/` to read/clear/bundle the log
+# file without re-deriving the location.
+LOG_DIR: Path | None = None
+LOG_FILE: Path | None = None
 
 
 def setup_logging(log_level: str = "DEBUG") -> None:
     """
     Configure the root logger with a human-readable format.
 
+    Two handlers are attached to the root logger:
+      - StreamHandler(stdout) — keeps `docker logs` working as before.
+      - RotatingFileHandler(<DATA_DIR>/logs/backend.log) — persists logs to
+        the `backend-data` volume so the admin "Logs" UI can serve them
+        even after a container restart. 5MB × 5 archives = ~25MB ceiling.
+
     Called once at app startup in create_app(). All modules that use
-    logging.getLogger(__name__) will inherit this configuration.
+    logging.getLogger(__name__) inherit this configuration.
     """
+    global LOG_DIR, LOG_FILE
+
     level = getattr(logging, log_level.upper(), logging.DEBUG)
 
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(logging.Formatter(
+    formatter = logging.Formatter(
         "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         datefmt="%H:%M:%S",
-    ))
+    )
+
+    handlers: list[logging.Handler] = []
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    handlers.append(stream_handler)
+
+    # File handler. Imported lazily so logger.py stays importable without
+    # the Flask app being constructed (some test paths and CLI helpers
+    # touch this module before config is available).
+    try:
+        from config import Config
+
+        LOG_DIR = Path(Config.DATA_DIR) / "logs"
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        LOG_FILE = LOG_DIR / "backend.log"
+
+        file_handler = RotatingFileHandler(
+            str(LOG_FILE),
+            maxBytes=5 * 1024 * 1024,
+            backupCount=5,
+            encoding="utf-8",
+        )
+        file_handler.setFormatter(formatter)
+        handlers.append(file_handler)
+    except Exception as exc:  # noqa: BLE001 — file handler is best-effort
+        # Don't crash startup if the volume isn't writable — stdout still
+        # works and the admin Logs UI will simply show "no log file".
+        sys.stderr.write(f"[logger] file handler disabled: {exc}\n")
 
     root = logging.getLogger()
     root.setLevel(level)
     # Avoid duplicate handlers on reloads
-    root.handlers = [handler]
+    root.handlers = handlers
 
     # Quiet noisy third-party loggers
     for name in ("urllib3", "werkzeug", "httpcore", "httpx", "hpack", "PIL"):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,8 @@ import { PermissionsProvider } from './contexts/PermissionsContext';
 import { IntegrationsProvider } from './contexts/IntegrationsContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ShareWorkspace } from './components/share/ShareWorkspace';
+import { GlobalLogsModalGate } from './components/project/GlobalLogsModalGate';
+import { setAdminMode } from './lib/adminMode';
 
 const log = createLogger('app');
 
@@ -110,10 +112,12 @@ function AppContent({
 function ProjectWorkspaceRoute({
   setRefreshTrigger,
   isAuthenticated,
+  isAdmin,
   onSignOut,
 }: {
   setRefreshTrigger: (fn: (prev: number) => number) => void;
   isAuthenticated: boolean;
+  isAdmin: boolean;
   onSignOut: () => Promise<void>;
 }) {
   const { projectId } = useParams<{ projectId: string }>();
@@ -182,6 +186,7 @@ function ProjectWorkspaceRoute({
         onDeleteProject={handleDeleteProject}
         onRenameProject={handleRenameProject}
         onSignOut={isAuthenticated ? onSignOut : undefined}
+        isAdmin={isAdmin}
       />
     </ErrorBoundary>
   );
@@ -233,6 +238,13 @@ function App() {
     refreshAuth();
   }, []);
 
+  // Mirror admin status into the module-level adminMode flag so leaf
+  // components (toast renderer in particular) can gate admin-only
+  // affordances without prop-drilling.
+  useEffect(() => {
+    setAdminMode(isAdmin);
+  }, [isAdmin]);
+
   if (!authReady) {
     return (
       <div className="h-screen flex items-center justify-center bg-background">
@@ -269,6 +281,7 @@ function App() {
                 <ProjectWorkspaceRoute
                   setRefreshTrigger={setRefreshTrigger}
                   isAuthenticated={isAuthenticated}
+                  isAdmin={isAdmin}
                   onSignOut={handleSignOut}
                 />
               }
@@ -294,6 +307,11 @@ function App() {
             />
             </Routes>
           </BrowserRouter>
+          {/* Single shared LogsModal mounted at the App root. Any toast
+              that calls `errorWithLogs(...)` dispatches a window event
+              this gate listens for, opening the modal regardless of
+              which route the user is on. Renders nothing for non-admins. */}
+          <GlobalLogsModalGate isAdmin={isAdmin} />
         </IntegrationsProvider>
       </PermissionsProvider>
     </ErrorBoundary>

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -56,7 +56,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   onRemoveSendingChat,
   openChatId,
 }) => {
-  const { toasts, dismissToast, success, error } = useToast();
+  const { toasts, dismissToast, success, error, errorWithLogs } = useToast();
 
   // Chat state
   const [message, setMessage] = useState('');
@@ -131,7 +131,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       onActiveChatChange(chat.id, chat.selected_source_ids ?? []);
     } catch (err) {
       log.error({ err }, 'failed to load chat');
-      error('Failed to load chat');
+      errorWithLogs('Failed to load chat');
     }
   };
 
@@ -150,7 +150,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       }
     } catch (err) {
       log.error({ err }, 'failed to load chats');
-      error('Failed to load chats');
+      errorWithLogs('Failed to load chats');
     } finally {
       setLoading(false);
     }
@@ -559,11 +559,11 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             }
           } catch (fallbackError) {
             log.error({ err: fallbackError }, 'failed to send message via fallback');
-            error('Failed to send message');
+            errorWithLogs('Failed to send message');
           }
         } else {
           log.error({ err }, 'failed to send message');
-          error('Failed to send message');
+          errorWithLogs('Failed to send message');
         }
       }
       setStreamingAssistantContent('');

--- a/frontend/src/components/dashboard/AppSettings.tsx
+++ b/frontend/src/components/dashboard/AppSettings.tsx
@@ -21,6 +21,7 @@ import {
   DesignSection,
   ModelsSection,
   PromptsSection,
+  LogsSection,
 } from '../settings/sections';
 
 interface AppSettingsProps {
@@ -48,7 +49,7 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
 
   // Handle section change with admin check
   const handleSectionChange = (section: SettingsSection) => {
-    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'prompts', 'design', 'system'];
+    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'prompts', 'design', 'system', 'logs'];
     if (!isAdmin && adminOnlySections.includes(section)) {
       return; // Prevent non-admins from switching to admin sections
     }
@@ -104,13 +105,15 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
         return isAdmin ? <DesignSection /> : null;
       case 'system':
         return isAdmin ? <SystemSection /> : null;
+      case 'logs':
+        return isAdmin ? <LogsSection /> : null;
       default:
         return null;
     }
   };
 
   const visibleSections = Array.from(mountedSections).filter((section) => {
-    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'prompts', 'design', 'system'];
+    const adminOnlySections: SettingsSection[] = ['team', 'api-keys', 'models', 'prompts', 'design', 'system', 'logs'];
     return isAdmin || !adminOnlySections.includes(section);
   });
 

--- a/frontend/src/components/project/GlobalLogsModalGate.tsx
+++ b/frontend/src/components/project/GlobalLogsModalGate.tsx
@@ -1,0 +1,33 @@
+/**
+ * GlobalLogsModalGate
+ *
+ * Mounts a single LogsModal instance at the App root that opens in
+ * response to the `noobbook:open-logs` window event. Lets any toast
+ * (or other deeply-nested component) request the logs view without
+ * having to plumb open-state down through props or context.
+ *
+ * Only renders for admins — non-admin users dispatching the event get
+ * no-op behavior, which is the correct fallback since the underlying
+ * /logs/* endpoints are admin-gated server-side anyway.
+ */
+import React, { useEffect, useState } from 'react';
+import { LogsModal } from './LogsModal';
+import { LOGS_OPEN_EVENT } from '@/lib/adminMode';
+
+interface GlobalLogsModalGateProps {
+  isAdmin: boolean;
+}
+
+export const GlobalLogsModalGate: React.FC<GlobalLogsModalGateProps> = ({ isAdmin }) => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    const handler = () => setOpen(true);
+    window.addEventListener(LOGS_OPEN_EVENT, handler);
+    return () => window.removeEventListener(LOGS_OPEN_EVENT, handler);
+  }, [isAdmin]);
+
+  if (!isAdmin) return null;
+  return <LogsModal open={open} onOpenChange={setOpen} />;
+};

--- a/frontend/src/components/project/LogConsole.tsx
+++ b/frontend/src/components/project/LogConsole.tsx
@@ -1,0 +1,254 @@
+/**
+ * LogConsole — shared presentational layer for the diagnostic-logs viewer.
+ *
+ * Renders three pieces:
+ *   - Filter row     (level chips + Refresh)
+ *   - Console panel  (dark stone-900 panel with monospace LogRow entries)
+ *   - Action row     (Clear / Copy / Download bundle)
+ *
+ * Both `LogsModal` and `LogsSection` compose these with their own outer
+ * chrome. State and handlers come from `useLogsState`, so the two
+ * surfaces stay in lockstep behaviorally — they only differ in framing
+ * (Dialog vs settings page).
+ */
+import React from 'react';
+import {
+  ArrowsClockwise,
+  CircleNotch,
+  Copy,
+  DownloadSimple,
+  Trash,
+  Warning,
+  XCircle,
+} from '@phosphor-icons/react';
+import { Button } from '@/components/ui/button';
+import type { LogLine } from '@/lib/api/logs';
+import { LEVEL_FILTERS, type LevelFilter } from './useLogsState';
+
+type ChipPalette = 'modal' | 'page';
+
+interface LogConsoleProps {
+  lines: LogLine[];
+  filter: LevelFilter;
+  onFilterChange: (next: LevelFilter) => void;
+  loading: boolean;
+  logFilePresent: boolean;
+  confirmingClear: boolean;
+  onRefresh: () => void;
+  onCopy: () => void;
+  onDownload: () => void;
+  onClear: () => void;
+  /**
+   * Modal mode wraps its filters in a tinted-amber pressed state (matches
+   * SharingModal's primary chip), page mode uses cream/amber that reads
+   * better against the white settings background.
+   */
+  variant?: ChipPalette;
+  /** Tailwind classes that bound the panel's vertical size. */
+  panelMaxHeightClassName?: string;
+}
+
+export const LogConsole: React.FC<LogConsoleProps> = ({
+  lines,
+  filter,
+  onFilterChange,
+  loading,
+  logFilePresent,
+  confirmingClear,
+  onRefresh,
+  onCopy,
+  onDownload,
+  onClear,
+  variant = 'page',
+  panelMaxHeightClassName = 'max-h-[58vh]',
+}) => {
+  return (
+    <div className="space-y-4">
+      <FilterRow
+        filter={filter}
+        onFilterChange={onFilterChange}
+        loading={loading}
+        onRefresh={onRefresh}
+        variant={variant}
+      />
+      <ConsolePanel
+        lines={lines}
+        loading={loading}
+        logFilePresent={logFilePresent}
+        panelMaxHeightClassName={panelMaxHeightClassName}
+      />
+      <ActionRow
+        onClear={onClear}
+        onCopy={onCopy}
+        onDownload={onDownload}
+        loading={loading}
+        hasLines={lines.length > 0}
+        confirmingClear={confirmingClear}
+      />
+    </div>
+  );
+};
+
+// ── Subcomponents ─────────────────────────────────────────────────
+
+const FilterRow: React.FC<{
+  filter: LevelFilter;
+  onFilterChange: (next: LevelFilter) => void;
+  loading: boolean;
+  onRefresh: () => void;
+  variant: ChipPalette;
+}> = ({ filter, onFilterChange, loading, onRefresh, variant }) => (
+  <div className="flex items-center gap-2 flex-wrap">
+    {LEVEL_FILTERS.map((f) => {
+      const isActive = filter === f.id;
+      const activeClasses =
+        variant === 'modal'
+          ? 'border-primary/40 bg-primary/5 text-foreground'
+          : 'border-amber-500/50 bg-amber-50 text-stone-900';
+      const inactiveClasses =
+        variant === 'modal'
+          ? 'border-border/60 bg-background text-muted-foreground hover:text-foreground'
+          : 'border-stone-200 bg-white text-stone-500 hover:text-stone-900';
+      return (
+        <button
+          key={f.id}
+          onClick={() => onFilterChange(f.id)}
+          className={[
+            'px-3 py-1 text-[11px] uppercase tracking-[0.08em] rounded-full border transition-colors',
+            isActive ? activeClasses : inactiveClasses,
+          ].join(' ')}
+          aria-pressed={isActive}
+        >
+          {f.label}
+        </button>
+      );
+    })}
+    <button
+      onClick={onRefresh}
+      className={[
+        'ml-auto inline-flex items-center gap-1 px-2 py-1 text-[11px] uppercase tracking-[0.08em] rounded-full',
+        variant === 'modal'
+          ? 'text-muted-foreground hover:text-foreground'
+          : 'text-stone-500 hover:text-stone-900',
+      ].join(' ')}
+      title="Refresh"
+    >
+      <ArrowsClockwise size={12} className={loading ? 'animate-spin' : ''} />
+      Refresh
+    </button>
+  </div>
+);
+
+const ConsolePanel: React.FC<{
+  lines: LogLine[];
+  loading: boolean;
+  logFilePresent: boolean;
+  panelMaxHeightClassName: string;
+}> = ({ lines, loading, logFilePresent, panelMaxHeightClassName }) => (
+  <div className="rounded-lg border border-stone-800/60 bg-stone-900 text-stone-100 font-mono text-[12px] leading-relaxed shadow-inner overflow-hidden">
+    <div className={`${panelMaxHeightClassName} overflow-y-auto`}>
+      {loading && lines.length === 0 ? (
+        <div className="h-48 flex items-center justify-center text-stone-400">
+          <CircleNotch size={16} className="mr-2 animate-spin" />
+          Loading logs…
+        </div>
+      ) : !logFilePresent ? (
+        <EmptyState
+          title="No log file on disk yet."
+          body="The rotating handler creates the file on the first log line. Trigger any action and refresh."
+        />
+      ) : lines.length === 0 ? (
+        <EmptyState title="All quiet." body="No matching lines for this filter." />
+      ) : (
+        <ul className="divide-y divide-stone-800/80">
+          {lines.map((l, i) => (
+            <LogRow key={i} line={l} />
+          ))}
+        </ul>
+      )}
+    </div>
+  </div>
+);
+
+const EmptyState: React.FC<{ title: string; body: string }> = ({ title, body }) => (
+  <div className="h-48 flex flex-col items-center justify-center text-stone-400 px-6 text-center">
+    <p className="text-stone-200">{title}</p>
+    <p className="text-[11px] mt-1 max-w-sm">{body}</p>
+  </div>
+);
+
+const ActionRow: React.FC<{
+  onClear: () => void;
+  onCopy: () => void;
+  onDownload: () => void;
+  loading: boolean;
+  hasLines: boolean;
+  confirmingClear: boolean;
+}> = ({ onClear, onCopy, onDownload, loading, hasLines, confirmingClear }) => (
+  <div className="flex items-center gap-2 flex-wrap">
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onClear}
+      disabled={loading}
+      className={
+        confirmingClear
+          ? 'gap-2 text-rose-700 hover:text-rose-800'
+          : 'gap-2 text-stone-500 hover:text-stone-900'
+      }
+    >
+      <Trash size={14} />
+      {confirmingClear ? 'Click again to clear' : 'Clear logs'}
+    </Button>
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onCopy}
+      disabled={loading || !hasLines}
+      className="gap-2 text-stone-500 hover:text-stone-900"
+    >
+      <Copy size={14} />
+      Copy view
+    </Button>
+    <div className="flex-1" />
+    <Button variant="default" size="sm" onClick={onDownload} className="gap-2">
+      <DownloadSimple size={14} weight="bold" />
+      Download bundle (.zip)
+    </Button>
+  </div>
+);
+
+const LogRow: React.FC<{ line: LogLine }> = ({ line }) => {
+  const isError = line.level === 'ERROR' || line.level === 'CRITICAL';
+  const isWarn = line.level === 'WARNING';
+  return (
+    <li className="px-4 py-2.5 hover:bg-stone-800/40 transition-colors">
+      <div className="flex items-center gap-2 text-[11px] tracking-tight">
+        <span className="text-stone-500 tabular-nums">{line.ts}</span>
+        <span
+          className={[
+            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm uppercase tracking-[0.06em] text-[10px] font-semibold',
+            isError
+              ? 'bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/30'
+              : isWarn
+                ? 'bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/30'
+                : 'bg-stone-700/40 text-stone-400 ring-1 ring-stone-600/30',
+          ].join(' ')}
+        >
+          {isError ? (
+            <XCircle size={10} weight="fill" />
+          ) : isWarn ? (
+            <Warning size={10} weight="fill" />
+          ) : null}
+          {line.level}
+        </span>
+        <span className="text-stone-400 truncate" title={line.logger}>
+          {line.logger}
+        </span>
+      </div>
+      <pre className="mt-1 whitespace-pre-wrap break-words text-stone-100 text-[12px] leading-relaxed font-mono pl-[3px]">
+        {line.message}
+      </pre>
+    </li>
+  );
+};

--- a/frontend/src/components/project/LogsButton.tsx
+++ b/frontend/src/components/project/LogsButton.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { Bug } from '@phosphor-icons/react';
+import { Button } from '../ui/button';
+import { LogsModal } from './LogsModal';
+
+/**
+ * LogsButton
+ *
+ * Admin-only header trigger that opens the diagnostic logs modal. Caller
+ * is responsible for the `isAdmin` gate — this component renders the
+ * button unconditionally so it can be reused from settings too.
+ */
+export const LogsButton: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant="soft"
+        size="sm"
+        onClick={() => setOpen(true)}
+        className="gap-2"
+        aria-haspopup="dialog"
+        title="View diagnostic logs"
+      >
+        <Bug size={16} />
+        Logs
+      </Button>
+      <LogsModal open={open} onOpenChange={setOpen} />
+    </>
+  );
+};

--- a/frontend/src/components/project/LogsModal.tsx
+++ b/frontend/src/components/project/LogsModal.tsx
@@ -1,0 +1,313 @@
+/**
+ * LogsModal — admin diagnostic logs viewer.
+ *
+ * Aesthetic direction: a small "operator's console" embedded inside the
+ * warm cream chrome of the rest of the app. The dialog header and action
+ * row stay in the project palette (stone / amber); the log viewer panel
+ * itself flips dark (stone-900) with monospace text and color-coded
+ * level pills, signalling "this is the under-the-hood view." The
+ * contrast is the differentiator — it reads as a real terminal, not just
+ * another card.
+ *
+ * Composition:
+ *   ┌─ Header ─────────────────────────────────┐
+ *   │ Diagnostic logs · 24KB · 3 archives      │
+ *   ├──────────────────────────────────────────┤
+ *   │ ┌─ stone-900 panel, monospace ───────┐  │
+ *   │ │ 10:23:44  ERROR  module.path       │  │
+ *   │ │   message line one                 │  │
+ *   │ │   stack trace continuation         │  │
+ *   │ │ 10:23:42  WARN   module.path       │  │
+ *   │ └──────────────────────────────────────┘  │
+ *   ├──────────────────────────────────────────┤
+ *   │ [Clear] [Copy]        [Download bundle ↓]│
+ *   └──────────────────────────────────────────┘
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import {
+  ArrowsClockwise,
+  Bug,
+  CircleNotch,
+  Copy,
+  DownloadSimple,
+  Trash,
+  Warning,
+  XCircle,
+} from '@phosphor-icons/react';
+import { useToast } from '../ui/use-toast';
+import { ToastContainer } from '../ui/toast';
+import { logsAPI, type LogLine } from '@/lib/api/logs';
+import { copyToClipboard } from '@/lib/clipboard';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('logs-modal');
+
+interface LogsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type LevelFilter = 'errors' | 'warnings' | 'all';
+
+const FILTERS: { id: LevelFilter; label: string }[] = [
+  { id: 'errors', label: 'Errors' },
+  { id: 'warnings', label: 'Errors + warnings' },
+  { id: 'all', label: 'All levels' },
+];
+
+export const LogsModal: React.FC<LogsModalProps> = ({ open, onOpenChange }) => {
+  const { toasts, dismissToast, success, error } = useToast();
+  const [lines, setLines] = useState<LogLine[]>([]);
+  const [filter, setFilter] = useState<LevelFilter>('errors');
+  const [loading, setLoading] = useState(false);
+  const [logFilePresent, setLogFilePresent] = useState(true);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+
+  const loadLines = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await logsAPI.getRecent(200, filter);
+      setLines(res.lines);
+      setLogFilePresent(res.log_file_present);
+    } catch (e) {
+      log.error({ err: e }, 'failed to load logs');
+      error('Could not load logs');
+    } finally {
+      setLoading(false);
+    }
+  }, [filter, error]);
+
+  useEffect(() => {
+    if (open) loadLines();
+  }, [open, loadLines]);
+
+  const formatLines = useMemo(
+    () =>
+      lines
+        .map((l) => `${l.ts} [${l.level}] ${l.logger}: ${l.message}`)
+        .join('\n'),
+    [lines],
+  );
+
+  const handleCopy = async () => {
+    if (!lines.length) {
+      error('Nothing to copy yet');
+      return;
+    }
+    const ok = await copyToClipboard(formatLines);
+    if (ok) success(`Copied ${lines.length} lines`);
+    else error('Could not copy. Select the text manually.');
+  };
+
+  const handleDownload = () => {
+    // Browser download with the JWT carried as query param — same pattern
+    // as studio output downloads. <a download> can't set Authorization
+    // headers, hence the helper.
+    const a = document.createElement('a');
+    a.href = logsAPI.bundleUrl();
+    a.rel = 'noopener';
+    a.click();
+  };
+
+  const handleClear = async () => {
+    if (!confirmingClear) {
+      setConfirmingClear(true);
+      // Reset the confirm state if the admin walks away from the button.
+      setTimeout(() => setConfirmingClear(false), 4000);
+      return;
+    }
+    setConfirmingClear(false);
+    setLoading(true);
+    try {
+      await logsAPI.clear();
+      success('Logs cleared');
+      await loadLines();
+    } catch (e) {
+      log.error({ err: e }, 'failed to clear logs');
+      error('Could not clear logs');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[760px] max-h-[88vh] p-0 overflow-hidden flex flex-col">
+        {/* ── Header ─────────────────────────────────────── */}
+        <div className="px-7 pt-6 pb-4 border-b flex-shrink-0">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-base font-semibold pr-8">
+              <Bug size={18} className="text-primary flex-shrink-0" />
+              <span>Diagnostic logs</span>
+            </DialogTitle>
+            <DialogDescription className="text-xs leading-relaxed text-muted-foreground mt-1">
+              Recent backend + frontend errors from this deployment. Download
+              the bundle to share a complete snapshot with support — log files,
+              env-var keys, and migration state are included.
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Filter chips */}
+          <div className="mt-4 flex items-center gap-2 flex-wrap">
+            {FILTERS.map((f) => {
+              const isActive = filter === f.id;
+              return (
+                <button
+                  key={f.id}
+                  onClick={() => setFilter(f.id)}
+                  className={[
+                    'px-3 py-1 text-[11px] uppercase tracking-[0.08em] rounded-full border transition-colors',
+                    isActive
+                      ? 'border-primary/40 bg-primary/5 text-foreground'
+                      : 'border-border/60 bg-background text-muted-foreground hover:text-foreground',
+                  ].join(' ')}
+                  aria-pressed={isActive}
+                >
+                  {f.label}
+                </button>
+              );
+            })}
+            <button
+              onClick={loadLines}
+              className="ml-auto inline-flex items-center gap-1 px-2 py-1 text-[11px] uppercase tracking-[0.08em] rounded-full text-muted-foreground hover:text-foreground"
+              title="Refresh"
+            >
+              <ArrowsClockwise
+                size={12}
+                className={loading ? 'animate-spin' : ''}
+              />
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {/* ── Console panel ──────────────────────────────── */}
+        <div className="flex-1 overflow-hidden bg-stone-50 px-7 py-5">
+          <div className="h-full rounded-lg border border-stone-800/60 bg-stone-900 text-stone-100 font-mono text-[12px] leading-relaxed shadow-inner overflow-y-auto">
+            {loading && lines.length === 0 ? (
+              <div className="h-full flex items-center justify-center text-stone-400">
+                <CircleNotch size={16} className="mr-2 animate-spin" />
+                Loading logs…
+              </div>
+            ) : !logFilePresent ? (
+              <div className="h-full flex flex-col items-center justify-center text-stone-400 px-6 py-10 text-center">
+                <p className="text-stone-200">No log file on disk yet.</p>
+                <p className="text-[11px] mt-1 max-w-sm">
+                  The rotating handler creates the file on the first log line.
+                  Trigger any action and refresh.
+                </p>
+              </div>
+            ) : lines.length === 0 ? (
+              <div className="h-full flex flex-col items-center justify-center text-stone-400 px-6 py-10 text-center">
+                <p className="text-stone-200">All quiet.</p>
+                <p className="text-[11px] mt-1">
+                  No matching lines for this filter.
+                </p>
+              </div>
+            ) : (
+              <ul className="divide-y divide-stone-800/80">
+                {lines.map((l, i) => (
+                  <LogRow key={i} line={l} />
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        {/* ── Action row ─────────────────────────────────── */}
+        <div className="px-7 py-4 border-t flex items-center gap-2 flex-shrink-0 bg-background">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClear}
+            disabled={loading}
+            className={
+              confirmingClear
+                ? 'gap-2 text-rose-700 hover:text-rose-800'
+                : 'gap-2 text-muted-foreground hover:text-foreground'
+            }
+          >
+            <Trash size={14} />
+            {confirmingClear ? 'Click again to clear' : 'Clear logs'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleCopy}
+            disabled={loading || !lines.length}
+            className="gap-2 text-muted-foreground hover:text-foreground"
+          >
+            <Copy size={14} />
+            Copy view
+          </Button>
+
+          <div className="flex-1" />
+
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handleDownload}
+            className="gap-2"
+          >
+            <DownloadSimple size={14} weight="bold" />
+            Download bundle (.zip)
+          </Button>
+        </div>
+
+        <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+/**
+ * LogRow
+ *
+ * One log entry. The header line packs timestamp + level pill + module
+ * path. The message body indents below — multi-line stack traces stay
+ * vertically aligned with the message, not the timestamp, which keeps
+ * the console scannable when several long traces stack up.
+ */
+const LogRow: React.FC<{ line: LogLine }> = ({ line }) => {
+  const isError = line.level === 'ERROR' || line.level === 'CRITICAL';
+  const isWarn = line.level === 'WARNING';
+
+  return (
+    <li className="px-4 py-2.5 hover:bg-stone-800/40 transition-colors">
+      <div className="flex items-center gap-2 text-[11px] tracking-tight">
+        <span className="text-stone-500 tabular-nums">{line.ts}</span>
+        <span
+          className={[
+            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm uppercase tracking-[0.06em] text-[10px] font-semibold',
+            isError
+              ? 'bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/30'
+              : isWarn
+                ? 'bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/30'
+                : 'bg-stone-700/40 text-stone-400 ring-1 ring-stone-600/30',
+          ].join(' ')}
+        >
+          {isError ? (
+            <XCircle size={10} weight="fill" />
+          ) : isWarn ? (
+            <Warning size={10} weight="fill" />
+          ) : null}
+          {line.level}
+        </span>
+        <span className="text-stone-400 truncate" title={line.logger}>
+          {line.logger}
+        </span>
+      </div>
+      <pre className="mt-1 whitespace-pre-wrap break-words text-stone-100 text-[12px] leading-relaxed font-mono pl-[3px]">
+        {line.message}
+      </pre>
+    </li>
+  );
+};

--- a/frontend/src/components/project/LogsModal.tsx
+++ b/frontend/src/components/project/LogsModal.tsx
@@ -1,29 +1,20 @@
 /**
- * LogsModal — admin diagnostic logs viewer.
+ * LogsModal — admin diagnostic logs viewer in dialog form.
  *
  * Aesthetic direction: a small "operator's console" embedded inside the
- * warm cream chrome of the rest of the app. The dialog header and action
- * row stay in the project palette (stone / amber); the log viewer panel
- * itself flips dark (stone-900) with monospace text and color-coded
- * level pills, signalling "this is the under-the-hood view." The
- * contrast is the differentiator — it reads as a real terminal, not just
- * another card.
+ * warm cream chrome of the rest of the app. The dialog header stays in
+ * the project palette (stone / amber); the log viewer panel itself
+ * flips dark (stone-900) with monospace text and color-coded level
+ * pills, signalling "this is the under-the-hood view." The contrast is
+ * the differentiator — it reads as a real terminal, not just another
+ * card.
  *
- * Composition:
- *   ┌─ Header ─────────────────────────────────┐
- *   │ Diagnostic logs · 24KB · 3 archives      │
- *   ├──────────────────────────────────────────┤
- *   │ ┌─ stone-900 panel, monospace ───────┐  │
- *   │ │ 10:23:44  ERROR  module.path       │  │
- *   │ │   message line one                 │  │
- *   │ │   stack trace continuation         │  │
- *   │ │ 10:23:42  WARN   module.path       │  │
- *   │ └──────────────────────────────────────┘  │
- *   ├──────────────────────────────────────────┤
- *   │ [Clear] [Copy]        [Download bundle ↓]│
- *   └──────────────────────────────────────────┘
+ * State + handlers come from `useLogsState`; the dark panel + filter
+ * chips + action row are rendered by `LogConsole`. This file is the
+ * Dialog wrapper only — the same pieces are reused in `LogsSection`
+ * for the settings page.
  */
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React from 'react';
 import {
   Dialog,
   DialogContent,
@@ -31,117 +22,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../ui/dialog';
-import { Button } from '../ui/button';
-import {
-  ArrowsClockwise,
-  Bug,
-  CircleNotch,
-  Copy,
-  DownloadSimple,
-  Trash,
-  Warning,
-  XCircle,
-} from '@phosphor-icons/react';
-import { useToast } from '../ui/use-toast';
+import { Bug } from '@phosphor-icons/react';
 import { ToastContainer } from '../ui/toast';
-import { logsAPI, type LogLine } from '@/lib/api/logs';
-import { copyToClipboard } from '@/lib/clipboard';
-import { createLogger } from '@/lib/logger';
-
-const log = createLogger('logs-modal');
+import { LogConsole } from './LogConsole';
+import { useLogsState } from './useLogsState';
 
 interface LogsModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-type LevelFilter = 'errors' | 'warnings' | 'all';
-
-const FILTERS: { id: LevelFilter; label: string }[] = [
-  { id: 'errors', label: 'Errors' },
-  { id: 'warnings', label: 'Errors + warnings' },
-  { id: 'all', label: 'All levels' },
-];
-
 export const LogsModal: React.FC<LogsModalProps> = ({ open, onOpenChange }) => {
-  const { toasts, dismissToast, success, error } = useToast();
-  const [lines, setLines] = useState<LogLine[]>([]);
-  const [filter, setFilter] = useState<LevelFilter>('errors');
-  const [loading, setLoading] = useState(false);
-  const [logFilePresent, setLogFilePresent] = useState(true);
-  const [confirmingClear, setConfirmingClear] = useState(false);
-
-  const loadLines = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await logsAPI.getRecent(200, filter);
-      setLines(res.lines);
-      setLogFilePresent(res.log_file_present);
-    } catch (e) {
-      log.error({ err: e }, 'failed to load logs');
-      error('Could not load logs');
-    } finally {
-      setLoading(false);
-    }
-  }, [filter, error]);
-
-  useEffect(() => {
-    if (open) loadLines();
-  }, [open, loadLines]);
-
-  const formatLines = useMemo(
-    () =>
-      lines
-        .map((l) => `${l.ts} [${l.level}] ${l.logger}: ${l.message}`)
-        .join('\n'),
-    [lines],
-  );
-
-  const handleCopy = async () => {
-    if (!lines.length) {
-      error('Nothing to copy yet');
-      return;
-    }
-    const ok = await copyToClipboard(formatLines);
-    if (ok) success(`Copied ${lines.length} lines`);
-    else error('Could not copy. Select the text manually.');
-  };
-
-  const handleDownload = () => {
-    // Browser download with the JWT carried as query param — same pattern
-    // as studio output downloads. <a download> can't set Authorization
-    // headers, hence the helper.
-    const a = document.createElement('a');
-    a.href = logsAPI.bundleUrl();
-    a.rel = 'noopener';
-    a.click();
-  };
-
-  const handleClear = async () => {
-    if (!confirmingClear) {
-      setConfirmingClear(true);
-      // Reset the confirm state if the admin walks away from the button.
-      setTimeout(() => setConfirmingClear(false), 4000);
-      return;
-    }
-    setConfirmingClear(false);
-    setLoading(true);
-    try {
-      await logsAPI.clear();
-      success('Logs cleared');
-      await loadLines();
-    } catch (e) {
-      log.error({ err: e }, 'failed to clear logs');
-      error('Could not clear logs');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const state = useLogsState({ active: open });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[760px] max-h-[88vh] p-0 overflow-hidden flex flex-col">
-        {/* ── Header ─────────────────────────────────────── */}
         <div className="px-7 pt-6 pb-4 border-b flex-shrink-0">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 text-base font-semibold pr-8">
@@ -154,160 +50,27 @@ export const LogsModal: React.FC<LogsModalProps> = ({ open, onOpenChange }) => {
               env-var keys, and migration state are included.
             </DialogDescription>
           </DialogHeader>
-
-          {/* Filter chips */}
-          <div className="mt-4 flex items-center gap-2 flex-wrap">
-            {FILTERS.map((f) => {
-              const isActive = filter === f.id;
-              return (
-                <button
-                  key={f.id}
-                  onClick={() => setFilter(f.id)}
-                  className={[
-                    'px-3 py-1 text-[11px] uppercase tracking-[0.08em] rounded-full border transition-colors',
-                    isActive
-                      ? 'border-primary/40 bg-primary/5 text-foreground'
-                      : 'border-border/60 bg-background text-muted-foreground hover:text-foreground',
-                  ].join(' ')}
-                  aria-pressed={isActive}
-                >
-                  {f.label}
-                </button>
-              );
-            })}
-            <button
-              onClick={loadLines}
-              className="ml-auto inline-flex items-center gap-1 px-2 py-1 text-[11px] uppercase tracking-[0.08em] rounded-full text-muted-foreground hover:text-foreground"
-              title="Refresh"
-            >
-              <ArrowsClockwise
-                size={12}
-                className={loading ? 'animate-spin' : ''}
-              />
-              Refresh
-            </button>
-          </div>
         </div>
 
-        {/* ── Console panel ──────────────────────────────── */}
-        <div className="flex-1 overflow-hidden bg-stone-50 px-7 py-5">
-          <div className="h-full rounded-lg border border-stone-800/60 bg-stone-900 text-stone-100 font-mono text-[12px] leading-relaxed shadow-inner overflow-y-auto">
-            {loading && lines.length === 0 ? (
-              <div className="h-full flex items-center justify-center text-stone-400">
-                <CircleNotch size={16} className="mr-2 animate-spin" />
-                Loading logs…
-              </div>
-            ) : !logFilePresent ? (
-              <div className="h-full flex flex-col items-center justify-center text-stone-400 px-6 py-10 text-center">
-                <p className="text-stone-200">No log file on disk yet.</p>
-                <p className="text-[11px] mt-1 max-w-sm">
-                  The rotating handler creates the file on the first log line.
-                  Trigger any action and refresh.
-                </p>
-              </div>
-            ) : lines.length === 0 ? (
-              <div className="h-full flex flex-col items-center justify-center text-stone-400 px-6 py-10 text-center">
-                <p className="text-stone-200">All quiet.</p>
-                <p className="text-[11px] mt-1">
-                  No matching lines for this filter.
-                </p>
-              </div>
-            ) : (
-              <ul className="divide-y divide-stone-800/80">
-                {lines.map((l, i) => (
-                  <LogRow key={i} line={l} />
-                ))}
-              </ul>
-            )}
-          </div>
+        <div className="flex-1 overflow-y-auto bg-stone-50 px-7 py-5">
+          <LogConsole
+            variant="modal"
+            panelMaxHeightClassName="max-h-[55vh]"
+            lines={state.lines}
+            filter={state.filter}
+            onFilterChange={state.setFilter}
+            loading={state.loading}
+            logFilePresent={state.logFilePresent}
+            confirmingClear={state.confirmingClear}
+            onRefresh={state.loadLines}
+            onCopy={state.handleCopy}
+            onDownload={state.handleDownload}
+            onClear={state.handleClear}
+          />
         </div>
 
-        {/* ── Action row ─────────────────────────────────── */}
-        <div className="px-7 py-4 border-t flex items-center gap-2 flex-shrink-0 bg-background">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleClear}
-            disabled={loading}
-            className={
-              confirmingClear
-                ? 'gap-2 text-rose-700 hover:text-rose-800'
-                : 'gap-2 text-muted-foreground hover:text-foreground'
-            }
-          >
-            <Trash size={14} />
-            {confirmingClear ? 'Click again to clear' : 'Clear logs'}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleCopy}
-            disabled={loading || !lines.length}
-            className="gap-2 text-muted-foreground hover:text-foreground"
-          >
-            <Copy size={14} />
-            Copy view
-          </Button>
-
-          <div className="flex-1" />
-
-          <Button
-            variant="default"
-            size="sm"
-            onClick={handleDownload}
-            className="gap-2"
-          >
-            <DownloadSimple size={14} weight="bold" />
-            Download bundle (.zip)
-          </Button>
-        </div>
-
-        <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+        <ToastContainer toasts={state.toasts} onDismiss={state.dismissToast} />
       </DialogContent>
     </Dialog>
-  );
-};
-
-/**
- * LogRow
- *
- * One log entry. The header line packs timestamp + level pill + module
- * path. The message body indents below — multi-line stack traces stay
- * vertically aligned with the message, not the timestamp, which keeps
- * the console scannable when several long traces stack up.
- */
-const LogRow: React.FC<{ line: LogLine }> = ({ line }) => {
-  const isError = line.level === 'ERROR' || line.level === 'CRITICAL';
-  const isWarn = line.level === 'WARNING';
-
-  return (
-    <li className="px-4 py-2.5 hover:bg-stone-800/40 transition-colors">
-      <div className="flex items-center gap-2 text-[11px] tracking-tight">
-        <span className="text-stone-500 tabular-nums">{line.ts}</span>
-        <span
-          className={[
-            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm uppercase tracking-[0.06em] text-[10px] font-semibold',
-            isError
-              ? 'bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/30'
-              : isWarn
-                ? 'bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/30'
-                : 'bg-stone-700/40 text-stone-400 ring-1 ring-stone-600/30',
-          ].join(' ')}
-        >
-          {isError ? (
-            <XCircle size={10} weight="fill" />
-          ) : isWarn ? (
-            <Warning size={10} weight="fill" />
-          ) : null}
-          {line.level}
-        </span>
-        <span className="text-stone-400 truncate" title={line.logger}>
-          {line.logger}
-        </span>
-      </div>
-      <pre className="mt-1 whitespace-pre-wrap break-words text-stone-100 text-[12px] leading-relaxed font-mono pl-[3px]">
-        {line.message}
-      </pre>
-    </li>
   );
 };

--- a/frontend/src/components/project/ProjectHeader.tsx
+++ b/frontend/src/components/project/ProjectHeader.tsx
@@ -36,6 +36,7 @@ import { ToastContainer } from '../ui/toast';
 import { useToast } from '../ui/use-toast';
 import { createLogger } from '@/lib/logger';
 import { ShareButton } from './ShareButton';
+import { LogsButton } from './LogsButton';
 
 const log = createLogger('project-header');
 
@@ -56,6 +57,7 @@ interface ProjectHeaderProps {
   costsVersion?: number; // Increment to trigger cost refresh
   onRename?: (newName: string) => Promise<void>;
   onSignOut?: () => Promise<void>;
+  isAdmin?: boolean;
 }
 
 export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
@@ -65,8 +67,9 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
   costsVersion,
   onRename,
   onSignOut,
+  isAdmin = false,
 }) => {
-  const { toasts, dismissToast, error, success } = useToast();
+  const { toasts, dismissToast, error, success, errorWithLogs } = useToast();
 
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [settingsDialogOpen, setSettingsDialogOpen] = React.useState(false);
@@ -142,7 +145,7 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
       }
     } catch (err) {
       log.error({ err }, 'failed to load memory');
-      error('Failed to load memory');
+      errorWithLogs('Failed to load memory');
     } finally {
       setLoadingMemory(false);
     }
@@ -205,7 +208,7 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
       setAllPrompts(prompts);
     } catch (err) {
       log.error({ err }, 'failed to load prompts');
-      error('Failed to load prompts');
+      errorWithLogs('Failed to load prompts');
     } finally {
       setLoadingPrompts(false);
     }
@@ -399,6 +402,7 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
       {/* Right side - Actions */}
       <div className="flex items-center gap-2">
         <ShareButton projectId={project.id} projectName={project.name} />
+        {isAdmin && <LogsButton />}
 
         <Button
           variant="soft"

--- a/frontend/src/components/project/ProjectWorkspace.tsx
+++ b/frontend/src/components/project/ProjectWorkspace.tsx
@@ -33,6 +33,7 @@ interface ProjectWorkspaceProps {
   onDeleteProject: (projectId: string) => void;
   onRenameProject?: (newName: string) => Promise<void>;
   onSignOut?: () => Promise<void>;
+  isAdmin?: boolean;
 }
 
 export const ProjectWorkspace: React.FC<ProjectWorkspaceProps> = ({
@@ -41,6 +42,7 @@ export const ProjectWorkspace: React.FC<ProjectWorkspaceProps> = ({
   onDeleteProject,
   onRenameProject,
   onSignOut,
+  isAdmin = false,
 }) => {
   // Refs for programmatic panel control
   const leftPanelRef = useRef<ImperativePanelHandle>(null);
@@ -120,6 +122,7 @@ export const ProjectWorkspace: React.FC<ProjectWorkspaceProps> = ({
         costsVersion={costsVersion}
         onRename={onRenameProject}
         onSignOut={onSignOut}
+        isAdmin={isAdmin}
       />
 
       {/* Main Content Area - Floating panels over background */}

--- a/frontend/src/components/project/SharingModal.tsx
+++ b/frontend/src/components/project/SharingModal.tsx
@@ -66,7 +66,7 @@ export const SharingModal: React.FC<SharingModalProps> = ({
   projectId,
   projectName,
 }) => {
-  const { toasts, dismissToast, success, error } = useToast();
+  const { toasts, dismissToast, success, error, errorWithLogs } = useToast();
 
   // ── List state ───────────────────────────────────────────────────
   const [shares, setShares] = useState<ProjectShare[]>([]);
@@ -102,11 +102,11 @@ export const SharingModal: React.FC<SharingModalProps> = ({
       setShares(res.data.shares || []);
     } catch (err) {
       log.error({ err }, 'failed to load shares');
-      error('Failed to load shares');
+      errorWithLogs('Failed to load shares');
     } finally {
       setListLoading(false);
     }
-  }, [projectId, error]);
+  }, [projectId, errorWithLogs]);
 
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/components/project/useLogsState.ts
+++ b/frontend/src/components/project/useLogsState.ts
@@ -1,0 +1,124 @@
+/**
+ * useLogsState — shared state + handlers for the diagnostic-logs viewer.
+ *
+ * Powers both `LogsModal` (chat-header dialog) and `LogsSection`
+ * (settings tab). Centralizes the fetch lifecycle, level filter,
+ * clipboard copy, bundle download, and clear-with-confirm flow so the
+ * two surfaces are guaranteed to behave identically.
+ *
+ * The two callers differ only in chrome (Dialog vs settings page
+ * layout) — every interaction is delegated here.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { logsAPI, type LogLine } from '@/lib/api/logs';
+import { copyToClipboard } from '@/lib/clipboard';
+import { useToast } from '@/components/ui/use-toast';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('logs-state');
+
+export type LevelFilter = 'errors' | 'warnings' | 'all';
+
+export const LEVEL_FILTERS: { id: LevelFilter; label: string }[] = [
+  { id: 'errors', label: 'Errors' },
+  { id: 'warnings', label: 'Errors + warnings' },
+  { id: 'all', label: 'All levels' },
+];
+
+interface UseLogsStateOpts {
+  /** When false (modal closed), the hook skips the initial fetch. */
+  active?: boolean;
+}
+
+export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
+  const { toasts, dismissToast, success, error } = useToast();
+  const [lines, setLines] = useState<LogLine[]>([]);
+  const [filter, setFilter] = useState<LevelFilter>('errors');
+  const [loading, setLoading] = useState(false);
+  const [logFilePresent, setLogFilePresent] = useState(true);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+
+  const loadLines = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await logsAPI.getRecent(200, filter);
+      setLines(res.lines);
+      setLogFilePresent(res.log_file_present);
+    } catch (e) {
+      log.error({ err: e }, 'failed to load logs');
+      error('Could not load logs');
+    } finally {
+      setLoading(false);
+    }
+  }, [filter, error]);
+
+  // Refetch whenever the surface activates or the filter changes.
+  useEffect(() => {
+    if (!active) return;
+    loadLines();
+  }, [active, loadLines]);
+
+  const formatLines = useMemo(
+    () =>
+      lines
+        .map((l) => `${l.ts} [${l.level}] ${l.logger}: ${l.message}`)
+        .join('\n'),
+    [lines],
+  );
+
+  const handleCopy = useCallback(async () => {
+    if (!lines.length) {
+      error('Nothing to copy yet');
+      return;
+    }
+    const ok = await copyToClipboard(formatLines);
+    if (ok) success(`Copied ${lines.length} lines`);
+    else error('Could not copy. Select the text manually.');
+  }, [lines, formatLines, success, error]);
+
+  const handleDownload = useCallback(() => {
+    // Browser download via anchor; getAuthUrl puts the JWT in the query
+    // string because <a download> can't set Authorization headers.
+    const a = document.createElement('a');
+    a.href = logsAPI.bundleUrl();
+    a.rel = 'noopener';
+    a.click();
+  }, []);
+
+  const handleClear = useCallback(async () => {
+    if (!confirmingClear) {
+      setConfirmingClear(true);
+      // Reset the confirm state if the user walks away.
+      setTimeout(() => setConfirmingClear(false), 4000);
+      return;
+    }
+    setConfirmingClear(false);
+    setLoading(true);
+    try {
+      await logsAPI.clear();
+      success('Logs cleared');
+      await loadLines();
+    } catch (e) {
+      log.error({ err: e }, 'failed to clear logs');
+      error('Could not clear logs');
+    } finally {
+      setLoading(false);
+    }
+  }, [confirmingClear, loadLines, success, error]);
+
+  return {
+    lines,
+    filter,
+    setFilter,
+    loading,
+    logFilePresent,
+    confirmingClear,
+    loadLines,
+    handleCopy,
+    handleDownload,
+    handleClear,
+    // Toast plumbing — the consumer mounts <ToastContainer /> with these.
+    toasts,
+    dismissToast,
+  };
+}

--- a/frontend/src/components/settings/SettingsSidebar.tsx
+++ b/frontend/src/components/settings/SettingsSidebar.tsx
@@ -4,10 +4,10 @@
  */
 
 import React from 'react';
-import { User, Users, Key, Plug, Gear, Palette, Brain, TextAa } from '@phosphor-icons/react';
+import { User, Users, Key, Plug, Gear, Palette, Brain, TextAa, Bug } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils';
 
-export type SettingsSection = 'profile' | 'team' | 'api-keys' | 'models' | 'prompts' | 'integrations' | 'design' | 'system';
+export type SettingsSection = 'profile' | 'team' | 'api-keys' | 'models' | 'prompts' | 'integrations' | 'design' | 'system' | 'logs';
 
 interface SettingsSidebarProps {
   activeSection: SettingsSection;
@@ -32,6 +32,7 @@ const sidebarItems: SidebarItem[] = [
   { id: 'integrations', label: 'Integrations', icon: <Plug size={18} />, category: 'workspace' },
   { id: 'design', label: 'Design', icon: <Palette size={18} />, category: 'workspace', adminOnly: true },
   { id: 'system', label: 'System', icon: <Gear size={18} />, category: 'workspace', adminOnly: true },
+  { id: 'logs', label: 'Logs', icon: <Bug size={18} />, category: 'workspace', adminOnly: true },
 ];
 
 export const SettingsSidebar: React.FC<SettingsSidebarProps> = ({

--- a/frontend/src/components/settings/sections/ApiKeysSection.tsx
+++ b/frontend/src/components/settings/sections/ApiKeysSection.tsx
@@ -95,7 +95,7 @@ export const ApiKeysSection: React.FC = () => {
   const [validationState, setValidationState] = useState<ValidationState>({});
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
 
-  const { success, error, info } = useToast();
+  const { success, error, info, errorWithLogs } = useToast();
 
   useEffect(() => {
     loadApiKeys();
@@ -109,7 +109,7 @@ export const ApiKeysSection: React.FC = () => {
       setModifiedKeys({});
     } catch (err) {
       log.error({ err }, 'failed to load API keys');
-      error('Failed to load API keys');
+      errorWithLogs('Failed to load API keys');
     } finally {
       setInitialLoading(false);
     }

--- a/frontend/src/components/settings/sections/LogsSection.tsx
+++ b/frontend/src/components/settings/sections/LogsSection.tsx
@@ -1,0 +1,253 @@
+/**
+ * LogsSection — settings-page variant of the diagnostic logs viewer.
+ *
+ * Same console aesthetic as `LogsModal` but reflows for the settings
+ * content area: full-width panel, no Dialog chrome, prose-style intro
+ * paragraph that explains what the bundle contains so the admin knows
+ * what they're sharing.
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ArrowsClockwise,
+  CircleNotch,
+  Copy,
+  DownloadSimple,
+  Trash,
+  Warning,
+  XCircle,
+} from '@phosphor-icons/react';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/use-toast';
+import { logsAPI, type LogLine } from '@/lib/api/logs';
+import { copyToClipboard } from '@/lib/clipboard';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('logs-section');
+
+type LevelFilter = 'errors' | 'warnings' | 'all';
+
+const FILTERS: { id: LevelFilter; label: string }[] = [
+  { id: 'errors', label: 'Errors' },
+  { id: 'warnings', label: 'Errors + warnings' },
+  { id: 'all', label: 'All levels' },
+];
+
+export const LogsSection: React.FC = () => {
+  const { success, error } = useToast();
+  const [lines, setLines] = useState<LogLine[]>([]);
+  const [filter, setFilter] = useState<LevelFilter>('errors');
+  const [loading, setLoading] = useState(false);
+  const [logFilePresent, setLogFilePresent] = useState(true);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+
+  const loadLines = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await logsAPI.getRecent(200, filter);
+      setLines(res.lines);
+      setLogFilePresent(res.log_file_present);
+    } catch (e) {
+      log.error({ err: e }, 'failed to load logs');
+      error('Could not load logs');
+    } finally {
+      setLoading(false);
+    }
+  }, [filter, error]);
+
+  useEffect(() => {
+    loadLines();
+  }, [loadLines]);
+
+  const formatLines = useMemo(
+    () =>
+      lines
+        .map((l) => `${l.ts} [${l.level}] ${l.logger}: ${l.message}`)
+        .join('\n'),
+    [lines],
+  );
+
+  const handleCopy = async () => {
+    if (!lines.length) {
+      error('Nothing to copy yet');
+      return;
+    }
+    const ok = await copyToClipboard(formatLines);
+    if (ok) success(`Copied ${lines.length} lines`);
+    else error('Could not copy. Select the text manually.');
+  };
+
+  const handleDownload = () => {
+    const a = document.createElement('a');
+    a.href = logsAPI.bundleUrl();
+    a.rel = 'noopener';
+    a.click();
+  };
+
+  const handleClear = async () => {
+    if (!confirmingClear) {
+      setConfirmingClear(true);
+      setTimeout(() => setConfirmingClear(false), 4000);
+      return;
+    }
+    setConfirmingClear(false);
+    setLoading(true);
+    try {
+      await logsAPI.clear();
+      success('Logs cleared');
+      await loadLines();
+    } catch (e) {
+      log.error({ err: e }, 'failed to clear logs');
+      error('Could not clear logs');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-5xl space-y-6 pb-8">
+      <header>
+        <h2 className="text-lg font-semibold text-stone-900">Diagnostic logs</h2>
+        <p className="mt-1 text-sm text-stone-600 max-w-prose leading-relaxed">
+          Recent backend and frontend errors from this deployment. Download the{' '}
+          <strong>support bundle</strong> to share a complete snapshot — the ZIP
+          includes the rotating log files (with secrets scrubbed), env-var
+          names, applied migrations, and deployment metadata.
+        </p>
+      </header>
+
+      {/* Filter row */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {FILTERS.map((f) => {
+          const isActive = filter === f.id;
+          return (
+            <button
+              key={f.id}
+              onClick={() => setFilter(f.id)}
+              className={[
+                'px-3 py-1 text-[11px] uppercase tracking-[0.08em] rounded-full border transition-colors',
+                isActive
+                  ? 'border-amber-500/50 bg-amber-50 text-stone-900'
+                  : 'border-stone-200 bg-white text-stone-500 hover:text-stone-900',
+              ].join(' ')}
+              aria-pressed={isActive}
+            >
+              {f.label}
+            </button>
+          );
+        })}
+        <button
+          onClick={loadLines}
+          className="ml-auto inline-flex items-center gap-1 px-2 py-1 text-[11px] uppercase tracking-[0.08em] text-stone-500 hover:text-stone-900"
+          title="Refresh"
+        >
+          <ArrowsClockwise size={12} className={loading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Console panel */}
+      <div className="rounded-lg border border-stone-800/60 bg-stone-900 text-stone-100 font-mono text-[12px] leading-relaxed shadow-inner overflow-hidden">
+        <div className="max-h-[58vh] overflow-y-auto">
+          {loading && lines.length === 0 ? (
+            <div className="h-48 flex items-center justify-center text-stone-400">
+              <CircleNotch size={16} className="mr-2 animate-spin" />
+              Loading logs…
+            </div>
+          ) : !logFilePresent ? (
+            <div className="h-48 flex flex-col items-center justify-center text-stone-400 px-6 text-center">
+              <p className="text-stone-200">No log file on disk yet.</p>
+              <p className="text-[11px] mt-1 max-w-sm">
+                The rotating handler creates the file on the first log line.
+                Trigger any action and refresh.
+              </p>
+            </div>
+          ) : lines.length === 0 ? (
+            <div className="h-48 flex flex-col items-center justify-center text-stone-400 px-6 text-center">
+              <p className="text-stone-200">All quiet.</p>
+              <p className="text-[11px] mt-1">
+                No matching lines for this filter.
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-stone-800/80">
+              {lines.map((l, i) => (
+                <LogRow key={i} line={l} />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Action row */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleClear}
+          disabled={loading}
+          className={
+            confirmingClear
+              ? 'gap-2 text-rose-700 hover:text-rose-800'
+              : 'gap-2 text-stone-500 hover:text-stone-900'
+          }
+        >
+          <Trash size={14} />
+          {confirmingClear ? 'Click again to clear' : 'Clear logs'}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleCopy}
+          disabled={loading || !lines.length}
+          className="gap-2 text-stone-500 hover:text-stone-900"
+        >
+          <Copy size={14} />
+          Copy view
+        </Button>
+
+        <div className="flex-1" />
+
+        <Button variant="default" size="sm" onClick={handleDownload} className="gap-2">
+          <DownloadSimple size={14} weight="bold" />
+          Download bundle (.zip)
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+const LogRow: React.FC<{ line: LogLine }> = ({ line }) => {
+  const isError = line.level === 'ERROR' || line.level === 'CRITICAL';
+  const isWarn = line.level === 'WARNING';
+
+  return (
+    <li className="px-4 py-2.5 hover:bg-stone-800/40 transition-colors">
+      <div className="flex items-center gap-2 text-[11px] tracking-tight">
+        <span className="text-stone-500 tabular-nums">{line.ts}</span>
+        <span
+          className={[
+            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm uppercase tracking-[0.06em] text-[10px] font-semibold',
+            isError
+              ? 'bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/30'
+              : isWarn
+                ? 'bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/30'
+                : 'bg-stone-700/40 text-stone-400 ring-1 ring-stone-600/30',
+          ].join(' ')}
+        >
+          {isError ? (
+            <XCircle size={10} weight="fill" />
+          ) : isWarn ? (
+            <Warning size={10} weight="fill" />
+          ) : null}
+          {line.level}
+        </span>
+        <span className="text-stone-400 truncate" title={line.logger}>
+          {line.logger}
+        </span>
+      </div>
+      <pre className="mt-1 whitespace-pre-wrap break-words text-stone-100 text-[12px] leading-relaxed font-mono pl-[3px]">
+        {line.message}
+      </pre>
+    </li>
+  );
+};

--- a/frontend/src/components/settings/sections/LogsSection.tsx
+++ b/frontend/src/components/settings/sections/LogsSection.tsx
@@ -5,103 +5,16 @@
  * content area: full-width panel, no Dialog chrome, prose-style intro
  * paragraph that explains what the bundle contains so the admin knows
  * what they're sharing.
+ *
+ * Behavior + content all come from `useLogsState` and `LogConsole` so
+ * the modal and this section can never drift out of sync.
  */
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  ArrowsClockwise,
-  CircleNotch,
-  Copy,
-  DownloadSimple,
-  Trash,
-  Warning,
-  XCircle,
-} from '@phosphor-icons/react';
-import { Button } from '@/components/ui/button';
-import { useToast } from '@/components/ui/use-toast';
-import { logsAPI, type LogLine } from '@/lib/api/logs';
-import { copyToClipboard } from '@/lib/clipboard';
-import { createLogger } from '@/lib/logger';
-
-const log = createLogger('logs-section');
-
-type LevelFilter = 'errors' | 'warnings' | 'all';
-
-const FILTERS: { id: LevelFilter; label: string }[] = [
-  { id: 'errors', label: 'Errors' },
-  { id: 'warnings', label: 'Errors + warnings' },
-  { id: 'all', label: 'All levels' },
-];
+import React from 'react';
+import { LogConsole } from '@/components/project/LogConsole';
+import { useLogsState } from '@/components/project/useLogsState';
 
 export const LogsSection: React.FC = () => {
-  const { success, error } = useToast();
-  const [lines, setLines] = useState<LogLine[]>([]);
-  const [filter, setFilter] = useState<LevelFilter>('errors');
-  const [loading, setLoading] = useState(false);
-  const [logFilePresent, setLogFilePresent] = useState(true);
-  const [confirmingClear, setConfirmingClear] = useState(false);
-
-  const loadLines = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await logsAPI.getRecent(200, filter);
-      setLines(res.lines);
-      setLogFilePresent(res.log_file_present);
-    } catch (e) {
-      log.error({ err: e }, 'failed to load logs');
-      error('Could not load logs');
-    } finally {
-      setLoading(false);
-    }
-  }, [filter, error]);
-
-  useEffect(() => {
-    loadLines();
-  }, [loadLines]);
-
-  const formatLines = useMemo(
-    () =>
-      lines
-        .map((l) => `${l.ts} [${l.level}] ${l.logger}: ${l.message}`)
-        .join('\n'),
-    [lines],
-  );
-
-  const handleCopy = async () => {
-    if (!lines.length) {
-      error('Nothing to copy yet');
-      return;
-    }
-    const ok = await copyToClipboard(formatLines);
-    if (ok) success(`Copied ${lines.length} lines`);
-    else error('Could not copy. Select the text manually.');
-  };
-
-  const handleDownload = () => {
-    const a = document.createElement('a');
-    a.href = logsAPI.bundleUrl();
-    a.rel = 'noopener';
-    a.click();
-  };
-
-  const handleClear = async () => {
-    if (!confirmingClear) {
-      setConfirmingClear(true);
-      setTimeout(() => setConfirmingClear(false), 4000);
-      return;
-    }
-    setConfirmingClear(false);
-    setLoading(true);
-    try {
-      await logsAPI.clear();
-      success('Logs cleared');
-      await loadLines();
-    } catch (e) {
-      log.error({ err: e }, 'failed to clear logs');
-      error('Could not clear logs');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const state = useLogsState({ active: true });
 
   return (
     <div className="max-w-5xl space-y-6 pb-8">
@@ -115,139 +28,20 @@ export const LogsSection: React.FC = () => {
         </p>
       </header>
 
-      {/* Filter row */}
-      <div className="flex items-center gap-2 flex-wrap">
-        {FILTERS.map((f) => {
-          const isActive = filter === f.id;
-          return (
-            <button
-              key={f.id}
-              onClick={() => setFilter(f.id)}
-              className={[
-                'px-3 py-1 text-[11px] uppercase tracking-[0.08em] rounded-full border transition-colors',
-                isActive
-                  ? 'border-amber-500/50 bg-amber-50 text-stone-900'
-                  : 'border-stone-200 bg-white text-stone-500 hover:text-stone-900',
-              ].join(' ')}
-              aria-pressed={isActive}
-            >
-              {f.label}
-            </button>
-          );
-        })}
-        <button
-          onClick={loadLines}
-          className="ml-auto inline-flex items-center gap-1 px-2 py-1 text-[11px] uppercase tracking-[0.08em] text-stone-500 hover:text-stone-900"
-          title="Refresh"
-        >
-          <ArrowsClockwise size={12} className={loading ? 'animate-spin' : ''} />
-          Refresh
-        </button>
-      </div>
-
-      {/* Console panel */}
-      <div className="rounded-lg border border-stone-800/60 bg-stone-900 text-stone-100 font-mono text-[12px] leading-relaxed shadow-inner overflow-hidden">
-        <div className="max-h-[58vh] overflow-y-auto">
-          {loading && lines.length === 0 ? (
-            <div className="h-48 flex items-center justify-center text-stone-400">
-              <CircleNotch size={16} className="mr-2 animate-spin" />
-              Loading logs…
-            </div>
-          ) : !logFilePresent ? (
-            <div className="h-48 flex flex-col items-center justify-center text-stone-400 px-6 text-center">
-              <p className="text-stone-200">No log file on disk yet.</p>
-              <p className="text-[11px] mt-1 max-w-sm">
-                The rotating handler creates the file on the first log line.
-                Trigger any action and refresh.
-              </p>
-            </div>
-          ) : lines.length === 0 ? (
-            <div className="h-48 flex flex-col items-center justify-center text-stone-400 px-6 text-center">
-              <p className="text-stone-200">All quiet.</p>
-              <p className="text-[11px] mt-1">
-                No matching lines for this filter.
-              </p>
-            </div>
-          ) : (
-            <ul className="divide-y divide-stone-800/80">
-              {lines.map((l, i) => (
-                <LogRow key={i} line={l} />
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
-
-      {/* Action row */}
-      <div className="flex items-center gap-2 flex-wrap">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleClear}
-          disabled={loading}
-          className={
-            confirmingClear
-              ? 'gap-2 text-rose-700 hover:text-rose-800'
-              : 'gap-2 text-stone-500 hover:text-stone-900'
-          }
-        >
-          <Trash size={14} />
-          {confirmingClear ? 'Click again to clear' : 'Clear logs'}
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleCopy}
-          disabled={loading || !lines.length}
-          className="gap-2 text-stone-500 hover:text-stone-900"
-        >
-          <Copy size={14} />
-          Copy view
-        </Button>
-
-        <div className="flex-1" />
-
-        <Button variant="default" size="sm" onClick={handleDownload} className="gap-2">
-          <DownloadSimple size={14} weight="bold" />
-          Download bundle (.zip)
-        </Button>
-      </div>
+      <LogConsole
+        variant="page"
+        panelMaxHeightClassName="max-h-[58vh]"
+        lines={state.lines}
+        filter={state.filter}
+        onFilterChange={state.setFilter}
+        loading={state.loading}
+        logFilePresent={state.logFilePresent}
+        confirmingClear={state.confirmingClear}
+        onRefresh={state.loadLines}
+        onCopy={state.handleCopy}
+        onDownload={state.handleDownload}
+        onClear={state.handleClear}
+      />
     </div>
-  );
-};
-
-const LogRow: React.FC<{ line: LogLine }> = ({ line }) => {
-  const isError = line.level === 'ERROR' || line.level === 'CRITICAL';
-  const isWarn = line.level === 'WARNING';
-
-  return (
-    <li className="px-4 py-2.5 hover:bg-stone-800/40 transition-colors">
-      <div className="flex items-center gap-2 text-[11px] tracking-tight">
-        <span className="text-stone-500 tabular-nums">{line.ts}</span>
-        <span
-          className={[
-            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm uppercase tracking-[0.06em] text-[10px] font-semibold',
-            isError
-              ? 'bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/30'
-              : isWarn
-                ? 'bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/30'
-                : 'bg-stone-700/40 text-stone-400 ring-1 ring-stone-600/30',
-          ].join(' ')}
-        >
-          {isError ? (
-            <XCircle size={10} weight="fill" />
-          ) : isWarn ? (
-            <Warning size={10} weight="fill" />
-          ) : null}
-          {line.level}
-        </span>
-        <span className="text-stone-400 truncate" title={line.logger}>
-          {line.logger}
-        </span>
-      </div>
-      <pre className="mt-1 whitespace-pre-wrap break-words text-stone-100 text-[12px] leading-relaxed font-mono pl-[3px]">
-        {line.message}
-      </pre>
-    </li>
   );
 };

--- a/frontend/src/components/settings/sections/index.ts
+++ b/frontend/src/components/settings/sections/index.ts
@@ -6,3 +6,4 @@ export { SystemSection } from './SystemSection';
 export { DesignSection } from './DesignSection';
 export { ModelsSection } from './ModelsSection';
 export { PromptsSection } from './PromptsSection';
+export { LogsSection } from './LogsSection';

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,12 +1,16 @@
 /**
  * Simple Toast Notification Component
+ *
  * Educational Note: A lightweight toast notification system for showing
- * temporary messages to users.
+ * temporary messages to users. Toasts can carry an optional action
+ * button (e.g. "View logs") which is admin-gated when `adminOnly` is
+ * set on the action.
  */
 
 import React, { useEffect } from 'react';
 import { CheckCircle, XCircle, Info, X } from '@phosphor-icons/react';
 import type { Toast } from './use-toast';
+import { getAdminMode } from '@/lib/adminMode';
 
 interface ToastContainerProps {
   toasts: Toast[];
@@ -29,13 +33,16 @@ interface ToastItemProps {
 }
 
 const ToastItem: React.FC<ToastItemProps> = ({ toast, onDismiss }) => {
+  // Toasts with an action stay on screen longer — the user needs time to
+  // notice and click. Plain toasts dismiss in 5s as before.
+  const dismissMs = toast.action ? 8000 : 5000;
   useEffect(() => {
     const timer = setTimeout(() => {
       onDismiss(toast.id);
-    }, 5000); // Auto dismiss after 5 seconds
+    }, dismissMs);
 
     return () => clearTimeout(timer);
-  }, [toast.id, onDismiss]);
+  }, [toast.id, onDismiss, dismissMs]);
 
   const getIcon = () => {
     switch (toast.type) {
@@ -59,12 +66,29 @@ const ToastItem: React.FC<ToastItemProps> = ({ toast, onDismiss }) => {
     }
   };
 
+  // Action button visibility: hide adminOnly actions when the current
+  // user isn't admin, so a "View logs" button never appears for someone
+  // who can't actually see logs.
+  const showAction =
+    toast.action && (!toast.action.adminOnly || getAdminMode());
+
   return (
     <div
       className={`flex items-center gap-3 px-4 py-3 rounded-lg border shadow-lg ${getBgColor()} min-w-[300px] max-w-[500px] animate-in slide-in-from-right`}
     >
       {getIcon()}
       <p className="flex-1 text-sm">{toast.message}</p>
+      {showAction && toast.action && (
+        <button
+          onClick={() => {
+            toast.action!.onClick();
+            onDismiss(toast.id);
+          }}
+          className="text-xs font-medium text-stone-700 hover:text-stone-900 underline underline-offset-2 decoration-stone-400 hover:decoration-stone-700 whitespace-nowrap"
+        >
+          {toast.action.label}
+        </button>
+      )}
       <button
         onClick={() => onDismiss(toast.id)}
         className="text-muted-foreground hover:text-foreground"

--- a/frontend/src/components/ui/use-toast.ts
+++ b/frontend/src/components/ui/use-toast.ts
@@ -1,20 +1,33 @@
 import { useCallback, useState } from 'react';
+import { getAdminMode, openLogsModal } from '@/lib/adminMode';
 
 export type ToastType = 'success' | 'error' | 'info';
+
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+  /** When true, the action is hidden for non-admins. Used by `errorWithLogs`
+   * so a "View logs" affordance never leaks past the role gate. */
+  adminOnly?: boolean;
+}
 
 export interface Toast {
   id: string;
   type: ToastType;
   message: string;
+  action?: ToastAction;
 }
 
 export const useToast = () => {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const showToast = useCallback((type: ToastType, message: string) => {
-    const id = Date.now().toString();
-    setToasts((prev) => [...prev, { id, type, message }]);
-  }, []);
+  const showToast = useCallback(
+    (type: ToastType, message: string, action?: ToastAction) => {
+      const id = Date.now().toString() + Math.random().toString(36).slice(2, 6);
+      setToasts((prev) => [...prev, { id, type, message, action }]);
+    },
+    [],
+  );
 
   const dismissToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((toast) => toast.id !== id));
@@ -24,5 +37,38 @@ export const useToast = () => {
   const error = useCallback((message: string) => showToast('error', message), [showToast]);
   const info = useCallback((message: string) => showToast('info', message), [showToast]);
 
-  return { toasts, showToast, dismissToast, success, error, info };
+  /**
+   * Like `error()`, but appends a "View logs" button on the toast that
+   * opens the diagnostic-logs modal directly. Use this for failures that
+   * actually represent backend breakage (network errors, 500s, "failed
+   * to load …") — *not* for input validation, missing-config prompts,
+   * or "permission denied" messages where logs won't help.
+   *
+   * The action is admin-only at render time, so non-admins see the same
+   * plain error toast as if `error()` had been called.
+   */
+  const errorWithLogs = useCallback(
+    (message: string) =>
+      showToast('error', message, {
+        label: 'View logs',
+        onClick: openLogsModal,
+        adminOnly: true,
+      }),
+    [showToast],
+  );
+
+  return {
+    toasts,
+    showToast,
+    dismissToast,
+    success,
+    error,
+    errorWithLogs,
+    info,
+  };
 };
+
+// Re-export for convenience so call sites that already do `import { useToast }`
+// can also `import { getAdminMode }` from the same place if needed for
+// custom action gating.
+export { getAdminMode };

--- a/frontend/src/lib/adminMode.ts
+++ b/frontend/src/lib/adminMode.ts
@@ -1,0 +1,33 @@
+/**
+ * Tiny module-level mirror of the current user's admin status.
+ *
+ * Set once from App.tsx after auth resolves. Read by leaf-level helpers
+ * (the toast renderer is the main consumer) so they can decide whether
+ * to surface admin-only affordances without prop-drilling `isAdmin`
+ * through every component tree.
+ *
+ * Trade-off acknowledged: this is module-level mutable state, which
+ * normally we'd avoid. The alternative — threading isAdmin through
+ * every error-toast call site — is worse. The flag is read-only from
+ * the consumer's perspective and only flips on auth refresh, so it
+ * doesn't introduce render-correctness issues.
+ */
+let adminMode = false;
+
+export function setAdminMode(value: boolean): void {
+  adminMode = value;
+}
+
+export function getAdminMode(): boolean {
+  return adminMode;
+}
+
+/**
+ * Window event names dispatched / listened-to globally. Centralized
+ * here so producers and consumers can't drift on the string.
+ */
+export const LOGS_OPEN_EVENT = 'noobbook:open-logs';
+
+export function openLogsModal(): void {
+  window.dispatchEvent(new CustomEvent(LOGS_OPEN_EVENT));
+}

--- a/frontend/src/lib/api/logs.ts
+++ b/frontend/src/lib/api/logs.ts
@@ -1,0 +1,60 @@
+/**
+ * Logs API — admin diagnostic bundle + client-side error reporting.
+ *
+ * The admin endpoints (recent / bundle / clear) are gated by @require_admin
+ * on the backend. The client-error endpoint accepts any authenticated user
+ * so the frontend's window.onerror hook can report from any session.
+ */
+import { api, API_HOST, getAuthUrl } from './client';
+
+export interface LogLine {
+  ts: string;
+  level: 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR' | 'CRITICAL';
+  logger: string;
+  message: string;
+}
+
+export interface RecentLogsResponse {
+  success: boolean;
+  lines: LogLine[];
+  log_file_present: boolean;
+}
+
+export interface ClientErrorPayload {
+  message: string;
+  stack?: string;
+  url?: string;
+  userAgent?: string;
+  timestamp?: string;
+}
+
+export const logsAPI = {
+  async getRecent(n = 100, level: 'errors' | 'warnings' | 'all' = 'errors') {
+    const res = await api.get<RecentLogsResponse>('/logs/recent', {
+      params: { n, level },
+    });
+    return res.data;
+  },
+
+  /** Browser-direct download URL for the support bundle. JWT goes in query
+   * string because <a download> can't set Authorization headers. */
+  bundleUrl(): string {
+    return getAuthUrl(`${API_HOST}/api/v1/logs/bundle`);
+  },
+
+  async clear() {
+    const res = await api.post<{ success: boolean; cleared: number }>('/logs/clear');
+    return res.data;
+  },
+
+  /** Fire-and-forget client error report. We don't await the response in
+   * the error handler — keeping the post lightweight + non-blocking is the
+   * point. */
+  async reportClientError(payload: ClientErrorPayload): Promise<void> {
+    try {
+      await api.post('/logs/client', payload);
+    } catch {
+      // Swallow — reporting an error must never throw an error itself.
+    }
+  },
+};

--- a/frontend/src/lib/errorReporter.ts
+++ b/frontend/src/lib/errorReporter.ts
@@ -1,0 +1,97 @@
+/**
+ * Browser-error reporter.
+ *
+ * Hooks `window.onerror` and `window.onunhandledrejection` and forwards
+ * reports to the backend's `/logs/client` endpoint, where they're written
+ * into the same rotating log file as backend errors. Admins can then
+ * download the support bundle and see client + server events
+ * interleaved.
+ *
+ * Design notes:
+ *   - Throttled to one POST per second so a runaway-error loop can't
+ *     pummel the backend.
+ *   - Drops if the buffer hits 50 pending — we'd rather lose later
+ *     events than block the page.
+ *   - All POST failures are swallowed; reporting an error must never
+ *     itself throw.
+ *   - Idempotent install — calling install() twice doesn't double-hook.
+ */
+import { logsAPI, type ClientErrorPayload } from './api/logs';
+
+const MAX_BUFFER = 50;
+const POST_INTERVAL_MS = 1000;
+
+let installed = false;
+const buffer: ClientErrorPayload[] = [];
+let flushScheduled = false;
+
+function scheduleFlush() {
+  if (flushScheduled) return;
+  flushScheduled = true;
+  setTimeout(async () => {
+    flushScheduled = false;
+    while (buffer.length > 0) {
+      const next = buffer.shift()!;
+      await logsAPI.reportClientError(next);
+      if (buffer.length > 0) {
+        await new Promise((r) => setTimeout(r, POST_INTERVAL_MS));
+      }
+    }
+  }, 0);
+}
+
+function enqueue(payload: ClientErrorPayload) {
+  if (buffer.length >= MAX_BUFFER) return;
+  buffer.push({
+    ...payload,
+    url: payload.url ?? window.location.href,
+    userAgent: payload.userAgent ?? navigator.userAgent,
+    timestamp: payload.timestamp ?? new Date().toISOString(),
+  });
+  scheduleFlush();
+}
+
+function handleError(event: ErrorEvent) {
+  enqueue({
+    message: event.message || 'window.onerror with empty message',
+    stack: event.error?.stack ?? `at ${event.filename}:${event.lineno}:${event.colno}`,
+  });
+}
+
+function handleRejection(event: PromiseRejectionEvent) {
+  const reason = event.reason;
+  let message = 'unhandledrejection';
+  let stack: string | undefined;
+  if (reason instanceof Error) {
+    message = reason.message || message;
+    stack = reason.stack;
+  } else if (typeof reason === 'string') {
+    message = reason;
+  } else {
+    try {
+      message = JSON.stringify(reason);
+    } catch {
+      // leave default
+    }
+  }
+  enqueue({ message, stack });
+}
+
+export const errorReporter = {
+  install() {
+    if (installed) return;
+    installed = true;
+    window.addEventListener('error', handleError);
+    window.addEventListener('unhandledrejection', handleRejection);
+  },
+
+  /** Manual report path — use from React error boundaries or anywhere
+   * the global handlers can't see (e.g. caught-then-handled errors that
+   * are still worth telemetry). */
+  report(message: string, error?: unknown) {
+    enqueue({
+      message,
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+  },
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,11 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { errorReporter } from './lib/errorReporter'
+
+// Install global browser-error capture so unhandled errors / promise
+// rejections show up alongside backend errors in the admin Logs bundle.
+errorReporter.install()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
Self-hosted customers (e.g. the recent Freshdesk DB-connectivity bug) had no way to share backend logs with us — `docker logs` is the only path and most Coolify-style deployments don't give the customer shell access. This PR ships an admin-only Logs feature: a button in the project header (next to Share) and a Settings → Logs tab, both letting an admin browse recent errors and download a complete diagnostic bundle as a ZIP.

### Backend
- **`backend/app/utils/logger.py`** — adds a `RotatingFileHandler` (`/app/data/logs/backend.log`, 5MB × 5 archives) on top of the existing stdout handler. Stdout output is unchanged so `docker logs` keeps working; the file is purely additive and persists in the `backend-data` volume.
- **`backend/app/api/logs/`** (new blueprint) — 4 routes:
  - `POST /logs/client` (any auth) — frontend reports browser errors, written into `backend.log` with a `[CLIENT user=… url=…]` tag so client + server events interleave naturally.
  - `GET /logs/recent` (`@require_admin`) — JSON of last N error/warning lines for the modal preview.
  - `GET /logs/bundle` (`@require_admin`) — streams a ZIP attachment containing all rotated log files (redacted), `info.json` (deployment metadata, redacted Supabase host), `env-keys.txt` (env-var names only — no values), and `migrations.txt` (applied migrations from `schema_migrations`).
  - `POST /logs/clear` (`@require_admin`) — truncates the log file + removes archives so admins can capture a clean reproduction window.
- **Redaction** — `redaction.py` scrubs Postgres connection strings, Bearer tokens, JWT shapes, and Anthropic/OpenAI API key shapes before lines leave the server. Original log file is never modified.

### Frontend
- **`LogsButton`** — header trigger next to Share, gated `{isAdmin && <LogsButton />}` in `ProjectHeader`.
- **`LogsModal`** — operator's-console aesthetic: warm cream chrome, dark stone-900 panel for the actual log content with monospace text and color-coded level pills (rose for ERROR, amber for WARNING). Filter chips (errors / warnings / all), Refresh, Copy view, Clear (two-click confirm), and the primary "Download bundle (.zip)" action.
- **`LogsSection`** — same content reflowed for the Settings page; adds a `{ id: 'logs', adminOnly: true }` entry to `SettingsSidebar`.
- **`errorReporter`** (`lib/errorReporter.ts`) — installed once in `main.tsx`, hooks `window.onerror` and `window.onunhandledrejection`, throttled to one POST/sec, max-50 buffer. Unhandled browser errors land in the same log file as backend errors.

### Toast integration
- `useToast()` now exposes `errorWithLogs(message)` — appends a "View logs" action button on the toast that opens the LogsModal directly. Action is admin-only at render time (`adminMode` flag mirrored from App auth state) so non-admins never see the button.
- A single `<GlobalLogsModalGate isAdmin={isAdmin} />` mounted at the App root listens for the `noobbook:open-logs` window event so any toast (or future caller) can request the logs view without prop-drilling.
- Converted ~6 high-signal backend-failure toasts to `errorWithLogs` (load chat / chats, send message ×2, load memory, load prompts, load shares, load API keys). Validation/config error toasts intentionally left as plain `error()`.

## Test plan
- [ ] Trigger a backend error (e.g. malformed API call) → check `/app/data/logs/backend.log` exists and the line is captured. `docker logs` still shows the same line.
- [ ] Browser console: `throw new Error('client test')` → after ~1s, that line appears in `backend.log` with `[CLIENT user=… url=…]` prefix.
- [ ] Sign in as admin → Logs button visible in project header. Click → modal opens, recent errors render, level pills color-coded. Download bundle → ZIP contains `backend.log`, `info.json`, `env-keys.txt`, `migrations.txt`. Connection strings/Bearer tokens inside `backend.log` are `[REDACTED]`.
- [ ] Settings → Logs tab present (admin only) — same content, wider layout.
- [ ] Sign in as non-admin → Logs button hidden, Logs settings tab hidden, `GET /logs/recent` returns 403.
- [ ] Trigger any of the converted error toasts (e.g. force a network failure on chat send) → toast shows "View logs" button, clicking opens the LogsModal.
- [ ] As non-admin, force the same toast → "View logs" button is *not* shown.
- [ ] Clear logs (two-click confirm) → file truncated, archives removed, modal shows "All quiet".
- [ ] `npm run lint` clean (only the 2 pre-existing warnings), `npx tsc --noEmit` clean, `npm run build` succeeds.