### PR TITLE
Release: develop → main (#203, #204, plus earlier proxy/healthcheck PRs)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,4 +21,19 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 
+# Container-readiness probe. Without this, Docker reports the
+# container as "Up" the instant the nginx process spawns — but
+# before nginx has actually bound to :80. Coolify / Traefik then
+# routes traffic at the not-yet-listening container during a fresh
+# build, producing the 504 Gateway Timeout window we kept hitting.
+# A HEALTHCHECK lets the orchestrator wait for `healthy` before
+# switching upstream traffic over.
+#
+# `wget` is part of the busybox bundled with nginx:alpine, so no
+# extra package install. start-period=3s gives nginx time to bind
+# before the first probe; interval=10s + retries=2 reacts inside
+# ~30s if it ever crashes after start.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=3s --retries=2 \
+  CMD wget -qO- http://127.0.0.1/healthz >/dev/null 2>&1 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -42,6 +42,15 @@ server {
     gzip_min_length 256;
 
     # Stream chat responses without proxy buffering.
+    #
+    # proxy_read_timeout 600s matches gunicorn's worker timeout (see
+    # backend/gunicorn.conf.py). Tier-4 tool-use loops (Mixpanel queries,
+    # web_fetch, slow Claude API tokens) can sit silent on the wire well
+    # past the old 300s cap — when nginx FIN'd the upstream connection
+    # mid-flight, the browser's fetch() reader saw done=true with no
+    # `assistant_done` SSE event, leaving the chat UI stuck on the
+    # Reading Beat indicator (#item-needs-refresh repro). Backend log
+    # showed 407s / 523s / 658s real-world streams driving the bug.
     location ~ ^/api/v1/projects/.*/chats/.*/messages/stream$ {
         proxy_pass http://noobbook-backend:5001;
         proxy_http_version 1.1;
@@ -49,7 +58,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
-        proxy_read_timeout 300s;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
         proxy_connect_timeout 75s;
         proxy_buffering off;
         add_header X-Accel-Buffering no;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,20 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Preserve X-Forwarded-Proto from the upstream proxy (Coolify's Traefik)
+    # if it set one; only fall back to our own $scheme when running outside
+    # a proxy chain. Without this we'd unconditionally overwrite the header
+    # with $scheme=http (Traefik terminates HTTPS and forwards over plain
+    # HTTP to the frontend container), so the backend's ProxyFix sees http,
+    # request.host_url comes back as http://app.noobbooklm.com/, the
+    # signed-URL rewriter emits an http:// URL, and the browser blocks the
+    # PDF / image / audio fetch as Mixed Active Content from the https://
+    # page. This was exactly the recurring "Failed to load PDF" symptom.
+    set $forwarded_proto $scheme;
+    if ($http_x_forwarded_proto) {
+        set $forwarded_proto $http_x_forwarded_proto;
+    }
+
     # Container readiness probe. Returns 200 the instant nginx is bound
     # to :80 and serving — no disk read, no upstream call. Used by the
     # Dockerfile's HEALTHCHECK so Coolify / Traefik can wait for the
@@ -34,7 +48,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_read_timeout 300s;
         proxy_connect_timeout 75s;
         proxy_buffering off;
@@ -47,7 +61,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_read_timeout 300s;
         proxy_connect_timeout 75s;
     }
@@ -61,7 +75,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_read_timeout 86400s;
     }
 
@@ -90,7 +104,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_buffering off;
         proxy_request_buffering off;
         proxy_read_timeout 600s;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Container readiness probe. Returns 200 the instant nginx is bound
+    # to :80 and serving — no disk read, no upstream call. Used by the
+    # Dockerfile's HEALTHCHECK so Coolify / Traefik can wait for the
+    # frontend to actually be ready before routing traffic at it during
+    # a fresh build (otherwise the swap window produces 504s).
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 'ok';
+    }
+
     # Allow large file uploads (PDFs, audio, large CSVs, etc.).
     # Must match Flask MAX_CONTENT_LENGTH (1GB) and Supabase storage
     # FILE_SIZE_LIMIT in docker/supabase/docker-compose.yml — the UI also

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -65,6 +65,39 @@ server {
         proxy_read_timeout 86400s;
     }
 
+    # Proxy Supabase Storage signed URLs to Kong on the same origin.
+    #
+    # WHY THIS LIVES IN THE FRONTEND NGINX:
+    # The backend hands the browser short-lived signed URLs that look
+    # like https://app.noobbooklm.com/storage/v1/object/sign/raw-files/...
+    # so they're fetchable from the same origin (avoids the mixed-content
+    # / CORS / internal-host issues we wrestled with in #196 + #197). For
+    # that to work, *something* on this origin has to proxy /storage/v1/*
+    # to Kong (the Supabase API gateway). Without this block, every
+    # signed URL falls through to the SPA's catch-all and the browser
+    # gets index.html instead of the file bytes — pdfjs / CSV parser /
+    # <img> all silently fail.
+    #
+    # NOTES:
+    # - proxy_buffering off so large files (PDFs, audio, CSVs up to 1GB)
+    #   stream straight through without filling up nginx's buffer.
+    # - Long read timeout for slow connections / large downloads.
+    # - $request_uri preserves the entire path + query (the ?token=...
+    #   on signed URLs is the auth, so it MUST survive the proxy).
+    location /storage/v1/ {
+        proxy_pass http://kong:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 600s;
+        proxy_connect_timeout 30s;
+        client_max_body_size 1024M;
+    }
+
     # SPA fallback: serve index.html for all non-file routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -75,6 +75,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   const canonicalUserMessageReceivedRef = useRef(false);
   const assistantDeltaReceivedRef = useRef(false);
   const pendingTitleSyncRef = useRef<{ chatId: string; hasSeenNamingTask: boolean } | null>(null);
+  // Mirrors activeChat?.id so async callbacks (recoverChatFromServer) can
+  // check "is the user still on the originating chat?" *synchronously*
+  // without going through a setState updater — React 18's automatic
+  // batching means functional-updater side effects don't run before the
+  // line that reads them, which broke the previous guard pattern.
+  const activeChatIdRef = useRef<string | null>(null);
 
   // Sources state for header display
   const [sources, setSources] = useState<Source[]>([]);
@@ -198,6 +204,13 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     }
   }, [activeChat, onSignalsChange]);
 
+  // Keep the activeChatId ref in sync — read-only mirror used by async
+  // recovery paths so they can compare current chat without racing with
+  // batched state updates.
+  useEffect(() => {
+    activeChatIdRef.current = activeChat?.id ?? null;
+  }, [activeChat?.id]);
+
   /**
    * Load per-chat cost/token breakdown whenever the active chat changes.
    * Refreshed again after each message via `loadChatCosts()` in the send flow.
@@ -272,6 +285,50 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     onCostsChange?.();
     return true;
   }, [onCostsChange]);
+
+  /**
+   * Refetch a chat's full state when SSE streaming ended without a terminal
+   * event (proxy truncation, network drop, etc.). Backend has already
+   * persisted whatever it produced, so we just need to surface it.
+   *
+   * Chat-id-aware: if the user has switched to a different chat by the
+   * time the refetch returns, the activeChat replacement and source-
+   * selection notification are skipped so the recovery doesn't yank
+   * them back to the chat they navigated away from.
+   *
+   * The "still on this chat?" check is read off `activeChatIdRef` (kept
+   * in sync via useEffect above) — synchronously and reliably. A prior
+   * version of this helper used a side effect inside a setActiveChat
+   * functional updater, which doesn't fire before the line that reads
+   * it under React 18 automatic batching (Greptile flagged this on
+   * PR #204). The functional updater on setActiveChat is still kept as
+   * defence-in-depth against a chat switch racing in between the ref
+   * check and the actual state commit.
+   */
+  const recoverChatFromServer = useCallback(
+    async (chatId: string, errorToastMessage?: string) => {
+      try {
+        const chat = await chatsAPI.getChat(projectId, chatId);
+        const stillActive = activeChatIdRef.current === chat.id;
+        if (stillActive) {
+          setActiveChat((prev) => {
+            if (!prev || prev.id !== chat.id) return prev;
+            return chat;
+          });
+          onActiveChatChange(chat.id, chat.selected_source_ids ?? []);
+        }
+        onCostsChange?.();
+        await loadUserUsage();
+      } catch (recoveryErr) {
+        log.error({ err: recoveryErr, chatId }, 'recovery refetch failed');
+        errorWithLogs(
+          errorToastMessage ||
+            'Connection dropped before the response arrived. Refresh to load it.',
+        );
+      }
+    },
+    [projectId, onActiveChatChange, onCostsChange, loadUserUsage, errorWithLogs],
+  );
 
   const reconcileChatMetadata = useCallback(async (chatId: string) => {
     try {
@@ -556,6 +613,25 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           onCostsChange?.();
           await reconcileChatMetadata(currentChat.id);
         }
+      } else {
+        // Stream closed cleanly but neither `assistant_done` nor `error`
+        // arrived. The most common cause is an upstream proxy (frontend
+        // nginx, Coolify Traefik) FIN'ing the connection during a long
+        // tool-use gap — the backend has already persisted the assistant
+        // message via main_chat_service, so a refetch surfaces it without
+        // re-running the model. Without this branch the UI stuck on the
+        // Reading Beat until the user manually refreshed (prod logs
+        // showed 407s / 523s / 658s streams driving the bug).
+        log.warn(
+          {
+            chatId: currentChat.id,
+            hadUserMessage: streamResult.hadUserMessage,
+            hadAssistantDelta: streamResult.hadAssistantDelta,
+          },
+          'stream ended without terminal event — recovering from server',
+        );
+        setStreamingAssistantContent('');
+        await recoverChatFromServer(currentChat.id);
       }
     } catch (err) {
       // Don't show error toast if user intentionally stopped
@@ -578,8 +654,16 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             errorWithLogs('Failed to send message');
           }
         } else {
-          log.error({ err }, 'failed to send message');
-          errorWithLogs('Failed to send message');
+          // Stream errored mid-flight after delivering partial events
+          // (canonical user_message and/or assistant_delta). Re-sending
+          // via the REST fallback would duplicate the user's message —
+          // recover by re-fetching the chat instead. The backend's
+          // exception handler in main_chat_service already persists an
+          // error-marked assistant message before the SSE error event,
+          // so the refetch surfaces either the partial response or a
+          // recorded failure the user can retry from.
+          log.warn({ err }, 'stream errored after partial events — recovering from server');
+          await recoverChatFromServer(currentChat.id, 'Failed to send message');
         }
       }
       setStreamingAssistantContent('');

--- a/frontend/src/components/project/SharingModal.tsx
+++ b/frontend/src/components/project/SharingModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 import {
   Dialog,
@@ -243,17 +243,21 @@ export const SharingModal: React.FC<SharingModalProps> = ({
     }
   };
 
-  const handleCopy = async (share: ProjectShare) => {
+  const handleCopy = async (share: ProjectShare, selectFallback: () => void) => {
     // copyToClipboard handles the modern Clipboard API + the legacy
     // execCommand fallback for non-HTTPS / unfocused contexts where
     // navigator.clipboard.writeText throws (the original failure mode here).
+    // When BOTH paths fail (some browsers block execCommand inside Radix
+    // portals, Safari iOS, strict Firefox), we surface the row's URL input
+    // pre-selected so the user can hit Cmd/Ctrl-C immediately.
     const ok = await copyToClipboard(share.url);
     if (ok) {
       setCopiedId(share.id);
       success('Link copied');
       setTimeout(() => setCopiedId((id) => (id === share.id ? null : id)), 1600);
     } else {
-      error('Could not copy. Select the URL manually.');
+      selectFallback();
+      error("Couldn't auto-copy — URL is selected, press Cmd/Ctrl-C.");
     }
   };
 
@@ -526,7 +530,7 @@ const EmptyState: React.FC = () => (
 interface ShareRowProps {
   share: ProjectShare;
   copied: boolean;
-  onCopy: (s: ProjectShare) => void;
+  onCopy: (s: ProjectShare, selectFallback: () => void) => void;
   onRevoke: (s: ProjectShare) => void;
   staggerMs: number;
 }
@@ -535,6 +539,21 @@ const ShareRow: React.FC<ShareRowProps> = ({ share, copied, onCopy, onRevoke, st
   const inactive = !share.is_active;
   const inactiveLabel = share.revoked_at ? 'Revoked' : 'Expired';
   const expiryLabel = formatExpiry(share);
+
+  // Per-row input ref — surfaces the full URL as selectable DOM text so
+  // users can manually copy (Cmd/Ctrl-C) when the Clipboard API path fails.
+  // The handler also auto-selects after a failed Copy click.
+  const urlInputRef = useRef<HTMLInputElement | null>(null);
+  // Memoised so the input doesn't see a fresh handler on every parent
+  // re-render. The ref is stable, so the callback has no dependencies.
+  const selectUrl = useCallback(() => {
+    const el = urlInputRef.current;
+    if (!el) return;
+    el.focus();
+    // setSelectionRange is the cross-platform-safe variant; .select() flakes
+    // on some mobile browsers when the input has just received focus.
+    el.setSelectionRange(0, el.value.length);
+  }, []);
 
   return (
     <div
@@ -565,14 +584,34 @@ const ShareRow: React.FC<ShareRowProps> = ({ share, copied, onCopy, onRevoke, st
           )}
         </span>
 
-        {/* URL + metadata */}
+        {/* URL + metadata. The URL is rendered as a read-only <input> (not a
+            <span>) so users can manually triple-click + copy on browsers
+            where the Clipboard API and its execCommand fallback both fail
+            (Safari iOS, strict Firefox, sandboxed iframes). The value is the
+            full URL with scheme — the input scrolls horizontally if needed,
+            but selection always covers the entire string. */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-            <span className="font-mono truncate" title={share.url}>
-              {compactUrl(share.url)}
-            </span>
+            <input
+              ref={urlInputRef}
+              readOnly
+              value={share.url}
+              onClick={selectUrl}
+              onFocus={selectUrl}
+              title={share.url}
+              // Unique per row so screen readers can distinguish multiple
+              // share inputs in the list — generic "Share link URL" alone
+              // produced identical accessible names for every row.
+              aria-label={`Share link URL: ${share.url}`}
+              // overflow-x-auto (NOT `truncate`) so the input scrolls
+              // horizontally for long URLs. `truncate` adds overflow:hidden
+              // which silently clips the text inside the input — selection
+              // still copies the full value, but a user clicking just to
+              // visually inspect the URL would only ever see the prefix.
+              className="flex-1 min-w-0 overflow-x-auto font-mono text-[11px] text-muted-foreground bg-transparent border-0 outline-none p-0 m-0 h-auto leading-normal focus-visible:ring-0 focus-visible:ring-offset-0 focus:text-foreground cursor-text"
+            />
             {inactive && (
-              <span className="px-1.5 py-px rounded text-[10px] font-medium uppercase tracking-wide bg-stone-200/70 text-stone-700 dark:bg-stone-800/70 dark:text-stone-300">
+              <span className="flex-shrink-0 px-1.5 py-px rounded text-[10px] font-medium uppercase tracking-wide bg-stone-200/70 text-stone-700 dark:bg-stone-800/70 dark:text-stone-300">
                 {inactiveLabel}
               </span>
             )}
@@ -603,7 +642,7 @@ const ShareRow: React.FC<ShareRowProps> = ({ share, copied, onCopy, onRevoke, st
           <Button
             variant={copied ? 'secondary' : 'outline'}
             size="sm"
-            onClick={() => onCopy(share)}
+            onClick={() => onCopy(share, selectUrl)}
             disabled={inactive}
             className="h-7 px-2.5 gap-1.5 text-xs"
             aria-label="Copy link"
@@ -656,17 +695,6 @@ const shareRowKeyframes = `
   to   { opacity: 1; transform: translateY(0); }
 }
 `;
-
-function compactUrl(url: string): string {
-  // Show only the last meaningful segment so the row stays tidy at any width.
-  // e.g. https://app.example.com/share/AbC123 → /share/AbC123
-  try {
-    const u = new URL(url);
-    return `${u.host}${u.pathname}`;
-  } catch {
-    return url;
-  }
-}
 
 function formatExpiry(share: ProjectShare): string {
   if (share.revoked_at) return 'Revoked';


### PR DESCRIPTION
## Summary
Promote develop → main. Includes:

- **#203** — frontend: selectable share-URL input as manual-copy fallback for HTTP / failing Clipboard API
- **#204** — fix chat: surface AI response when SSE stream truncates before `assistant_done`
- **#202** (e1133ba) — frontend: preserve `X-Forwarded-Proto` from Coolify Traefik
- **#201** (053cff5) — frontend: proxy `/storage/v1/*` to Kong so signed-URL previews actually load
- **#200** (213f110) — frontend: `HEALTHCHECK` + `/healthz` so Coolify/Traefik can wait on readiness

8 commits total. All shipped to `develop` and CI-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
