### PR TITLE
fix chat: surface AI response when SSE stream truncates before assistant_done

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -42,6 +42,15 @@ server {
     gzip_min_length 256;
 
     # Stream chat responses without proxy buffering.
+    #
+    # proxy_read_timeout 600s matches gunicorn's worker timeout (see
+    # backend/gunicorn.conf.py). Tier-4 tool-use loops (Mixpanel queries,
+    # web_fetch, slow Claude API tokens) can sit silent on the wire well
+    # past the old 300s cap — when nginx FIN'd the upstream connection
+    # mid-flight, the browser's fetch() reader saw done=true with no
+    # `assistant_done` SSE event, leaving the chat UI stuck on the
+    # Reading Beat indicator (#item-needs-refresh repro). Backend log
+    # showed 407s / 523s / 658s real-world streams driving the bug.
     location ~ ^/api/v1/projects/.*/chats/.*/messages/stream$ {
         proxy_pass http://noobbook-backend:5001;
         proxy_http_version 1.1;
@@ -49,7 +58,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
-        proxy_read_timeout 300s;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
         proxy_connect_timeout 75s;
         proxy_buffering off;
         add_header X-Accel-Buffering no;

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -556,6 +556,34 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           onCostsChange?.();
           await reconcileChatMetadata(currentChat.id);
         }
+      } else {
+        // Stream closed cleanly but neither `assistant_done` nor `error`
+        // arrived. The most common cause is an upstream proxy (frontend
+        // nginx, Coolify Traefik) FIN'ing the connection during a long
+        // tool-use gap — the backend has already persisted the assistant
+        // message via main_chat_service, so a refetch surfaces it without
+        // re-running the model. Without this branch the UI stuck on the
+        // Reading Beat until the user manually refreshed (#item-still-not-
+        // working repro from prod logs showed 407s / 523s / 658s streams).
+        log.warn(
+          {
+            chatId: currentChat.id,
+            hadUserMessage: streamResult.hadUserMessage,
+            hadAssistantDelta: streamResult.hadAssistantDelta,
+          },
+          'stream ended without terminal event — recovering from server',
+        );
+        setStreamingAssistantContent('');
+        try {
+          await loadFullChat(currentChat.id);
+          onCostsChange?.();
+          await loadUserUsage();
+        } catch (recoveryErr) {
+          log.error({ err: recoveryErr }, 'recovery refetch failed');
+          errorWithLogs(
+            'Connection dropped before the response arrived. Refresh to load it.',
+          );
+        }
       }
     } catch (err) {
       // Don't show error toast if user intentionally stopped
@@ -578,8 +606,23 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             errorWithLogs('Failed to send message');
           }
         } else {
-          log.error({ err }, 'failed to send message');
-          errorWithLogs('Failed to send message');
+          // Stream errored mid-flight after delivering partial events
+          // (canonical user_message and/or assistant_delta). Re-sending
+          // via the REST fallback would duplicate the user's message —
+          // recover by re-fetching the chat instead. The backend's
+          // exception handler in main_chat_service already persists an
+          // error-marked assistant message before the SSE error event,
+          // so the refetch should surface either the partial response
+          // or a recorded failure the user can retry from.
+          log.warn({ err }, 'stream errored after partial events — recovering from server');
+          try {
+            await loadFullChat(currentChat.id);
+            onCostsChange?.();
+            await loadUserUsage();
+          } catch (recoveryErr) {
+            log.error({ err: recoveryErr }, 'recovery refetch failed');
+            errorWithLogs('Failed to send message');
+          }
         }
       }
       setStreamingAssistantContent('');

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -75,6 +75,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   const canonicalUserMessageReceivedRef = useRef(false);
   const assistantDeltaReceivedRef = useRef(false);
   const pendingTitleSyncRef = useRef<{ chatId: string; hasSeenNamingTask: boolean } | null>(null);
+  // Mirrors activeChat?.id so async callbacks (recoverChatFromServer) can
+  // check "is the user still on the originating chat?" *synchronously*
+  // without going through a setState updater — React 18's automatic
+  // batching means functional-updater side effects don't run before the
+  // line that reads them, which broke the previous guard pattern.
+  const activeChatIdRef = useRef<string | null>(null);
 
   // Sources state for header display
   const [sources, setSources] = useState<Source[]>([]);
@@ -198,6 +204,13 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     }
   }, [activeChat, onSignalsChange]);
 
+  // Keep the activeChatId ref in sync — read-only mirror used by async
+  // recovery paths so they can compare current chat without racing with
+  // batched state updates.
+  useEffect(() => {
+    activeChatIdRef.current = activeChat?.id ?? null;
+  }, [activeChat?.id]);
+
   /**
    * Load per-chat cost/token breakdown whenever the active chat changes.
    * Refreshed again after each message via `loadChatCosts()` in the send flow.
@@ -279,22 +292,29 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
    * persisted whatever it produced, so we just need to surface it.
    *
    * Chat-id-aware: if the user has switched to a different chat by the
-   * time the refetch returns, the activeChat replacement is skipped so
-   * the recovery doesn't yank them back to the chat they navigated away
-   * from. The source-selection notification fires only when the chat is
-   * still active.
+   * time the refetch returns, the activeChat replacement and source-
+   * selection notification are skipped so the recovery doesn't yank
+   * them back to the chat they navigated away from.
+   *
+   * The "still on this chat?" check is read off `activeChatIdRef` (kept
+   * in sync via useEffect above) — synchronously and reliably. A prior
+   * version of this helper used a side effect inside a setActiveChat
+   * functional updater, which doesn't fire before the line that reads
+   * it under React 18 automatic batching (Greptile flagged this on
+   * PR #204). The functional updater on setActiveChat is still kept as
+   * defence-in-depth against a chat switch racing in between the ref
+   * check and the actual state commit.
    */
   const recoverChatFromServer = useCallback(
     async (chatId: string, errorToastMessage?: string) => {
       try {
         const chat = await chatsAPI.getChat(projectId, chatId);
-        let stillActive = false;
-        setActiveChat((prev) => {
-          if (!prev || prev.id !== chat.id) return prev;
-          stillActive = true;
-          return chat;
-        });
+        const stillActive = activeChatIdRef.current === chat.id;
         if (stillActive) {
+          setActiveChat((prev) => {
+            if (!prev || prev.id !== chat.id) return prev;
+            return chat;
+          });
           onActiveChatChange(chat.id, chat.selected_source_ids ?? []);
         }
         onCostsChange?.();

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -273,6 +273,43 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     return true;
   }, [onCostsChange]);
 
+  /**
+   * Refetch a chat's full state when SSE streaming ended without a terminal
+   * event (proxy truncation, network drop, etc.). Backend has already
+   * persisted whatever it produced, so we just need to surface it.
+   *
+   * Chat-id-aware: if the user has switched to a different chat by the
+   * time the refetch returns, the activeChat replacement is skipped so
+   * the recovery doesn't yank them back to the chat they navigated away
+   * from. The source-selection notification fires only when the chat is
+   * still active.
+   */
+  const recoverChatFromServer = useCallback(
+    async (chatId: string, errorToastMessage?: string) => {
+      try {
+        const chat = await chatsAPI.getChat(projectId, chatId);
+        let stillActive = false;
+        setActiveChat((prev) => {
+          if (!prev || prev.id !== chat.id) return prev;
+          stillActive = true;
+          return chat;
+        });
+        if (stillActive) {
+          onActiveChatChange(chat.id, chat.selected_source_ids ?? []);
+        }
+        onCostsChange?.();
+        await loadUserUsage();
+      } catch (recoveryErr) {
+        log.error({ err: recoveryErr, chatId }, 'recovery refetch failed');
+        errorWithLogs(
+          errorToastMessage ||
+            'Connection dropped before the response arrived. Refresh to load it.',
+        );
+      }
+    },
+    [projectId, onActiveChatChange, onCostsChange, loadUserUsage, errorWithLogs],
+  );
+
   const reconcileChatMetadata = useCallback(async (chatId: string) => {
     try {
       const [chat] = await Promise.all([
@@ -563,8 +600,8 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         // tool-use gap — the backend has already persisted the assistant
         // message via main_chat_service, so a refetch surfaces it without
         // re-running the model. Without this branch the UI stuck on the
-        // Reading Beat until the user manually refreshed (#item-still-not-
-        // working repro from prod logs showed 407s / 523s / 658s streams).
+        // Reading Beat until the user manually refreshed (prod logs
+        // showed 407s / 523s / 658s streams driving the bug).
         log.warn(
           {
             chatId: currentChat.id,
@@ -574,16 +611,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           'stream ended without terminal event — recovering from server',
         );
         setStreamingAssistantContent('');
-        try {
-          await loadFullChat(currentChat.id);
-          onCostsChange?.();
-          await loadUserUsage();
-        } catch (recoveryErr) {
-          log.error({ err: recoveryErr }, 'recovery refetch failed');
-          errorWithLogs(
-            'Connection dropped before the response arrived. Refresh to load it.',
-          );
-        }
+        await recoverChatFromServer(currentChat.id);
       }
     } catch (err) {
       // Don't show error toast if user intentionally stopped
@@ -612,17 +640,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           // recover by re-fetching the chat instead. The backend's
           // exception handler in main_chat_service already persists an
           // error-marked assistant message before the SSE error event,
-          // so the refetch should surface either the partial response
-          // or a recorded failure the user can retry from.
+          // so the refetch surfaces either the partial response or a
+          // recorded failure the user can retry from.
           log.warn({ err }, 'stream errored after partial events — recovering from server');
-          try {
-            await loadFullChat(currentChat.id);
-            onCostsChange?.();
-            await loadUserUsage();
-          } catch (recoveryErr) {
-            log.error({ err: recoveryErr }, 'recovery refetch failed');
-            errorWithLogs('Failed to send message');
-          }
+          await recoverChatFromServer(currentChat.id, 'Failed to send message');
         }
       }
       setStreamingAssistantContent('');

--- a/frontend/src/components/project/SharingModal.tsx
+++ b/frontend/src/components/project/SharingModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 import {
   Dialog,
@@ -243,17 +243,21 @@ export const SharingModal: React.FC<SharingModalProps> = ({
     }
   };
 
-  const handleCopy = async (share: ProjectShare) => {
+  const handleCopy = async (share: ProjectShare, selectFallback: () => void) => {
     // copyToClipboard handles the modern Clipboard API + the legacy
     // execCommand fallback for non-HTTPS / unfocused contexts where
     // navigator.clipboard.writeText throws (the original failure mode here).
+    // When BOTH paths fail (some browsers block execCommand inside Radix
+    // portals, Safari iOS, strict Firefox), we surface the row's URL input
+    // pre-selected so the user can hit Cmd/Ctrl-C immediately.
     const ok = await copyToClipboard(share.url);
     if (ok) {
       setCopiedId(share.id);
       success('Link copied');
       setTimeout(() => setCopiedId((id) => (id === share.id ? null : id)), 1600);
     } else {
-      error('Could not copy. Select the URL manually.');
+      selectFallback();
+      error("Couldn't auto-copy — URL is selected, press Cmd/Ctrl-C.");
     }
   };
 
@@ -526,7 +530,7 @@ const EmptyState: React.FC = () => (
 interface ShareRowProps {
   share: ProjectShare;
   copied: boolean;
-  onCopy: (s: ProjectShare) => void;
+  onCopy: (s: ProjectShare, selectFallback: () => void) => void;
   onRevoke: (s: ProjectShare) => void;
   staggerMs: number;
 }
@@ -535,6 +539,19 @@ const ShareRow: React.FC<ShareRowProps> = ({ share, copied, onCopy, onRevoke, st
   const inactive = !share.is_active;
   const inactiveLabel = share.revoked_at ? 'Revoked' : 'Expired';
   const expiryLabel = formatExpiry(share);
+
+  // Per-row input ref — surfaces the full URL as selectable DOM text so
+  // users can manually copy (Cmd/Ctrl-C) when the Clipboard API path fails.
+  // The handler also auto-selects after a failed Copy click.
+  const urlInputRef = useRef<HTMLInputElement | null>(null);
+  const selectUrl = () => {
+    const el = urlInputRef.current;
+    if (!el) return;
+    el.focus();
+    // setSelectionRange is the cross-platform-safe variant; .select() flakes
+    // on some mobile browsers when the input has just received focus.
+    el.setSelectionRange(0, el.value.length);
+  };
 
   return (
     <div
@@ -565,14 +582,26 @@ const ShareRow: React.FC<ShareRowProps> = ({ share, copied, onCopy, onRevoke, st
           )}
         </span>
 
-        {/* URL + metadata */}
+        {/* URL + metadata. The URL is rendered as a read-only <input> (not a
+            <span>) so users can manually triple-click + copy on browsers
+            where the Clipboard API and its execCommand fallback both fail
+            (Safari iOS, strict Firefox, sandboxed iframes). The value is the
+            full URL with scheme — the input scrolls horizontally if needed,
+            but selection always covers the entire string. */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-            <span className="font-mono truncate" title={share.url}>
-              {compactUrl(share.url)}
-            </span>
+            <input
+              ref={urlInputRef}
+              readOnly
+              value={share.url}
+              onClick={selectUrl}
+              onFocus={selectUrl}
+              title={share.url}
+              aria-label="Share link URL"
+              className="flex-1 min-w-0 truncate font-mono text-[11px] text-muted-foreground bg-transparent border-0 outline-none p-0 m-0 h-auto leading-normal focus-visible:ring-0 focus-visible:ring-offset-0 focus:text-foreground cursor-text"
+            />
             {inactive && (
-              <span className="px-1.5 py-px rounded text-[10px] font-medium uppercase tracking-wide bg-stone-200/70 text-stone-700 dark:bg-stone-800/70 dark:text-stone-300">
+              <span className="flex-shrink-0 px-1.5 py-px rounded text-[10px] font-medium uppercase tracking-wide bg-stone-200/70 text-stone-700 dark:bg-stone-800/70 dark:text-stone-300">
                 {inactiveLabel}
               </span>
             )}
@@ -603,7 +632,7 @@ const ShareRow: React.FC<ShareRowProps> = ({ share, copied, onCopy, onRevoke, st
           <Button
             variant={copied ? 'secondary' : 'outline'}
             size="sm"
-            onClick={() => onCopy(share)}
+            onClick={() => onCopy(share, selectUrl)}
             disabled={inactive}
             className="h-7 px-2.5 gap-1.5 text-xs"
             aria-label="Copy link"
@@ -656,17 +685,6 @@ const shareRowKeyframes = `
   to   { opacity: 1; transform: translateY(0); }
 }
 `;
-
-function compactUrl(url: string): string {
-  // Show only the last meaningful segment so the row stays tidy at any width.
-  // e.g. https://app.example.com/share/AbC123 → /share/AbC123
-  try {
-    const u = new URL(url);
-    return `${u.host}${u.pathname}`;
-  } catch {
-    return url;
-  }
-}
 
 function formatExpiry(share: ProjectShare): string {
   if (share.revoked_at) return 'Revoked';


### PR DESCRIPTION
## Summary
Customer reported the chat appears stuck on the **Reading Beat** indicator until they refresh — after which the AI response shows up. Production logs from `pmbot.dericrypt.com` confirmed:

- Multiple `messages/stream` requests running **407s / 523s / 658s** (Tier 4 deploy with tool-use loops, Mixpanel queries, web fetches).
- `frontend/nginx.conf` had `proxy_read_timeout 300s` for the stream location → nginx was FIN'ing the upstream connection during long tool-use gaps.
- Browser `fetch()` reader saw `done=true` cleanly with neither `assistant_done` nor `error` SSE event arriving.
- Existing `handleSend()` had no branch for `terminalEvent === null` — it just fell through. Backend had already persisted the assistant message via `main_chat_service.py:656` *before* emitting `assistant_done`, so a manual page refresh fetched it.

## Fix (two parts)

### 1. `frontend/nginx.conf`
- Raise `proxy_read_timeout` from **300s → 600s** for the stream location, matching gunicorn's worker timeout (`backend/gunicorn.conf.py`).
- Add `proxy_send_timeout 600s` so the request side gets the same headroom.

### 2. `frontend/src/components/chat/ChatPanel.tsx`
- When `streamMessage()` resolves with `terminalEvent === null`, log a warning and call `loadFullChat(chatId)` — surfaces whatever the backend persisted without re-running the model.
- Harden the `catch` path: when partial events were received (`!shouldFallback`), re-sending via the REST fallback would duplicate the user message. Recover via the same refetch instead, with `errorWithLogs` only as a last resort.

## Test plan
- [ ] Trigger a long tool-use chat (Mixpanel query, repeated web_fetch) so the stream sits silent past 5 min — confirm nginx no longer truncates and `assistant_done` arrives.
- [ ] Manually kill the stream connection mid-flight (e.g. throttle network in DevTools, restart backend container) — confirm the chat UI auto-recovers via `loadFullChat` instead of stranding the Reading Beat.
- [ ] Send a message under normal conditions — happy path unchanged, costs / sync / title-naming all still apply.
- [ ] Resend after a forced failure — verify no duplicate user messages.
- [ ] Browser typecheck (`tsc -b`) + lint clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)