### PR TITLE
Default new users to $25/week + admin 'Reset spend now' button

### DIFF
--- a/backend/app/api/settings/users.py
+++ b/backend/app/api/settings/users.py
@@ -14,7 +14,10 @@ from flask import jsonify, request, current_app
 
 from app.api.settings import settings_bp
 from app.services.auth.rbac import require_admin, get_request_identity
-from app.services.data_services.user_service import get_user_service
+from app.services.data_services.user_service import (
+    get_user_service,
+    SpendingPersistenceError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -249,7 +252,16 @@ def reset_cost_period(user_id: str):
         return jsonify({"success": False, "error": "User not found"}), 404
     prior_spend = float(target.get("period_spend") or 0.0)
 
-    updated = svc.reset_spending_period(user_id)
+    try:
+        updated = svc.reset_spending_period(user_id)
+    except SpendingPersistenceError as exc:
+        # Persistence failure — Supabase update affected 0 rows. Distinct
+        # from "no limit set" so the admin sees the right error.
+        logger.error("Failed to persist spend reset for %s: %s", user_id, exc)
+        return jsonify({
+            "success": False,
+            "error": "Failed to persist spend reset — try again or check backend logs",
+        }), 500
     if updated is None:
         return jsonify({"success": False, "error": "User has no spending limit to reset"}), 400
 

--- a/backend/app/api/settings/users.py
+++ b/backend/app/api/settings/users.py
@@ -8,11 +8,15 @@ Routes:
 - PUT  /settings/users/<user_id>/role
 - POST /settings/users/<user_id>/reset-password
 """
+import logging
+
 from flask import jsonify, request, current_app
 
 from app.api.settings import settings_bp
 from app.services.auth.rbac import require_admin, get_request_identity
 from app.services.data_services.user_service import get_user_service
+
+logger = logging.getLogger(__name__)
 
 
 @settings_bp.route("/settings/users", methods=["GET"])
@@ -219,6 +223,55 @@ def update_cost_limit(user_id: str):
         return jsonify({"success": False, "error": "User not found"}), 404
 
     return jsonify({"success": True, "cost_limit": cost_limit, "reset_frequency": reset_frequency}), 200
+
+
+@settings_bp.route("/settings/users/<user_id>/cost-limit/reset", methods=["POST"])
+@require_admin
+def reset_cost_period(user_id: str):
+    """
+    Hard-reset a user's running spend tally without waiting for the
+    weekly / monthly tick.
+
+    Use case: admin manually approves a one-off overrun, or wants to
+    clear the slate for a user mid-period. For lifetime caps (no
+    reset_frequency), zeroes period_spend only.
+
+    Returns the freshly-updated settings so the frontend can replace
+    the row state in one go (same shape as the cost-limit PUT response,
+    plus the post-reset period_spend / period_start).
+    """
+    svc = get_user_service()
+
+    # Capture the user's email and prior period_spend BEFORE the write so
+    # we can attribute the action in the audit log.
+    target = svc.get_user(user_id)
+    if not target:
+        return jsonify({"success": False, "error": "User not found"}), 404
+    prior_spend = float(target.get("period_spend") or 0.0)
+
+    updated = svc.reset_spending_period(user_id)
+    if updated is None:
+        return jsonify({"success": False, "error": "User has no spending limit to reset"}), 400
+
+    # Audit log — lands in the rotating log file, included in the admin
+    # diagnostic bundle (see backend/app/api/logs/). Lets us answer "who
+    # reset whom and when" without a separate audit table.
+    identity = get_request_identity()
+    admin_email = (identity.email or identity.user_id) if identity else "unknown"
+    target_email = target.get("email") or user_id
+    logger.info(
+        "[ADMIN] %s reset cost period for %s (was $%.2f)",
+        admin_email, target_email, prior_spend,
+    )
+
+    return jsonify({
+        "success": True,
+        "cost_limit": updated.get("cost_limit"),
+        "reset_frequency": updated.get("reset_frequency"),
+        "period_spend": updated.get("period_spend", 0.0),
+        "period_start": updated.get("period_start"),
+        "prior_period_spend": prior_spend,
+    }), 200
 
 
 @settings_bp.route("/settings/users/me/usage", methods=["GET"])

--- a/backend/app/services/data_services/user_service.py
+++ b/backend/app/services/data_services/user_service.py
@@ -26,6 +26,15 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+class SpendingPersistenceError(RuntimeError):
+    """Raised when a spending-config write succeeds at the SDK level but
+    Supabase reports zero rows affected (e.g. the user_id was deleted
+    between fetch and update). Distinct from the "user has no cost_limit
+    to reset" case so the route layer can map each to the correct HTTP
+    status — 500 vs 400.
+    """
+
+
 def default_user_settings() -> Dict[str, Any]:
     """
     Build the seed `users.settings` JSONB for newly-created accounts.
@@ -242,10 +251,16 @@ class UserService:
 
         Returns:
             Updated settings dict on success.
-            None if the user has no `cost_limit` set (nothing to reset) or
-            the persistence layer reported the row wasn't updated. The
-            caller surfaces this as a 400. Missing-user is handled at the
-            route layer via a pre-fetch `get_user`.
+            None if the user has no `cost_limit` set (nothing to reset).
+            Caller surfaces this as a 400.
+
+        Raises:
+            SpendingPersistenceError: if the underlying Supabase write
+            reports zero rows affected. Caller surfaces as a 500 — this
+            is a real backend failure, not a "no-op" the admin can
+            interpret as "user already had no limit".
+            Missing-user is handled at the route layer via a pre-fetch
+            `get_user`.
         """
         settings = self.get_user_settings_raw(user_id)
         if not settings.get("cost_limit"):
@@ -255,13 +270,10 @@ class UserService:
         if settings.get("reset_frequency"):
             settings["period_start"] = _now_iso()
 
-        # Propagate the persistence outcome — matches the contract the rest
-        # of this file follows (update_spending_config and friends all
-        # return the boolean from save_user_settings). Without this, a
-        # silent Supabase write failure still echoes "success" + the
-        # mutated in-memory dict back to the admin and into the audit log.
         if not self.save_user_settings(user_id, settings):
-            return None
+            raise SpendingPersistenceError(
+                f"Supabase update affected 0 rows for user {user_id}"
+            )
         return settings
 
     def increment_period_spend(self, user_id: str, amount: float) -> None:

--- a/backend/app/services/data_services/user_service.py
+++ b/backend/app/services/data_services/user_service.py
@@ -9,7 +9,7 @@ operations always use the service_role key.
 """
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from supabase import create_client
@@ -18,6 +18,57 @@ from app.services.integrations.supabase import is_supabase_enabled
 from app.utils.password_utils import generate_secure_password
 
 logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """ISO-8601 UTC with `Z` suffix — matches the convention used elsewhere
+    in this module (see `update_spending_config`)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def default_user_settings() -> Dict[str, Any]:
+    """
+    Build the seed `users.settings` JSONB for newly-created accounts.
+
+    Driven by env vars so self-hosted operators can override without a
+    code change:
+      - NOOBBOOK_DEFAULT_USER_COST_LIMIT  (default: 25)
+      - NOOBBOOK_DEFAULT_USER_RESET_FREQUENCY  (default: weekly)
+
+    Setting the limit to 0 (or any non-positive number) opts out — new
+    users get an empty settings object and behave as unlimited, matching
+    the pre-feature default.
+    """
+    raw_limit = os.getenv("NOOBBOOK_DEFAULT_USER_COST_LIMIT", "25")
+    raw_freq = os.getenv("NOOBBOOK_DEFAULT_USER_RESET_FREQUENCY", "weekly")
+
+    try:
+        cost_limit = float(raw_limit)
+    except ValueError:
+        logger.warning(
+            "Invalid NOOBBOOK_DEFAULT_USER_COST_LIMIT=%r; falling back to 25", raw_limit
+        )
+        cost_limit = 25.0
+
+    if cost_limit <= 0:
+        return {}
+
+    if raw_freq not in ("daily", "weekly", "monthly", "none"):
+        logger.warning(
+            "Invalid NOOBBOOK_DEFAULT_USER_RESET_FREQUENCY=%r; falling back to weekly",
+            raw_freq,
+        )
+        raw_freq = "weekly"
+
+    if raw_freq == "none":
+        return {"cost_limit": cost_limit, "period_spend": 0.0}
+
+    return {
+        "cost_limit": cost_limit,
+        "reset_frequency": raw_freq,
+        "period_spend": 0.0,
+        "period_start": _now_iso(),
+    }
 
 
 class UserService:
@@ -180,6 +231,33 @@ class UserService:
 
         return self.save_user_settings(user_id, settings)
 
+    def reset_spending_period(self, user_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Hard-reset a user's period_spend to 0 and bump period_start to now.
+
+        Used by the admin "Reset spend now" button — lets an operator clear
+        a user's running tally without waiting for the time-based weekly /
+        monthly tick. For lifetime caps (no `reset_frequency`), zeroes
+        period_spend only and leaves period_start untouched.
+
+        Returns:
+            Updated settings dict on success.
+            None if the user doesn't exist or has no `cost_limit` set
+            (nothing to reset). The caller surfaces this as a 400 / 404.
+        """
+        settings = self.get_user_settings_raw(user_id)
+        if settings is None:
+            return None
+        if not settings.get("cost_limit"):
+            return None
+
+        settings["period_spend"] = 0.0
+        if settings.get("reset_frequency"):
+            settings["period_start"] = _now_iso()
+
+        self.save_user_settings(user_id, settings)
+        return settings
+
     def increment_period_spend(self, user_id: str, amount: float) -> None:
         """
         Add to the user's period_spend after a successful API call.
@@ -324,13 +402,15 @@ class UserService:
         if not user_id:
             raise ValueError("Failed to create user in auth system")
 
-        # Create profile in public.users
+        # Create profile in public.users with the env-driven default
+        # spending limit ($25/week unless an operator overrides via
+        # NOOBBOOK_DEFAULT_USER_COST_LIMIT / RESET_FREQUENCY).
         self.supabase.table(self.table).insert({
             "id": user_id,
             "email": email,
             "role": role,
             "memory": {},
-            "settings": {}
+            "settings": default_user_settings()
         }).execute()
 
         user = self.get_user(user_id)

--- a/backend/app/services/data_services/user_service.py
+++ b/backend/app/services/data_services/user_service.py
@@ -242,12 +242,12 @@ class UserService:
 
         Returns:
             Updated settings dict on success.
-            None if the user doesn't exist or has no `cost_limit` set
-            (nothing to reset). The caller surfaces this as a 400 / 404.
+            None if the user has no `cost_limit` set (nothing to reset) or
+            the persistence layer reported the row wasn't updated. The
+            caller surfaces this as a 400. Missing-user is handled at the
+            route layer via a pre-fetch `get_user`.
         """
         settings = self.get_user_settings_raw(user_id)
-        if settings is None:
-            return None
         if not settings.get("cost_limit"):
             return None
 
@@ -255,7 +255,13 @@ class UserService:
         if settings.get("reset_frequency"):
             settings["period_start"] = _now_iso()
 
-        self.save_user_settings(user_id, settings)
+        # Propagate the persistence outcome — matches the contract the rest
+        # of this file follows (update_spending_config and friends all
+        # return the boolean from save_user_settings). Without this, a
+        # silent Supabase write failure still echoes "success" + the
+        # mutated in-memory dict back to the admin and into the audit log.
+        if not self.save_user_settings(user_id, settings):
+            return None
         return settings
 
     def increment_period_spend(self, user_id: str, amount: float) -> None:

--- a/backend/app/services/integrations/supabase/auth_service.py
+++ b/backend/app/services/integrations/supabase/auth_service.py
@@ -265,8 +265,19 @@ class AuthService:
         user data like memory and settings.
         """
         try:
+            # Lazy import to avoid the user_service's own import-time Supabase
+            # init when this auth path runs in environments where user_service
+            # hasn't been needed yet.
+            from app.services.data_services.user_service import default_user_settings
+
             self.supabase.table("users").insert(
-                {"id": user_id, "email": email, "role": role, "memory": {}, "settings": {}}
+                {
+                    "id": user_id,
+                    "email": email,
+                    "role": role,
+                    "memory": {},
+                    "settings": default_user_settings(),
+                }
             ).execute()
         except Exception as e:
             logger.warning("Failed to create user profile: %s", e)

--- a/frontend/src/components/settings/sections/TeamSection.tsx
+++ b/frontend/src/components/settings/sections/TeamSection.tsx
@@ -43,6 +43,7 @@ import {
   Sliders,
   Infinity as InfinityIcon,
   PencilSimple,
+  ArrowCounterClockwise,
 } from '@phosphor-icons/react';
 import {
   Popover,
@@ -82,14 +83,18 @@ const SpendLimitCell: React.FC<{
   const [draftLimit, setDraftLimit] = useState('');
   const [draftFreq, setDraftFreq] = useState<string>('none');
   const [saving, setSaving] = useState(false);
+  const [confirmingReset, setConfirmingReset] = useState(false);
+  const [resetting, setResetting] = useState(false);
   const { success: showSuccess, error: showError } = useToast();
 
-  // Sync draft when popover opens
+  // Sync draft when popover opens. Also clear the reset confirm-state so a
+  // half-armed confirmation from a previous open doesn't carry over.
   const handleOpen = (isOpen: boolean) => {
     if (isOpen) {
       setDraftLimit(value != null ? String(value) : '');
       setDraftFreq(resetFrequency || 'none');
     }
+    setConfirmingReset(false);
     setOpen(isOpen);
   };
 
@@ -115,6 +120,35 @@ const SpendLimitCell: React.FC<{
       showError('Failed to update');
     } finally {
       setSaving(false);
+    }
+  };
+
+  // Two-click confirm pattern (matches the LogsModal "Clear logs" flow):
+  // first click flips the button into a destructive armed state; a second
+  // click within 4s fires the API. After 4s without a follow-up click the
+  // button reverts to its neutral state, so an admin who walks away
+  // doesn't return to a primed nuke button.
+  const handleReset = async () => {
+    if (!confirmingReset) {
+      setConfirmingReset(true);
+      setTimeout(() => setConfirmingReset(false), 4000);
+      return;
+    }
+    setConfirmingReset(false);
+    setResetting(true);
+    try {
+      const result = await usersAPI.resetCostPeriod(userId);
+      onSaved(userId, {
+        cost_limit: result.cost_limit,
+        reset_frequency: result.reset_frequency,
+        period_spend: result.period_spend,
+      });
+      showSuccess(`Reset $${result.prior_period_spend.toFixed(2)} spend to $0`);
+      setOpen(false);
+    } catch {
+      showError('Failed to reset spend');
+    } finally {
+      setResetting(false);
     }
   };
 
@@ -229,6 +263,39 @@ const SpendLimitCell: React.FC<{
             Save
           </Button>
         </div>
+
+        {/* Hard-reset row — separated by a divider so it reads as a
+            distinct destructive action, not a sibling of "Save". Only
+            shown when the user actually has accumulated spend; if
+            period_spend is already $0 there's nothing to reset. */}
+        {periodSpend > 0 && (
+          <div className="pt-3 border-t border-stone-100 space-y-2">
+            <p className="text-[11px] text-stone-500">
+              Current period: <span className="tabular-nums text-stone-700 font-medium">${periodSpend.toFixed(2)}</span> spent
+            </p>
+            <button
+              type="button"
+              onClick={handleReset}
+              disabled={resetting}
+              className={cn(
+                'w-full h-7 inline-flex items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors',
+                confirmingReset
+                  ? 'bg-rose-50 text-rose-700 ring-1 ring-rose-200 hover:bg-rose-100'
+                  : 'text-stone-600 hover:bg-stone-100 hover:text-stone-900',
+                resetting && 'opacity-60 cursor-not-allowed',
+              )}
+            >
+              {resetting ? (
+                <CircleNotch size={12} className="animate-spin" />
+              ) : (
+                <ArrowCounterClockwise size={12} />
+              )}
+              {confirmingReset
+                ? `Click again to confirm — resets $${periodSpend.toFixed(2)}`
+                : 'Reset spend now'}
+            </button>
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/frontend/src/components/settings/sections/TeamSection.tsx
+++ b/frontend/src/components/settings/sections/TeamSection.tsx
@@ -3,7 +3,7 @@
  * Full team management: list users, create, delete, reset password, change roles.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Table,
@@ -85,14 +85,32 @@ const SpendLimitCell: React.FC<{
   const [saving, setSaving] = useState(false);
   const [confirmingReset, setConfirmingReset] = useState(false);
   const [resetting, setResetting] = useState(false);
+  // Track the arming-window timer so we can cancel it on close / re-arm.
+  // Without this, a stale 4s timer from a previous open could fire mid-way
+  // through a fresh confirmation window and silently disarm the button.
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { success: showSuccess, error: showError } = useToast();
 
+  const cancelResetTimer = () => {
+    if (resetTimerRef.current) {
+      clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    }
+  };
+
+  // Cancel any pending arming-window timer when this row unmounts so it
+  // doesn't fire against a torn-down state setter.
+  useEffect(() => () => cancelResetTimer(), []);
+
   // Sync draft when popover opens. Also clear the reset confirm-state so a
-  // half-armed confirmation from a previous open doesn't carry over.
+  // half-armed confirmation from a previous open doesn't carry over, and
+  // cancel any in-flight arming timer on close.
   const handleOpen = (isOpen: boolean) => {
     if (isOpen) {
       setDraftLimit(value != null ? String(value) : '');
       setDraftFreq(resetFrequency || 'none');
+    } else {
+      cancelResetTimer();
     }
     setConfirmingReset(false);
     setOpen(isOpen);
@@ -130,10 +148,15 @@ const SpendLimitCell: React.FC<{
   // doesn't return to a primed nuke button.
   const handleReset = async () => {
     if (!confirmingReset) {
+      cancelResetTimer();
       setConfirmingReset(true);
-      setTimeout(() => setConfirmingReset(false), 4000);
+      resetTimerRef.current = setTimeout(() => {
+        setConfirmingReset(false);
+        resetTimerRef.current = null;
+      }, 4000);
       return;
     }
+    cancelResetTimer();
     setConfirmingReset(false);
     setResetting(true);
     try {

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -502,6 +502,31 @@ class UsersAPI {
     }
   }
 
+  /**
+   * Hard-reset a user's running spend tally to $0 without waiting for
+   * the time-based weekly / monthly tick. Returns the prior period_spend
+   * so the UI can show "reset $11.06" in the toast.
+   */
+  async resetCostPeriod(
+    userId: string,
+  ): Promise<{
+    cost_limit: number | null;
+    reset_frequency: ResetFrequency;
+    period_spend: number;
+    period_start: string | null;
+    prior_period_spend: number;
+  }> {
+    try {
+      const response = await axios.post(
+        `${API_BASE_URL}/settings/users/${userId}/cost-limit/reset`,
+      );
+      return response.data;
+    } catch (error) {
+      log.error({ err: error }, 'failed to reset cost period');
+      throw error;
+    }
+  }
+
   async getMyUsage(): Promise<UserUsage | null> {
     try {
       const response = await axios.get(`${API_BASE_URL}/settings/users/me/usage`);


### PR DESCRIPTION
## Summary
Two related spending-limit improvements (roadmap #20):

**1. Default $25/week for every new user.**
- `users.settings` defaults to `'{}'::jsonb` today, so new users are unlimited until an admin manually sets a cap. Now both creation paths seed `{cost_limit: 25, reset_frequency: "weekly", period_spend: 0, period_start: <now>}`.
- Env-driven via `NOOBBOOK_DEFAULT_USER_COST_LIMIT` and `NOOBBOOK_DEFAULT_USER_RESET_FREQUENCY` so customers can override without a code change. Setting the limit to `0` opts out (back to unlimited). Invalid env values fall back with a warning.
- New helper `default_user_settings()` in `user_service.py` is the single source of truth — used by `user_service.create_user` (admin-created) and `auth_service._create_user_profile` (self-signup).
- Existing users untouched.

**2. Admin "Reset spend now" button.**
- New endpoint `POST /settings/users/<id>/cost-limit/reset` (`@require_admin`). Zeroes `period_spend` and bumps `period_start` to now. Returns the prior period_spend so the frontend can show "Reset $11.06 spend to $0".
- Audit log: `[ADMIN] {admin_email} reset cost period for {user_email} (was $X)` lands in the rotating log file → auto-included in the diagnostic bundle (admin Logs feature shipped in #167). No new audit table needed.
- 400 if user has no `cost_limit` set; 404 if user not found; 403 for non-admins.

**3. Reset UX in `SpendLimitCell`.**
- Two-click confirm pattern matching the LogsModal "Clear logs" flow. First click flips the button to `Click again to confirm — resets $X` (rose-colored). Second click within 4s fires the API. After 4s without a follow-up, button reverts.
- Lives below a divider in the existing edit popover; only shown when `period_spend > 0` (no point resetting a $0 tally).
- Optimistic UI updates the row state via the existing `onSaved` path; popover closes; toast confirms with the prior amount.

## Test plan
- [ ] **Default seed (admin-created):** create a user via Team → confirm Team table shows `$0.00 / $25 (0%) Resets weekly`.
- [ ] **Default seed (self-signup):** sign up via /auth/signup → same.
- [ ] **Env override:** `NOOBBOOK_DEFAULT_USER_COST_LIMIT=50 NOOBBOOK_DEFAULT_USER_RESET_FREQUENCY=monthly` → restart backend → new user shows `$0 / $50 (0%) Resets monthly`.
- [ ] **Env opt-out:** `NOOBBOOK_DEFAULT_USER_COST_LIMIT=0` → new user is `Unlimited`.
- [ ] **Existing users untouched** (no migration runs).
- [ ] **Reset happy path:** pick a user with $11.06 / $25, click cell → popover → click `Reset spend now` → button flips red `Click again to confirm — resets $11.06` → click again → toast `Reset $11.06 spend to $0` → cell drops to `$0.00 / $25 (0%)`.
- [ ] **Reset auto-revert:** click reset, wait 5s, button is neutral again, no API call fired.
- [ ] **Reset hidden when nothing to reset:** user with `period_spend = 0` doesn't see the reset row.
- [ ] **Reset on lifetime cap** (cost_limit set, reset_frequency null): zeroes period_spend, leaves period_start untouched.
- [ ] **Auth gate:** non-admin POST → 403; user without cost_limit → 400.
- [ ] **Audit trail:** download logs bundle after a reset, confirm `[ADMIN] ... reset cost period for ... (was $X)` line is present.
- [ ] `npm run lint`, `npx tsc --noEmit`, `npm run build` clean (only the 2 pre-existing warnings).