### PR TITLE
chat: polish bundle (scroll-FAB, sending pulse, citation a11y, mobile reflow)

### DIFF
--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -147,11 +147,12 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <div className="flex items-center gap-2 px-2 py-1 bg-muted/50 rounded-md cursor-default min-w-[90px]">
-                    <div className="flex-1 space-y-0.5">
+                  <div className="flex items-center gap-2 px-2 py-1 bg-muted/50 rounded-md cursor-default sm:min-w-[90px]">
+                    <div className="flex-1 space-y-0.5 min-w-[44px]">
                       <div className="flex items-center justify-between">
-                        <span className="text-[10px] font-medium text-muted-foreground tabular-nums">
-                          ${userUsage.current_spend.toFixed(2)}/${userUsage.cost_limit}
+                        <span className="text-[10px] font-medium text-muted-foreground tabular-nums whitespace-nowrap">
+                          <span className="hidden sm:inline">${userUsage.current_spend.toFixed(2)}/${userUsage.cost_limit}</span>
+                          <span className="sm:hidden">${userUsage.current_spend.toFixed(0)}/${userUsage.cost_limit}</span>
                         </span>
                       </div>
                       <div className="h-1 w-full bg-stone-200 rounded-full overflow-hidden">

--- a/frontend/src/components/chat/ChatList.tsx
+++ b/frontend/src/components/chat/ChatList.tsx
@@ -23,6 +23,12 @@ import type { ChatMetadata } from '../../lib/api/chats';
 
 interface ChatListProps {
   chats: ChatMetadata[];
+  /**
+   * IDs of chats that are currently mid-stream (waiting on the assistant).
+   * Used to render a soft amber heartbeat next to those rows so users can see
+   * which conversation the AI is answering when they switch back to the list.
+   */
+  sendingChatIds?: Set<string>;
   onSelectChat: (chatId: string) => void;
   onDeleteChat: (chatId: string) => void;
   onRenameChat: (chatId: string, newTitle: string) => void;
@@ -50,6 +56,7 @@ const formatRelativeTime = (timestamp: string): string => {
 
 export const ChatList: React.FC<ChatListProps> = ({
   chats,
+  sendingChatIds,
   onSelectChat,
   onDeleteChat,
   onRenameChat,
@@ -144,10 +151,16 @@ export const ChatList: React.FC<ChatListProps> = ({
                 Try a different search term
               </p>
             </div>
-          ) : filteredChats.map((chat) => (
+          ) : filteredChats.map((chat) => {
+            const isSending = sendingChatIds?.has(chat.id) ?? false;
+            return (
             <div
               key={chat.id}
-              className="p-3 border rounded-lg hover:bg-accent transition-colors group"
+              className={
+                isSending
+                  ? 'p-3 border border-amber-200 bg-amber-50/40 rounded-lg hover:bg-amber-50 transition-colors group'
+                  : 'p-3 border rounded-lg hover:bg-accent transition-colors group'
+              }
             >
               <div className="flex items-start justify-between mb-1">
                 <div
@@ -155,8 +168,26 @@ export const ChatList: React.FC<ChatListProps> = ({
                   onClick={() => onSelectChat(chat.id)}
                 >
                   <div className="flex items-center gap-2">
-                    <Hash size={16} className="text-muted-foreground" />
+                    {isSending ? (
+                      <span
+                        aria-label="Assistant is replying"
+                        title="Assistant is replying"
+                        className="inline-flex h-2.5 w-2.5 flex-shrink-0 items-center justify-center"
+                      >
+                        <span
+                          className="h-2 w-2 rounded-full bg-amber-500"
+                          style={{ animation: 'reading-breathe 1.6s ease-in-out infinite' }}
+                        />
+                      </span>
+                    ) : (
+                      <Hash size={16} className="text-muted-foreground" />
+                    )}
                     <h3 className="font-medium text-sm">{chat.title}</h3>
+                    {isSending && (
+                      <span className="text-[10px] font-medium uppercase tracking-wider text-amber-700/80 italic font-serif normal-case">
+                        replying
+                      </span>
+                    )}
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
@@ -195,7 +226,8 @@ export const ChatList: React.FC<ChatListProps> = ({
                 {chat.message_count} messages
               </p>
             </div>
-          ))}
+            );
+          })}
         </div>
       </ScrollArea>
     </div>

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -10,7 +10,7 @@
 import React, { useRef, useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Ghost, FileText, Copy, Check, DownloadSimple } from '@phosphor-icons/react';
+import { Ghost, FileText, Copy, Check, DownloadSimple, ArrowDown } from '@phosphor-icons/react';
 import type { Message } from '../../lib/api/chats';
 import { parseCitations } from '../../lib/citations';
 import { CitationBadge } from './CitationBadge';
@@ -26,6 +26,7 @@ import {
 } from '../ui/tooltip';
 import { copyToClipboard } from '@/lib/clipboard';
 import { createLogger } from '@/lib/logger';
+import { cn } from '@/lib/utils';
 
 const log = createLogger('chat-messages');
 
@@ -555,6 +556,11 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
   // Track if user has manually scrolled away from bottom
   const userScrolledAwayRef = useRef(false);
 
+  // Mirror of userScrolledAwayRef for rendering the "Jump to latest" reading
+  // marker — refs don't trigger re-renders, so we keep a state copy that the
+  // scroll handler updates only on threshold crossings (not every pixel).
+  const [showJumpMarker, setShowJumpMarker] = useState(false);
+
   // Track previous message count to detect initial load
   const prevMessageCountRef = useRef(0);
 
@@ -592,16 +598,25 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
     // User is "back at bottom" if within 50px (with some tolerance)
     if (distanceFromBottom > 150) {
       userScrolledAwayRef.current = true;
+      if (!showJumpMarker) setShowJumpMarker(true);
     } else if (distanceFromBottom < 50) {
       userScrolledAwayRef.current = false;
+      if (showJumpMarker) setShowJumpMarker(false);
     }
   };
 
+  const jumpToLatest = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    userScrolledAwayRef.current = false;
+    setShowJumpMarker(false);
+  };
+
   return (
+    <div className="relative flex-1 min-h-0 min-w-0 w-full bg-white">
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      className="flex-1 min-h-0 min-w-0 w-full overflow-y-auto overflow-x-hidden bg-white"
+      className="absolute inset-0 overflow-y-auto overflow-x-hidden"
     >
       <div className="pt-6 pb-2 px-6 space-y-4 w-full">
         {messages.filter((msg) => msg && msg.id).map((msg) => (
@@ -637,6 +652,34 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
         {/* Invisible element to scroll to */}
         <div ref={messagesEndRef} />
       </div>
+    </div>
+
+    {/* Reading marker — appears only when the user has scrolled away from the
+       latest message. Editorial styling: amber pill with serif label, breath
+       animation matches the Reading Beat so the chat surface feels coherent. */}
+    {showJumpMarker && (
+      <button
+        type="button"
+        onClick={jumpToLatest}
+        aria-label="Jump to latest message"
+        className={cn(
+          'group absolute bottom-4 right-5 z-10 inline-flex items-center gap-1.5',
+          'rounded-full border border-amber-200/80 bg-white/85 px-3 py-1.5',
+          'text-xs font-medium text-amber-800 shadow-[0_4px_14px_-4px_rgba(217,119,6,0.35)]',
+          'backdrop-blur-md transition-all duration-200',
+          'hover:border-amber-300 hover:bg-white hover:text-amber-900 hover:shadow-[0_6px_18px_-4px_rgba(217,119,6,0.45)]',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white',
+        )}
+        style={{ animation: 'reading-bubble-in 240ms ease-out both' }}
+      >
+        <span className="font-serif italic tracking-tight">Jump to latest</span>
+        <ArrowDown
+          size={13}
+          weight="bold"
+          className="transition-transform duration-200 group-hover:translate-y-0.5"
+        />
+      </button>
+    )}
     </div>
   );
 });

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -774,6 +774,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       <>
         <ChatList
           chats={allChats}
+          sendingChatIds={sendingChatIds}
           onSelectChat={handleSelectChat}
           onDeleteChat={handleDeleteChat}
           onRenameChat={handleRenameChat}

--- a/frontend/src/components/chat/CitationBadge.tsx
+++ b/frontend/src/components/chat/CitationBadge.tsx
@@ -12,7 +12,6 @@ import {
   HoverCardTrigger,
 } from '../ui/hover-card';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '../ui/card';
-import { Badge } from '../ui/badge';
 import { FileText, CircleNotch } from '@phosphor-icons/react';
 import { sourcesAPI, type ChunkContent } from '../../lib/api/sources';
 import { createLogger } from '@/lib/logger';
@@ -96,14 +95,21 @@ export const CitationBadge: React.FC<CitationBadgeProps> = ({
       .trim();
   };
 
+  // Citation trigger is a real <button> so keyboard users can Tab to it and
+  // Radix HoverCard's focus listener opens the same content the mouse path
+  // does. The visual still reads as an inline superscript badge.
+  const ariaLabel = `Citation ${citationNumber}${sourceName ? ` from ${sourceName}` : ''}, page ${pageNumber}`;
+
   return (
     <HoverCard openDelay={200} closeDelay={100} onOpenChange={handleOpenChange}>
       <HoverCardTrigger asChild>
-        <Badge
-          className="cursor-pointer text-[11px] px-2 py-0.5 h-[18px] align-super -mt-1 bg-primary text-primary-foreground hover:bg-primary/90 border-0"
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          className="inline-flex cursor-pointer items-center justify-center rounded-md align-super -mt-1 h-[18px] min-w-[20px] px-1.5 text-[11px] font-medium leading-none bg-primary text-primary-foreground hover:bg-primary/90 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-white"
         >
           {citationNumber}
-        </Badge>
+        </button>
       </HoverCardTrigger>
       <HoverCardContent className="w-[28rem] p-0" side="top" align="start">
         <Card className="border-0 shadow-none">


### PR DESCRIPTION
Closes #190.

Four small UX wins on the most-used surface, all sharing the editorial amber/serif language we established with the Reading Beat (#188):

## Changes

**1. \`ChatMessages.tsx\` — "Jump to latest" reading-marker FAB**
Appears only when the user has scrolled away (>150px from bottom) mid-stream. Hides itself on click, on smooth-scroll-to-bottom, or when the user manually scrolls back within 50px of the latest message. Amber pill with italic serif "Jump to latest" + bouncing arrow on hover; reuses the \`reading-bubble-in\` keyframe for entrance so it feels like part of the same chat surface.

**2. \`ChatList.tsx\` — sending heartbeat**
When \`sendingChatIds.has(chat.id)\`, the row gets:
- An amber dot replacing the Hash icon, animated with the existing \`reading-breathe\` keyframe (visual rhyme with the Reading Beat).
- An italic serif "replying" label.
- A subtle amber-50 background tint + amber-200 border so the row pops in the list.

\`sendingChatIds\` is wired through from \`ChatPanel\` (already in scope from #173's resilience work).

**3. \`CitationBadge.tsx\` — keyboard accessibility**
Trigger is now a real \`<button>\` with a descriptive \`aria-label\` (e.g. "Citation 1 from research-paper.pdf, page 5"). Radix HoverCard's focus listener opens the same content the mouse path does — keyboard-only users and touch-on-desktop users can now reach the source preview. Visual is unchanged.

**4. \`ChatHeader.tsx\` — mobile cost-limit reflow**
Spending-limit badge drops \`min-w-[90px]\` below \`sm:\` so the header no longer wraps under 375px. On mobile, the dollar amount is compact (e.g. \`$3/$25\`); on \`sm:\` and up, full precision returns. Tooltip still shows exact values + reset frequency.

## Test plan
- [ ] Scroll up mid-stream → "Jump to latest" pill appears bottom-right; click → smooth scrolls to latest, pill disappears
- [ ] Send a message in chat A, switch to chat list → chat A row shows amber dot + "replying" label, breathing animation
- [ ] Tab to a citation chip → focus ring visible, then HoverCard opens; Shift+Tab away → closes
- [ ] Resize browser to 375px → ChatHeader doesn't wrap; full precision returns at sm:
- [ ] Build clean, no TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)