### PR TITLE
fix: frontend HEALTHCHECK to stop 504 storms during fresh builds

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,4 +21,19 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 
+# Container-readiness probe. Without this, Docker reports the
+# container as "Up" the instant the nginx process spawns — but
+# before nginx has actually bound to :80. Coolify / Traefik then
+# routes traffic at the not-yet-listening container during a fresh
+# build, producing the 504 Gateway Timeout window we kept hitting.
+# A HEALTHCHECK lets the orchestrator wait for `healthy` before
+# switching upstream traffic over.
+#
+# `wget` is part of the busybox bundled with nginx:alpine, so no
+# extra package install. start-period=3s gives nginx time to bind
+# before the first probe; interval=10s + retries=2 reacts inside
+# ~30s if it ever crashes after start.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=3s --retries=2 \
+  CMD wget -qO- http://127.0.0.1/healthz >/dev/null 2>&1 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Container readiness probe. Returns 200 the instant nginx is bound
+    # to :80 and serving — no disk read, no upstream call. Used by the
+    # Dockerfile's HEALTHCHECK so Coolify / Traefik can wait for the
+    # frontend to actually be ready before routing traffic at it during
+    # a fresh build (otherwise the swap window produces 504s).
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 'ok';
+    }
+
     # Allow large file uploads (PDFs, audio, large CSVs, etc.).
     # Must match Flask MAX_CONTENT_LENGTH (1GB) and Supabase storage
     # FILE_SIZE_LIMIT in docker/supabase/docker-compose.yml — the UI also


### PR DESCRIPTION
## The recurring 504 we keep hitting on fresh deploys

Backend was always fine because Coolify configured a healthcheck for it via the per-app UI — \`docker inspect\` shows \`Health: \"healthy\"\`. **Frontend has no healthcheck at all** (\`Health: null\`), so Docker reports it \`Up\` the instant the nginx process spawns, before nginx has actually bound to :80. Coolify/Traefik then routes traffic at the not-yet-listening container and the request hangs for 30s → Cloudflare 504.

This is the standard Docker-without-HEALTHCHECK pitfall, well documented across nginx-on-Coolify reports.

## Fix

\`\`\`Dockerfile
HEALTHCHECK --interval=10s --timeout=3s --start-period=3s --retries=2 \\
  CMD wget -qO- http://127.0.0.1/healthz >/dev/null 2>&1 || exit 1
\`\`\`

Plus a dedicated \`/healthz\` nginx location that returns 200 the moment nginx is bound — no disk read, no upstream proxy.

\`wget\` is in the busybox bundled with \`nginx:alpine\` so there's no extra install.

## Pairs with two Coolify UI toggles

After this PR merges and Coolify rebuilds the new image:

1. **App settings → \"Zero Downtime Deployment\" → enable** on both \`frontend\` and \`backend\`. With healthchecks now in place, Coolify will: start new container → wait for \`healthy\` → switch Traefik → kill old. No window where Traefik routes to a dead/not-ready container.
2. **(Optional) Traefik retry middleware** — adds server-side retries for the brief instant during route swap. Coolify exposes this via labels but it's a UI tweak, not part of this PR.

## Test plan

- [ ] After merge, Coolify rebuilds → \`docker inspect frontend --format '{{.State.Health.Status}}'\` returns \`healthy\` (not \`null\`)
- [ ] Trigger a manual redeploy from Coolify UI → no 504 during the swap
- [ ] Old behavior reproduces by reverting just the Dockerfile change locally and pushing

🤖 Generated with [Claude Code](https://claude.com/claude-code)