### PR TITLE
fix: proxy /storage/v1/* in frontend nginx so signed-URL previews load

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -65,6 +65,39 @@ server {
         proxy_read_timeout 86400s;
     }
 
+    # Proxy Supabase Storage signed URLs to Kong on the same origin.
+    #
+    # WHY THIS LIVES IN THE FRONTEND NGINX:
+    # The backend hands the browser short-lived signed URLs that look
+    # like https://app.noobbooklm.com/storage/v1/object/sign/raw-files/...
+    # so they're fetchable from the same origin (avoids the mixed-content
+    # / CORS / internal-host issues we wrestled with in #196 + #197). For
+    # that to work, *something* on this origin has to proxy /storage/v1/*
+    # to Kong (the Supabase API gateway). Without this block, every
+    # signed URL falls through to the SPA's catch-all and the browser
+    # gets index.html instead of the file bytes — pdfjs / CSV parser /
+    # <img> all silently fail.
+    #
+    # NOTES:
+    # - proxy_buffering off so large files (PDFs, audio, CSVs up to 1GB)
+    #   stream straight through without filling up nginx's buffer.
+    # - Long read timeout for slow connections / large downloads.
+    # - $request_uri preserves the entire path + query (the ?token=...
+    #   on signed URLs is the auth, so it MUST survive the proxy).
+    location /storage/v1/ {
+        proxy_pass http://kong:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 600s;
+        proxy_connect_timeout 30s;
+        client_max_body_size 1024M;
+    }
+
     # SPA fallback: serve index.html for all non-file routes
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## The actual root cause of \"Failed to load PDF / CSV / image\" in source preview

After #196 (host rewrite) and #197 (ProxyFix for HTTPS scheme), the backend hands the browser signed URLs of the form:

\`\`\`
https://app.noobbooklm.com/storage/v1/object/sign/raw-files/<...>?token=<jwt>
\`\`\`

Same-origin URLs — chosen specifically to avoid mixed content / CORS / internal-host issues. **But the frontend nginx never had a proxy rule for \`/storage/v1/*\`.** Every signed-URL request fell through to the SPA catch-all (\`location / → try_files \$uri \$uri/ /index.html\`), so the browser got back the React app's \`index.html\` instead of the file bytes.

- pdfjs tries to parse HTML as PDF → \"Failed to load PDF\"
- CSV parser tries to parse HTML as CSV → fails silently
- \`<img>\` / \`<audio>\` get broken/missing
- This affected **every raw-file-based preview type**

Verified live: \`curl -I https://app.noobbooklm.com/storage/v1/object/sign/raw-files/foo\` returns \`200\` with \`content-type: text/html\` (the SPA index, not file bytes).

## Fix

Add a \`/storage/v1/\` location to \`frontend/nginx.conf\` that forwards to \`kong:8000\` (the Supabase API gateway). The frontend container can resolve \`kong\` over Coolify's docker network — verified with \`getent hosts kong\` from inside the container.

\`\`\`nginx
location /storage/v1/ {
    proxy_pass http://kong:8000;
    proxy_buffering off;
    proxy_request_buffering off;
    proxy_read_timeout 600s;
    ...
}
\`\`\`

Buffering off + 600s timeout so multi-MB PDFs and ~1GB audio files stream straight through. The \`?token=...\` query param survives the proxy hop natively (nginx forwards \`\$request_uri\` to upstream).

## Why the two earlier PRs weren't enough

| PR | What it did | What was still broken |
|---|---|---|
| #196 | Rewrote \`http://kong:8000\` → public host on signed URLs | URLs LOOKED right, but no receiver |
| #197 | Forced \`https://\` scheme via ProxyFix | URLs were now valid HTTPS, but still hit SPA fallback |
| **#201 (this)** | **Adds the actual /storage/v1/ proxy** | **Now signed URLs reach Kong → storage** |

## Test plan

After Coolify rebuilds:

- [ ] \`curl -I https://app.noobbooklm.com/storage/v1/health\` returns 200 from Kong (not text/html SPA)
- [ ] PDF preview opens cleanly, no \"Failed to load PDF\"
- [ ] CSV preview renders the table
- [ ] Image preview shows the image
- [ ] Audio preview plays + transcript loads
- [ ] Source download \"Open original\" button works
- [ ] Brand-asset preview in admin Design tab still works (uses studio-outputs bucket via the same /storage/v1/ path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)