### PR TITLE
fix: preserve X-Forwarded-Proto from Coolify Traefik (THE actual mixed-content cause)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,20 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Preserve X-Forwarded-Proto from the upstream proxy (Coolify's Traefik)
+    # if it set one; only fall back to our own $scheme when running outside
+    # a proxy chain. Without this we'd unconditionally overwrite the header
+    # with $scheme=http (Traefik terminates HTTPS and forwards over plain
+    # HTTP to the frontend container), so the backend's ProxyFix sees http,
+    # request.host_url comes back as http://app.noobbooklm.com/, the
+    # signed-URL rewriter emits an http:// URL, and the browser blocks the
+    # PDF / image / audio fetch as Mixed Active Content from the https://
+    # page. This was exactly the recurring "Failed to load PDF" symptom.
+    set $forwarded_proto $scheme;
+    if ($http_x_forwarded_proto) {
+        set $forwarded_proto $http_x_forwarded_proto;
+    }
+
     # Container readiness probe. Returns 200 the instant nginx is bound
     # to :80 and serving — no disk read, no upstream call. Used by the
     # Dockerfile's HEALTHCHECK so Coolify / Traefik can wait for the
@@ -34,7 +48,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_read_timeout 300s;
         proxy_connect_timeout 75s;
         proxy_buffering off;
@@ -47,7 +61,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_read_timeout 300s;
         proxy_connect_timeout 75s;
     }
@@ -61,7 +75,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_read_timeout 86400s;
     }
 
@@ -90,7 +104,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_buffering off;
         proxy_request_buffering off;
         proxy_read_timeout 600s;


### PR DESCRIPTION
## The smoking gun

Browser console:
\`\`\`
Blocked loading mixed active content
\"http://app.noobbooklm.com/storage/v1/object/sign/raw-files/...pdf?token=...\"
\`\`\`

The backend signed-URL builder is emitting \`http://\` URLs from a page on \`https://\`, which Firefox correctly blocks as Mixed Active Content. PDF.js fails, CSV parser fails, every raw-file preview dies.

## Why \`request.scheme\` was wrong despite ProxyFix (#197)

The proxy chain:
\`\`\`
Cloudflare ─HTTPS─► Traefik ─HTTP + X-Forwarded-Proto: https─► nginx
nginx ─HTTP + X-Forwarded-Proto: http (OVERWRITTEN)─► backend
\`\`\`

The frontend \`nginx.conf\` had \`proxy_set_header X-Forwarded-Proto \$scheme;\` in every upstream location. Inside the container, \$scheme is always \`http\` because Traefik terminates HTTPS upstream and forwards plain HTTP. So nginx was overwriting Traefik's correctly-set \`X-Forwarded-Proto: https\` with \`http\`. Backend's ProxyFix dutifully read \`http\` and built \`http://\` URLs.

## Fix

Server-level pass-through: preserve the upstream's \`X-Forwarded-Proto\` if it set one, only fall back to \$scheme outside a proxy chain (local dev).

\`\`\`nginx
set \$forwarded_proto \$scheme;
if (\$http_x_forwarded_proto) {
    set \$forwarded_proto \$http_x_forwarded_proto;
}
\`\`\`

Then \`proxy_set_header X-Forwarded-Proto \$forwarded_proto\` in all four upstream locations (\`/api/\` streaming, \`/api/\`, \`/socket.io/\`, \`/storage/v1/\`).

## The full \"Failed to load PDF\" saga, finally complete

| PR | What it did | What was still broken |
|---|---|---|
| #196 | Rewrote internal \`http://kong:8000\` host to public host | Scheme was still http |
| #197 | Added ProxyFix so request.host_url uses X-Forwarded-Proto | But the header arrived as \`http\` because… |
| #201 | Added /storage/v1/ proxy to the frontend | …nginx was overwriting it |
| **#202 (this)** | **Stops nginx from clobbering X-Forwarded-Proto** | **DONE.** |

## Test plan

After Coolify rebuilds:

- [ ] DevTools console: no Mixed Content warnings on the preview page
- [ ] PDF preview opens cleanly, document renders
- [ ] CSV preview renders the table
- [ ] Image preview shows the image
- [ ] Audio plays + transcript loads
- [ ] Network tab shows the signed URL request as \`https://\` — not \`http://\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)