### PR TITLE
sync develop → main: fix chat error-boundary crash

### DIFF
--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -527,7 +527,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
       className="flex-1 min-h-0 min-w-0 w-full overflow-y-auto overflow-x-hidden bg-white"
     >
       <div className="pt-6 pb-2 px-6 space-y-4 w-full">
-        {messages.map((msg) => (
+        {messages.filter((msg) => msg && msg.id).map((msg) => (
           <div key={msg.id}>
             {msg.role === 'user' ? (
               <UserMessage content={msg.content} />

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -444,6 +444,11 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     });
 
     const replaceTempWithCanonicalUser = (canonicalUserMessage: Chat['messages'][number]) => {
+      // Some SSE producers occasionally emit a `user_message` event with a
+      // missing/null payload during reconnects. Bail out instead of poisoning
+      // activeChat.messages with `undefined`, which crashes the renderer
+      // (`Cannot read properties of undefined (reading 'id')`).
+      if (!canonicalUserMessage?.id) return;
       canonicalUserMessageReceivedRef.current = true;
       setActiveChat((prev) => {
         if (!prev) return null;
@@ -459,6 +464,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     };
 
     const appendAssistantMessage = (assistantMessage: Chat['messages'][number]) => {
+      // Same defensive guard as replaceTempWithCanonicalUser. See note there.
+      if (!assistantMessage?.id) {
+        log.warn('appendAssistantMessage called with empty payload — ignoring');
+        setStreamingAssistantContent('');
+        return;
+      }
       // Append the final message first, THEN clear streaming content in the
       // same React batch. This prevents a flash where neither the streaming
       // bubble nor the final message is visible.
@@ -487,9 +498,14 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       setActiveChat((prev) => {
         if (!prev) return null;
         const messagesWithoutTemp = prev.messages.filter((m) => m.id !== tempUserMessage.id);
+        // Filter out anything missing an `id` so a malformed REST fallback
+        // payload doesn't crash the renderer downstream.
+        const incoming = [result.user_message, result.assistant_message].filter(
+          (m): m is Chat['messages'][number] => Boolean(m?.id),
+        );
         return {
           ...prev,
-          messages: [...messagesWithoutTemp, result.user_message, result.assistant_message],
+          messages: [...messagesWithoutTemp, ...incoming],
           updated_at: new Date().toISOString(),
         };
       });


### PR DESCRIPTION
## Summary
Sync develop → main. Fixes a render crash where `Cannot read properties of undefined (reading 'id')` would trigger the ErrorBoundary fallback after every AI response (refresh recovered correctly because the DB had the message — only the live SSE-update path was poisoning state).

Three defensive layers in `ChatPanel.tsx` + one in `ChatMessages.tsx`:
- `replaceTempWithCanonicalUser` / `appendAssistantMessage` bail if the SSE payload arrives without an `id`
- `applyFallbackResponse` type-narrows incoming messages so a malformed REST payload can't slip undefined into the array
- `ChatMessages.tsx` filters `messages` before mapping as a final safety net

## Test plan
- [ ] Send chat message → AI response renders without ErrorBoundary fallback
- [ ] If it still triggers, check the admin Logs bundle for `appendAssistantMessage called with empty payload` to identify which SSE event arrived empty