### PR TITLE
fix: ProxyFix middleware so signed URLs use https in production

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -10,6 +10,7 @@ import os
 from flask import Flask, request
 from flask_cors import CORS
 from flask_socketio import SocketIO
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from config import config
 from app.utils.logger import setup_logging
@@ -36,6 +37,18 @@ def create_app(config_name='development'):
     app.config.from_object(config[config_name])
     setup_logging(app.config.get('LOG_LEVEL', 'DEBUG'))
     config[config_name].init_app(app)
+
+    # Honor X-Forwarded-* headers when running behind Coolify's reverse
+    # proxy (nginx/Traefik terminates HTTPS, then forwards over plain
+    # HTTP to the backend container). Without this, request.host_url and
+    # request.scheme report the inner http:// origin, and any URL we
+    # generate from them — like Supabase signed URLs we hand back to
+    # the browser — gets blocked as mixed content from the https:// page.
+    # Trust exactly one level of proxy: the Coolify edge.
+    if config_name == 'production':
+        app.wsgi_app = ProxyFix(
+            app.wsgi_app, x_proto=1, x_host=1, x_for=1, x_prefix=1
+        )
 
     # Ensure base directories exist before any routes access them
     from app.utils.path_utils import ensure_base_directories


### PR DESCRIPTION
## Bug — second half of \"Failed to load PDF\"

#196 stripped the internal \`http://kong:8000\` host from Supabase signed URLs, but the rewritten URLs still came out as \`http://app.noobbooklm.com/storage/...\` (plain HTTP), and the browser blocks them as **mixed content** from the \`https://\` page. PDFs / images / audio still failed.

## Root cause

Coolify's reverse proxy terminates HTTPS and forwards to the backend container over plain HTTP. Without \`ProxyFix\`, Flask sees \`scheme=http\` and \`request.host_url\` returns \`http://app.noobbooklm.com/\`. Anywhere we build URLs from \`request.host_url\` — including the new helper in storage_service — emits \`http://\`.

## Fix

Wire \`werkzeug.middleware.proxy_fix.ProxyFix\` in \`create_app\` when \`config_name == 'production'\`, trusting exactly **one** proxy hop (the Coolify edge):

\`\`\`python
if config_name == 'production':
    app.wsgi_app = ProxyFix(
        app.wsgi_app, x_proto=1, x_host=1, x_for=1, x_prefix=1
    )
\`\`\`

After this, \`request.scheme == 'https'\` and \`request.host_url == 'https://app.noobbooklm.com/'\` — so the signed-URL rewrite emits a fetchable HTTPS URL.

Local dev unchanged (config_name != 'production').

## Test plan
- [ ] After Coolify redeploys: hit \`/api/v1/projects/<id>/sources/<sid>/raw\` from prod and verify the returned URL starts with \`https://\`
- [ ] Open a PDF preview on prod → loads cleanly
- [ ] Image / audio / brand-asset previews → load
- [ ] Local dev: API calls still succeed, no scheme weirdness

🤖 Generated with [Claude Code](https://claude.com/claude-code)