### PR TITLE
sources: flow polish (stage chip, retry toast, sticky drag-drop, preview retry)

### DIFF
--- a/frontend/src/components/sources/SourceItem.tsx
+++ b/frontend/src/components/sources/SourceItem.tsx
@@ -182,6 +182,14 @@ const getStatusDisplay = (status: Source['status'], source?: Source) => {
         animate: true,
         tooltip: 'Embedding...',
       };
+    case 'uploaded':
+      // Queued — file is uploaded, waiting for processing to start.
+      return {
+        icon: CircleNotch,
+        color: 'text-stone-500',
+        animate: false,
+        tooltip: 'Waiting to process',
+      };
     case 'ready':
       return {
         icon: CheckCircle,
@@ -199,6 +207,50 @@ const getStatusDisplay = (status: Source['status'], source?: Source) => {
     default:
       return null;
   }
+};
+
+/**
+ * SourceStageChip — small editorial pill showing the AI's current pass over
+ * a source. Reuses the `reading-breathe` keyframe from the chat surface so
+ * the visual language stays coherent across the app.
+ */
+const SourceStageChip: React.FC<{ status: Source['status'] }> = ({ status }) => {
+  if (status === 'ready') return null;
+
+  const config: Record<string, { label: string; classes: string; pulse: boolean }> = {
+    uploaded: {
+      label: 'Queued',
+      classes: 'border-stone-200 bg-stone-50 text-stone-600',
+      pulse: false,
+    },
+    processing: {
+      label: 'Reading',
+      classes: 'border-amber-200 bg-amber-50 text-amber-800',
+      pulse: true,
+    },
+    embedding: {
+      label: 'Indexing',
+      classes: 'border-sky-200 bg-sky-50 text-sky-700',
+      pulse: true,
+    },
+    error: {
+      label: 'Failed',
+      classes: 'border-rose-200 bg-rose-50 text-rose-700',
+      pulse: false,
+    },
+  };
+
+  const c = config[status];
+  if (!c) return null;
+
+  return (
+    <span
+      className={`inline-flex flex-shrink-0 items-center gap-1 rounded-full border px-1.5 py-0 text-[10px] font-medium leading-[14px] ${c.classes}`}
+      style={c.pulse ? { animation: 'reading-breathe 2.4s ease-in-out infinite' } : undefined}
+    >
+      {c.label}
+    </span>
+  );
 };
 
 export const SourceItem: React.FC<SourceItemProps> = ({
@@ -256,7 +308,7 @@ export const SourceItem: React.FC<SourceItemProps> = ({
     <div
       onClick={handleRowClick}
       className={`grid grid-cols-[auto_1fr_auto_auto] items-center gap-2 p-2 rounded-lg hover:bg-accent group transition-colors ${
-        isActivelyWorking ? 'opacity-60' : ''
+        isActivelyWorking ? 'opacity-90' : ''
       } ${canView ? 'cursor-pointer' : ''}`}
     >
       {/* Icon Area - Shows category icon, transforms to menu on hover */}
@@ -327,20 +379,29 @@ export const SourceItem: React.FC<SourceItemProps> = ({
 
       {/* Source Info - truncates when panel is narrow, expands when resized */}
       <div className="overflow-hidden">
-        <p className="text-sm truncate" title={source.name}>
-          {source.name}
-        </p>
+        <div className="flex items-center gap-1.5">
+          <p className="text-sm truncate" title={source.name}>
+            {source.name}
+          </p>
+          {/* Stage chip — shows the AI's current pass over this source.
+             Editorial language ("Queued / Reading / Indexing / Failed")
+             matches the rest of NoobBook's voice and reads at a glance. */}
+          {source.status !== 'ready' && (
+            <SourceStageChip status={source.status} />
+          )}
+        </div>
         <div className="flex items-center gap-2">
           <p className="text-xs text-muted-foreground">
             {formatFileSize(source.file_size)}
           </p>
-          {/* Status indicator text for non-ready states */}
-          {source.status !== 'ready' && statusDisplay && (
+          {/* For error state, surface the failure reason inline; healthy
+             stages already speak through the chip above. */}
+          {source.status === 'error' && statusDisplay && (
             <span
               className={`text-xs ${statusDisplay.color} truncate max-w-[140px]`}
               title={statusDisplay.tooltip}
             >
-              {source.status === 'error' ? 'Processing failed' : statusDisplay.tooltip}
+              {statusDisplay.tooltip}
             </span>
           )}
         </div>

--- a/frontend/src/components/sources/SourcesPanel.tsx
+++ b/frontend/src/components/sources/SourcesPanel.tsx
@@ -134,7 +134,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
   selectedSourceIds = [],
   onSelectedSourcesChange,
 }) => {
-  const { toasts, dismissToast, success, error, info } = useToast();
+  const { toasts, dismissToast, success, error, info, showToast } = useToast();
 
   // State
   const [sources, setSources] = useState<Source[]>([]);
@@ -339,13 +339,20 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     } catch (err: unknown) {
       log.error({ err }, 'failed to upload files');
       const errorMessage = err instanceof Error ? err.message : 'Upload failed';
-      // Check if it's an axios error with response data
+      // Pull the user-facing error out of an axios envelope when present.
+      let resolvedMessage = errorMessage;
       if (typeof err === 'object' && err !== null && 'response' in err) {
         const axiosErr = err as { response?: { data?: { error?: string } } };
-        error(axiosErr.response?.data?.error || errorMessage);
-      } else {
-        error(errorMessage);
+        resolvedMessage = axiosErr.response?.data?.error || errorMessage;
       }
+      // Inline Retry on the toast: one click re-runs the same upload batch
+      // without making the user re-pick files. Snapshot the original list
+      // so the closure stays stable even after `setUploading(false)`.
+      const retryFiles = fileArray;
+      showToast('error', resolvedMessage, {
+        label: 'Retry',
+        onClick: () => handleFileUpload(retryFiles),
+      });
     } finally {
       setUploading(false);
       setUploadProgress(null);

--- a/frontend/src/components/sources/UploadTab.tsx
+++ b/frontend/src/components/sources/UploadTab.tsx
@@ -111,7 +111,17 @@ export const UploadTab: React.FC<UploadTabProps> = ({
   };
 
   return (
-    <>
+    <div
+      // Sheet-wide drop target. The dashed zone below is the visual cue,
+      // but a drag anywhere inside the tab keeps it active and a drop
+      // anywhere lands in the same upload pipeline. Stops the
+      // "I dropped right next to the box and nothing happened" miss.
+      onDragEnter={handleDrag}
+      onDragLeave={handleDrag}
+      onDragOver={handleDrag}
+      onDrop={handleDrop}
+      className="relative"
+    >
       {/* Hidden file input */}
       <input
         ref={fileInputRef}
@@ -122,17 +132,14 @@ export const UploadTab: React.FC<UploadTabProps> = ({
         accept={ACCEPTED_FILE_TYPES}
       />
 
-      {/* Drag & Drop Zone */}
+      {/* Drag & Drop Zone — purely visual now; drop logic lives on the
+          wrapper above so the entire tab area is a valid drop target. */}
       <div
         className={`border-2 border-dashed rounded-lg p-8 text-center transition-colors ${
           dragActive
             ? 'border-primary bg-primary/5'
             : 'border-muted-foreground/25'
         } ${uploading ? 'opacity-50 pointer-events-none' : ''}`}
-        onDragEnter={handleDrag}
-        onDragLeave={handleDrag}
-        onDragOver={handleDrag}
-        onDrop={handleDrop}
       >
         {uploading ? (
           <>
@@ -188,6 +195,6 @@ export const UploadTab: React.FC<UploadTabProps> = ({
           <AlertDescription>{validationError}</AlertDescription>
         </Alert>
       )}
-    </>
+    </div>
   );
 };

--- a/frontend/src/components/sources/preview/SourcePreviewSheet.tsx
+++ b/frontend/src/components/sources/preview/SourcePreviewSheet.tsx
@@ -20,7 +20,7 @@
 import React, { Suspense, useCallback, useEffect, useState } from 'react';
 import { Sheet, SheetContent, SheetTitle } from '../../ui/sheet';
 import { ScrollArea } from '../../ui/scroll-area';
-import { CircleNotch, FileX } from '@phosphor-icons/react';
+import { ArrowsClockwise, CircleNotch, DownloadSimple, FileX } from '@phosphor-icons/react';
 import {
   sourcesAPI,
   getSourceFileExtension,
@@ -227,9 +227,30 @@ export const SourcePreviewSheet: React.FC<SourcePreviewSheetProps> = ({
     }
     if (errorMsg) {
       return (
-        <div className="flex flex-col items-center justify-center py-16 text-stone-500">
-          <FileX size={28} className="mb-2 text-stone-400" />
-          <p className="text-sm">{errorMsg}</p>
+        <div className="flex flex-col items-center justify-center py-16 px-8 text-center text-stone-500">
+          <FileX size={32} className="mb-3 text-stone-400" />
+          <p className="font-serif text-base italic text-stone-700">{errorMsg}</p>
+          <p className="mt-1 text-xs text-stone-500">
+            The preview couldn't load. Try again, or grab the original file.
+          </p>
+          <div className="mt-5 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setRefetchKey((k) => k + 1)}
+              className="inline-flex items-center gap-1.5 rounded-md border border-amber-200 bg-amber-50/70 px-3 py-1.5 text-xs font-medium text-amber-800 transition-colors hover:border-amber-300 hover:bg-amber-50 hover:text-amber-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            >
+              <ArrowsClockwise size={13} weight="bold" />
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={handleDownload}
+              className="inline-flex items-center gap-1.5 rounded-md border border-stone-200 bg-white px-3 py-1.5 text-xs font-medium text-stone-700 transition-colors hover:border-stone-300 hover:text-stone-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-400"
+            >
+              <DownloadSimple size={13} weight="bold" />
+              Download original
+            </button>
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
Closes #191.

Four small UX fixes on the source upload + processing path. All four address \"the system did something but the UI doesn't tell me what / I can't recover from it\" gaps.

## Changes

**5. \`SourceItem.tsx\` — stage chip**
A small editorial pill next to the source name labels the AI's current pass:
- \`uploaded\` → \`Queued\` (stone)
- \`processing\` → \`Reading\` (amber, breathing)
- \`embedding\` → \`Indexing\` (sky-blue, breathing)
- \`error\` → \`Failed\` (rose)

The breathing animation reuses the \`reading-breathe\` keyframe from #188 so the source list visually rhymes with the chat surface. The row's heavy \`opacity-60\` dim drops to \`opacity-90\` — the chip carries the meaning now.

**6. \`SourcesPanel.tsx\` — Retry on upload-failure toast**
The upload error toast now ships with an inline \`Retry\` action that re-runs the same batch. Captures the original file list so the closure stays valid even after \`setUploading(false)\` flips. One click, no re-pick.

**7. \`UploadTab.tsx\` — sticky drag-drop**
The drag handlers move from the dashed-border zone to the wrapping tab container, so a drop anywhere in the upload area lands in the pipeline. The dashed zone keeps its visual role as the obvious target. Stops the \"I dropped right next to the box and nothing happened\" miss.

**8. \`SourcePreviewSheet.tsx\` — preview error has Retry + Download**
The bare \"Failed to load preview\" error grows two affordances:
- **Retry** (amber): bumps \`refetchKey\` to re-run the fetch effect — handles transient signed-URL expiry / network blips.
- **Download original** (stone): falls through to \`handleDownload\` so even if the preview pipeline is broken, the user can still grab their file.

Editorial copy: italic serif headline plus a one-line hint. Same visual language as the rest of the brand kit.

## Test plan
- [ ] Upload a PDF → row shows \`Reading\` chip with breathing animation, then \`Indexing\`, then no chip when ready
- [ ] Upload past the source limit → toast appears with Retry button; click → upload re-attempts
- [ ] Drag a file into the upload sheet but drop on the supporting text below the dashed box → upload still starts
- [ ] Open a preview, kill the network, dismiss the modal & reopen → see Retry/Download error state; Retry restores normal flow once network is back
- [ ] Build clean, no TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)