### PR TITLE
chat: paste / drag-and-drop image attachments (Claude/Gemini-style)

### DIFF
--- a/backend/app/api/messages/routes.py
+++ b/backend/app/api/messages/routes.py
@@ -89,6 +89,21 @@ def _parse_message_request(project_id: str, chat_id: str) -> Tuple[Any, Union[Tu
             "error": f"Maximum {_MAX_ATTACHMENTS_PER_MESSAGE} attachments per message.",
         }), 400)
 
+    # Track every successfully-uploaded path so we can roll them back on
+    # any later failure in this loop. Without this, a partial failure
+    # (e.g. file 1 uploads, file 2 fails MIME check) would orphan file 1
+    # in the bucket — invisible until cascade-delete on chat removal.
+    uploaded_paths: List[str] = []
+
+    def _rollback_uploaded() -> None:
+        for path in uploaded_paths:
+            try:
+                storage_service.delete_chat_attachment(path)
+            except Exception:  # pragma: no cover — best-effort cleanup
+                current_app.logger.warning(
+                    "Rollback failed for chat attachment %s", path,
+                )
+
     attachment_blocks: List[dict] = []
     for upload in upload_files:
         mime = (upload.content_type or "").lower()
@@ -96,6 +111,7 @@ def _parse_message_request(project_id: str, chat_id: str) -> Tuple[Any, Union[Tu
         if mime == "image/jpg":
             mime = "image/jpeg"
         if mime not in _ALLOWED_ATTACHMENT_MIMES:
+            _rollback_uploaded()
             return None, (jsonify({
                 "success": False,
                 "error": f"Unsupported image format ({mime or 'unknown'}). Allowed: PNG, JPEG, WebP, GIF.",
@@ -103,8 +119,10 @@ def _parse_message_request(project_id: str, chat_id: str) -> Tuple[Any, Union[Tu
 
         data_bytes = upload.read()
         if not data_bytes:
+            _rollback_uploaded()
             return None, (jsonify({"success": False, "error": "Empty attachment."}), 400)
         if len(data_bytes) > _MAX_ATTACHMENT_BYTES:
+            _rollback_uploaded()
             return None, (jsonify({
                 "success": False,
                 "error": f"Image exceeds {_MAX_ATTACHMENT_BYTES // (1024*1024)}MB limit.",
@@ -123,8 +141,10 @@ def _parse_message_request(project_id: str, chat_id: str) -> Tuple[Any, Union[Tu
             content_type=mime,
         )
         if not storage_path:
+            _rollback_uploaded()
             return None, (jsonify({"success": False, "error": "Failed to store attachment."}), 500)
 
+        uploaded_paths.append(storage_path)
         attachment_blocks.append({
             "type": "image",
             "storage_path": storage_path,

--- a/backend/app/api/messages/routes.py
+++ b/backend/app/api/messages/routes.py
@@ -29,14 +29,125 @@ Routes:
 import json
 import queue
 import threading
+import uuid
+from typing import Any, List, Tuple, Union
 
 from flask import jsonify, request, current_app, Response, stream_with_context
+from werkzeug.utils import secure_filename
 from app.api.messages import messages_bp
 from app.services.chat_services import main_chat_service
 from app.services.auth.rbac import get_request_identity
+from app.services.integrations.supabase import storage_service
 
 
 _STREAM_SENTINEL = object()
+
+# Inline chat-image attachment constraints. Anthropic's vision API caps
+# at 5MB per image and supports png/jpeg/webp/gif. We cap at 10 images
+# per message — more than enough for "drop a few screenshots" and keeps
+# the multipart payload bounded.
+_ALLOWED_ATTACHMENT_MIMES = {
+    "image/png", "image/jpeg", "image/jpg", "image/webp", "image/gif",
+}
+_MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024
+_MAX_ATTACHMENTS_PER_MESSAGE = 10
+
+
+def _parse_message_request(project_id: str, chat_id: str) -> Tuple[Any, Union[Tuple[Response, int], None]]:
+    """
+    Read the message text + any inline image attachments from the request,
+    upload images to chat-attachments storage, and return the payload to
+    pass to main_chat_service.
+
+    Supports both `application/json` (text-only, legacy) and
+    `multipart/form-data` (text + attachments). Returns a tuple of
+    (user_message_payload, error_response). On error, error_response is
+    a (jsonified, status_code) pair the route can return directly; on
+    success, error_response is None.
+
+    The payload is either a plain string (no attachments — current shape
+    add_user_message has handled forever) or a list of content blocks
+    (new shape — image blocks first, text block last). Both flow through
+    add_user_message → JSONB storage → build_api_messages transparently.
+    """
+    content_type = request.content_type or ""
+
+    if content_type.startswith("multipart/"):
+        user_message_text = (request.form.get("message") or "").strip()
+        upload_files = request.files.getlist("attachments")
+    else:
+        data = request.get_json(silent=True) or {}
+        user_message_text = (data.get("message") or "").strip()
+        upload_files = []
+
+    if not user_message_text and not upload_files:
+        return None, (jsonify({"success": False, "error": "Message or attachment required"}), 400)
+
+    if len(upload_files) > _MAX_ATTACHMENTS_PER_MESSAGE:
+        return None, (jsonify({
+            "success": False,
+            "error": f"Maximum {_MAX_ATTACHMENTS_PER_MESSAGE} attachments per message.",
+        }), 400)
+
+    attachment_blocks: List[dict] = []
+    for upload in upload_files:
+        mime = (upload.content_type or "").lower()
+        # Normalise jpg → jpeg so downstream MIME comparisons are consistent.
+        if mime == "image/jpg":
+            mime = "image/jpeg"
+        if mime not in _ALLOWED_ATTACHMENT_MIMES:
+            return None, (jsonify({
+                "success": False,
+                "error": f"Unsupported image format ({mime or 'unknown'}). Allowed: PNG, JPEG, WebP, GIF.",
+            }), 400)
+
+        data_bytes = upload.read()
+        if not data_bytes:
+            return None, (jsonify({"success": False, "error": "Empty attachment."}), 400)
+        if len(data_bytes) > _MAX_ATTACHMENT_BYTES:
+            return None, (jsonify({
+                "success": False,
+                "error": f"Image exceeds {_MAX_ATTACHMENT_BYTES // (1024*1024)}MB limit.",
+            }), 400)
+
+        attachment_id = uuid.uuid4().hex
+        # secure_filename() returns "" for purely punctuation/Unicode names —
+        # fall back to a generated name so the storage path isn't malformed.
+        safe_name = secure_filename(upload.filename or "") or f"attachment-{attachment_id}"
+        storage_path = storage_service.upload_chat_attachment(
+            project_id=project_id,
+            chat_id=chat_id,
+            attachment_id=attachment_id,
+            filename=safe_name,
+            file_data=data_bytes,
+            content_type=mime,
+        )
+        if not storage_path:
+            return None, (jsonify({"success": False, "error": "Failed to store attachment."}), 500)
+
+        attachment_blocks.append({
+            "type": "image",
+            "storage_path": storage_path,
+            "media_type": mime,
+            "filename": safe_name,
+            # Signed URL is a convenience for chat-history rendering. It's
+            # short-lived (1h); _format_message_for_frontend re-signs on
+            # subsequent reads.
+            "url": storage_service.get_chat_attachment_url(storage_path) or "",
+        })
+
+    if attachment_blocks:
+        # Image blocks come BEFORE text — Anthropic's vision docs recommend
+        # this for best instruction-following ("here's an image, here's
+        # what to do with it").
+        user_message_payload: Union[str, list] = [
+            *attachment_blocks,
+            {"type": "text", "text": user_message_text or ""},
+        ]
+    else:
+        user_message_payload = user_message_text
+
+    return user_message_payload, None
 
 
 def _format_sse(event_name: str, payload: dict | None = None) -> str:
@@ -70,22 +181,16 @@ def send_message(project_id, chat_id):
         }
     """
     try:
-        data = request.get_json()
-
-        if not data or 'message' not in data:
-            return jsonify({
-                'success': False,
-                'error': 'Message is required'
-            }), 400
-
-        user_message_text = data['message']
+        user_message_payload, err = _parse_message_request(project_id, chat_id)
+        if err is not None:
+            return err
 
         # Delegate all processing to main_chat_service
         # This is the RAG + agentic loop entry point
         result = main_chat_service.send_message(
             project_id=project_id,
             chat_id=chat_id,
-            user_message_text=user_message_text
+            user_message_text=user_message_payload,
         )
 
         return jsonify({
@@ -116,15 +221,10 @@ def stream_message(project_id, chat_id):
 
     The final saved assistant message is emitted as an `assistant_done` event.
     """
-    data = request.get_json()
+    user_message_payload, err = _parse_message_request(project_id, chat_id)
+    if err is not None:
+        return err
 
-    if not data or 'message' not in data:
-        return jsonify({
-            'success': False,
-            'error': 'Message is required'
-        }), 400
-
-    user_message_text = data['message']
     identity = get_request_identity()
     user_id = identity.user_id
     app = current_app._get_current_object()
@@ -158,7 +258,7 @@ def stream_message(project_id, chat_id):
             main_chat_service.stream_message(
                 project_id=project_id,
                 chat_id=chat_id,
-                user_message_text=user_message_text,
+                user_message_text=user_message_payload,
                 user_id=user_id,
                 on_event=emit,
                 cancel_event=cancel_event,

--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -14,7 +14,34 @@ Message Flow:
 The service uses message_service for all message handling and tool parsing.
 """
 import logging
-from typing import Dict, Any, Tuple, List, Optional, Callable
+from typing import Dict, Any, Tuple, List, Optional, Callable, Union
+
+
+# A user message coming in from the API can be either a plain string
+# (legacy / no-attachment path) or a list of content blocks (new path
+# with inline image attachments). Both shapes round-trip through
+# add_user_message → JSONB storage → build_api_messages.
+UserMessagePayload = Union[str, List[Dict[str, Any]]]
+
+
+def _extract_user_text(content: UserMessagePayload) -> str:
+    """
+    Pull the plain-text portion out of a user-message payload, supporting
+    either a raw string or a content-block list. Used by codepaths that
+    want only the user's words (chat naming, studio-signal direction
+    override) — they shouldn't see internal image-block metadata.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            block.get("text", "")
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and block.get("text")
+        )
+    return ""
 
 from app.services.data_services import chat_service
 from app.services.data_services.user_service import get_user_service
@@ -326,7 +353,10 @@ class MainChatService:
             # this is the belt-and-braces guarantee.
             signals = tool_input.get("signals", [])
             if user_message_text and isinstance(signals, list):
-                stripped = user_message_text.strip()
+                # user_message_text can be a content-block list when the
+                # user attached an inline image — strip() only works on
+                # the text portion, so extract that first.
+                stripped = _extract_user_text(user_message_text).strip()
                 if stripped:
                     signals = [
                         {**s, "direction": stripped} if isinstance(s, dict) else s
@@ -436,7 +466,7 @@ class MainChatService:
         self,
         project_id: str,
         chat_id: str,
-        user_message_text: str,
+        user_message_text: UserMessagePayload,
         *,
         stream_text: bool = False,
         user_id: Optional[str] = None,
@@ -712,13 +742,15 @@ class MainChatService:
         # The naming runs in background so it doesn't block the response.
         if chat.get("message_count", 0) == 0:
             # Submit naming task to background
+            # Chat naming uses the plain-text portion only — image-block
+            # metadata isn't useful for picking a 1-5 word title.
             task_service.submit_task(
                 "chat_naming",
                 chat_id,
                 self._generate_and_update_chat_title,
                 project_id,
                 chat_id,
-                user_message_text,
+                _extract_user_text(user_message_text),
                 target_type="chat",
             )
 
@@ -732,7 +764,7 @@ class MainChatService:
         self,
         project_id: str,
         chat_id: str,
-        user_message_text: str
+        user_message_text: UserMessagePayload,
     ) -> Dict[str, Any]:
         """Process a user message and return saved messages plus sync metadata."""
         return self._run_message_flow(
@@ -746,7 +778,7 @@ class MainChatService:
         self,
         project_id: str,
         chat_id: str,
-        user_message_text: str,
+        user_message_text: UserMessagePayload,
         *,
         user_id: Optional[str] = None,
         on_event: Optional[Callable[[str, Dict[str, Any]], None]] = None,

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -394,6 +394,21 @@ class ChatService:
         # Delete the chat (messages and signals cascade automatically)
         self.supabase.table(self.table).delete().eq("id", chat_id).eq("project_id", project_id).execute()
 
+        # Cascade-delete inline chat attachments from storage. The DB
+        # cascade only covers tables, not the storage bucket — without
+        # this, screenshots pasted into deleted chats would orphan in
+        # the chat-attachments bucket forever. Best-effort: a storage
+        # failure shouldn't block the DB delete from being reported.
+        try:
+            from app.services.integrations.supabase import storage_service
+            storage_service.delete_chat_attachments_for_chat(project_id, chat_id)
+        except Exception as exc:  # pragma: no cover — defensive
+            import logging
+            logging.getLogger(__name__).warning(
+                "Failed to clean chat-attachment storage for %s/%s: %s",
+                project_id, chat_id, exc,
+            )
+
         return True
 
     def sync_chat_to_index(self, project_id: str, chat_id: str) -> bool:

--- a/backend/app/services/data_services/message_service.py
+++ b/backend/app/services/data_services/message_service.py
@@ -14,6 +14,7 @@ Key Responsibilities:
 For parsing Claude API responses (tool_use blocks, content extraction),
 see utils/claude_parsing_utils.py
 """
+import base64
 import json
 import uuid
 from datetime import datetime
@@ -190,7 +191,22 @@ class MessageService:
         # - A string (legacy)
         # - A list of content blocks (tool_use responses from Claude)
         #   e.g. [{"type": "text", "text": "..."}, {"type": "tool_use", ...}]
-        if isinstance(content, dict) and "text" in content:
+        # If the user attached inline images, the persisted content is a
+        # list with `{"type":"image","storage_path":...}` blocks. We surface
+        # those to the frontend as a typed-block list so the chat UI can
+        # render the image inline; pure-text messages keep the legacy
+        # string shape so existing renderers don't have to change.
+        has_image_blocks = (
+            isinstance(content, list)
+            and any(
+                isinstance(b, dict) and b.get("type") == "image"
+                for b in content
+            )
+        )
+
+        if has_image_blocks:
+            text_content = self._format_blocks_with_images(content)
+        elif isinstance(content, dict) and "text" in content:
             text_content = content["text"]
         elif isinstance(content, str):
             text_content = content
@@ -218,22 +234,69 @@ class MessageService:
             "error": is_error,
         }
 
+    def _format_blocks_with_images(self, content: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Project a persisted user-message content list down to the shape the
+        frontend renderer wants: a list of {type, ...} blocks with image
+        URLs re-signed at read time. Internal-only fields (storage_path)
+        and tool blocks are stripped.
+        """
+        # Lazy-import to avoid a circular dependency between message_service
+        # (data layer) and storage_service (integration layer).
+        from app.services.integrations.supabase import storage_service
+
+        rendered: List[Dict[str, Any]] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "image":
+                storage_path = block.get("storage_path")
+                if not storage_path:
+                    # Frontend-supplied image (e.g. blob URL during optimistic
+                    # render) — pass URL straight through if present.
+                    if block.get("url"):
+                        rendered.append({
+                            "type": "image",
+                            "url": block["url"],
+                            "media_type": block.get("media_type", "image/png"),
+                            "filename": block.get("filename", "attachment"),
+                        })
+                    continue
+                signed_url = storage_service.get_chat_attachment_url(storage_path) or ""
+                rendered.append({
+                    "type": "image",
+                    "url": signed_url,
+                    "media_type": block.get("media_type", "image/png"),
+                    "filename": block.get("filename", "attachment"),
+                })
+            elif btype == "text":
+                text_value = block.get("text", "")
+                if text_value:
+                    rendered.append({"type": "text", "text": text_value})
+            # Skip tool_use / tool_result / unknown block types — they
+            # belong to internal agent flow, not user-visible content.
+        return rendered
+
     def add_user_message(
         self,
         project_id: str,
         chat_id: str,
-        content: str
+        content: Any,
     ) -> Optional[Dict[str, Any]]:
         """
         Add a user message to a chat.
 
-        Educational Note: Convenience method for the common case of
-        adding a simple text message from the user.
-
         Args:
             project_id: The project UUID
             chat_id: The chat UUID
-            content: The user's message text
+            content: Either a plain text string (legacy / no-attachment
+                path) or a list of content blocks `[{type:"image",
+                storage_path:...}, {type:"text", text:"..."}]` for
+                messages with inline image attachments. Both shapes
+                round-trip through JSONB storage and re-emerge correctly
+                via `_format_message_for_frontend` and
+                `build_api_messages`.
 
         Returns:
             The created message dict
@@ -351,6 +414,11 @@ class MessageService:
             else:
                 api_content = content
 
+            # Persisted image blocks reference {storage_path, media_type, ...}
+            # — Claude's vision API needs base64-inline source. Rewrite
+            # before sending. No-op for messages that have no image blocks.
+            api_content = self._rewrite_image_blocks_for_claude(api_content)
+
             api_messages.append({
                 "role": msg["role"],
                 "content": api_content
@@ -396,6 +464,52 @@ class MessageService:
             api_messages.pop(0)
 
         return api_messages
+
+    def _rewrite_image_blocks_for_claude(self, content: Any) -> Any:
+        """
+        Translate persisted image blocks (`{type:"image", storage_path:...}`)
+        into Anthropic's vision content shape:
+        `{type:"image", source:{type:"base64", media_type, data}}`.
+
+        Non-list content and lists without image blocks pass through
+        unchanged so the existing tool-use plumbing still works.
+
+        Failure mode: if a referenced attachment can't be downloaded, the
+        image block is dropped (logged) rather than crashing the whole
+        request — Claude still gets the user's text.
+        """
+        if not isinstance(content, list):
+            return content
+        if not any(
+            isinstance(b, dict) and b.get("type") == "image" and b.get("storage_path")
+            for b in content
+        ):
+            return content
+
+        from app.services.integrations.supabase import storage_service
+
+        rewritten: List[Any] = []
+        for block in content:
+            if not isinstance(block, dict):
+                rewritten.append(block)
+                continue
+            if block.get("type") == "image" and block.get("storage_path"):
+                data = storage_service.download_chat_attachment(block["storage_path"])
+                if data is None:
+                    # Already-logged in storage_service; just skip the image
+                    # so the rest of the message still goes through.
+                    continue
+                rewritten.append({
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": block.get("media_type", "image/png"),
+                        "data": base64.standard_b64encode(data).decode("ascii"),
+                    },
+                })
+            else:
+                rewritten.append(block)
+        return rewritten
 
     def _sanitize_tool_sequences(self, api_messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """

--- a/backend/app/services/integrations/supabase/storage_service.py
+++ b/backend/app/services/integrations/supabase/storage_service.py
@@ -662,6 +662,22 @@ def get_chat_attachment_url(path: str, expires_in: int = 3600) -> Optional[str]:
         return None
 
 
+def delete_chat_attachment(path: str) -> bool:
+    """
+    Delete a single chat attachment by its full storage path. Used for
+    rollback when the message-stream multipart upload fails partway —
+    so a failed third-of-three upload doesn't leak the first two.
+    Returns True on success / not-found, False on a real error.
+    """
+    client = _get_client()
+    try:
+        client.storage.from_(BUCKET_CHAT_ATTACHMENTS).remove([path])
+        return True
+    except Exception as e:
+        logger.error("Failed to delete chat attachment %s: %s", path, e)
+        return False
+
+
 def delete_chat_attachments_for_chat(project_id: str, chat_id: str) -> bool:
     """
     Cascade-delete every attachment under a chat's prefix. Called from

--- a/backend/app/services/integrations/supabase/storage_service.py
+++ b/backend/app/services/integrations/supabase/storage_service.py
@@ -75,6 +75,11 @@ BUCKET_PROCESSED = "processed-files"
 BUCKET_CHUNKS = "chunks"
 BUCKET_STUDIO = "studio-outputs"
 BUCKET_BRAND_ASSETS = "brand-assets"
+# Transient inline images pasted/dropped into the chat input. Stored
+# permanently for chat-history rendering, but cleared when the chat is
+# deleted (cascade). Distinct from raw-files so RLS policies and
+# cleanup-on-chat-delete stay simple (single-prefix remove).
+BUCKET_CHAT_ATTACHMENTS = "chat-attachments"
 
 # Supabase storage3 defaults to limit=100 which silently drops entries.
 # Use a high limit to ensure we list all files in a folder.
@@ -563,6 +568,128 @@ def delete_source_chunks(project_id: str, source_id: str) -> bool:
         return True
     except Exception as e:
         logger.error("Failed to delete chunks for %s: %s", prefix, e)
+        return False
+
+
+# =============================================================================
+# CHAT ATTACHMENTS (Inline images pasted/dropped into the chat input)
+# =============================================================================
+#
+# Transient screenshots / images attached to a chat message — distinct from
+# Sources because they're one-shot context, not RAG-indexed knowledge. Layout:
+#
+#   {project_id}/{chat_id}/{attachment_id}/{filename}
+#
+# Cleanup-on-chat-delete is a single-prefix remove (cascade-safe).
+
+def _build_chat_attachment_path(
+    project_id: str, chat_id: str, attachment_id: str, filename: str
+) -> str:
+    return f"{project_id}/{chat_id}/{attachment_id}/{filename}"
+
+
+def upload_chat_attachment(
+    project_id: str,
+    chat_id: str,
+    attachment_id: str,
+    filename: str,
+    file_data: Union[bytes, BinaryIO],
+    content_type: str = "application/octet-stream",
+) -> Optional[str]:
+    """
+    Upload an inline chat attachment (typically a screenshot pasted/dropped
+    into the chat input). Returns the storage path on success.
+
+    Mirrors the upload_raw_file shape but writes to the chat-attachments
+    bucket and uses a chat-scoped path prefix so cascade-delete on chat
+    removal is a single prefix wipe.
+    """
+    client = _get_client()
+    path = _build_chat_attachment_path(project_id, chat_id, attachment_id, filename)
+    file_options = {"content-type": content_type}
+
+    try:
+        if not isinstance(file_data, (bytes, bytearray)):
+            try:
+                payload = file_data.read()
+            except Exception:
+                payload = file_data
+        else:
+            payload = bytes(file_data)
+        client.storage.from_(BUCKET_CHAT_ATTACHMENTS).upload(
+            path=path,
+            file=payload,
+            file_options=file_options,
+        )
+        return path
+    except Exception as exc:
+        msg = str(exc).lower()
+        if "duplicate" in msg or "already exists" in msg:
+            try:
+                client.storage.from_(BUCKET_CHAT_ATTACHMENTS).remove([path])
+                client.storage.from_(BUCKET_CHAT_ATTACHMENTS).upload(
+                    path=path, file=payload, file_options=file_options,
+                )
+                return path
+            except Exception as retry_exc:
+                logger.error("Chat-attachment retry upload failed for %s: %s", path, retry_exc)
+                return None
+        logger.error("Failed to upload chat attachment %s: %s", path, exc)
+        return None
+
+
+def download_chat_attachment(path: str) -> Optional[bytes]:
+    """
+    Download a chat attachment by full storage path. Used by the chat
+    pipeline when building Claude vision payloads (fresh base64 per send).
+    """
+    client = _get_client()
+    try:
+        return client.storage.from_(BUCKET_CHAT_ATTACHMENTS).download(path)
+    except Exception as e:
+        logger.error("Failed to download chat attachment %s: %s", path, e)
+        return None
+
+
+def get_chat_attachment_url(path: str, expires_in: int = 3600) -> Optional[str]:
+    """Signed URL for in-app chat-history rendering."""
+    client = _get_client()
+    try:
+        response = client.storage.from_(BUCKET_CHAT_ATTACHMENTS).create_signed_url(path, expires_in)
+        return _rewrite_signed_url_for_browser(response.get("signedURL"))
+    except Exception as e:
+        logger.error("Failed to get signed URL for chat attachment %s: %s", path, e)
+        return None
+
+
+def delete_chat_attachments_for_chat(project_id: str, chat_id: str) -> bool:
+    """
+    Cascade-delete every attachment under a chat's prefix. Called from
+    chat_service.delete_chat to keep storage in sync with the messages
+    cascade. Idempotent — empty prefix is a no-op success.
+    """
+    client = _get_client()
+    prefix = f"{project_id}/{chat_id}/"
+
+    try:
+        # The bucket layout is {project_id}/{chat_id}/{attachment_id}/{filename}
+        # so list returns the per-attachment dirs at this depth — recurse one
+        # level via list-with-prefix to get the actual file paths to remove.
+        attachment_dirs = client.storage.from_(BUCKET_CHAT_ATTACHMENTS).list(
+            prefix.rstrip("/"), options=_LIST_OPTIONS
+        ) or []
+        all_paths: List[str] = []
+        for entry in attachment_dirs:
+            sub_prefix = f"{prefix}{entry['name']}/"
+            files = client.storage.from_(BUCKET_CHAT_ATTACHMENTS).list(
+                sub_prefix.rstrip("/"), options=_LIST_OPTIONS
+            ) or []
+            all_paths.extend(f"{sub_prefix}{f['name']}" for f in files)
+        if all_paths:
+            client.storage.from_(BUCKET_CHAT_ATTACHMENTS).remove(all_paths)
+        return True
+    except Exception as e:
+        logger.error("Failed to delete chat attachments for %s: %s", prefix, e)
         return False
 
 

--- a/backend/supabase/migrations/00027_chat_attachments_bucket.sql
+++ b/backend/supabase/migrations/00027_chat_attachments_bucket.sql
@@ -27,9 +27,22 @@ VALUES (
 -- ============================================================================
 -- STORAGE POLICIES
 -- ============================================================================
--- Mirrors the raw-files / brand-assets pattern. Backend uploads/reads using
--- the service key (bypasses RLS); these policies are for direct user-token
--- access (e.g., a future feature that lets the frontend upload directly).
+-- Mirrors the raw-files / brand-assets pattern intentionally. Important
+-- nuance: the path layout we actually upload is
+--   {project_id}/{chat_id}/{attachment_id}/{filename}
+-- so `(storage.foldername(name))[1]` resolves to project_id, NOT user_id.
+-- The `auth.uid()::text = first_folder` check below therefore *cannot*
+-- match for user-token access — by design.
+--
+-- This is consistent with the existing buckets (raw-files in
+-- 00002_storage_buckets.sql, brand-assets in 00007_brand_assets.sql)
+-- which have the same shape. The backend always reads/writes with the
+-- service key (bypassing RLS) and hands the browser short-lived signed
+-- URLs that don't go through these policies. Direct user-token uploads
+-- aren't a feature today; if/when that lands, swap the path prefix to
+-- {user_id}/{project_id}/{chat_id}/... so this policy actually grants
+-- access (matching the convention encoded in
+-- generate_raw_file_path / generate_brand_asset_path).
 
 CREATE POLICY "Users can upload chat attachments to own projects"
 ON storage.objects FOR INSERT

--- a/backend/supabase/migrations/00027_chat_attachments_bucket.sql
+++ b/backend/supabase/migrations/00027_chat_attachments_bucket.sql
@@ -1,0 +1,60 @@
+-- Migration: Chat Attachments Storage Bucket
+-- Description: Bucket + storage policies for inline images pasted/dropped
+--              into the chat input (screenshots, etc.). Distinct from
+--              raw-files because the lifecycle is per-chat (cascade-delete
+--              on chat removal) rather than per-source.
+-- Created: 2026-05-08
+
+-- ============================================================================
+-- STORAGE BUCKET
+-- ============================================================================
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'chat-attachments',
+  'chat-attachments',
+  false, -- Private; access via signed URLs
+  10485760, -- 10MB per attachment (Claude vision caps at 5MB; 2× headroom for transient pre-validation)
+  ARRAY[
+    'image/png',
+    'image/jpeg',
+    'image/jpg',
+    'image/webp',
+    'image/gif'
+  ]
+);
+
+-- ============================================================================
+-- STORAGE POLICIES
+-- ============================================================================
+-- Mirrors the raw-files / brand-assets pattern. Backend uploads/reads using
+-- the service key (bypasses RLS); these policies are for direct user-token
+-- access (e.g., a future feature that lets the frontend upload directly).
+
+CREATE POLICY "Users can upload chat attachments to own projects"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'chat-attachments' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can read chat attachments from own projects"
+ON storage.objects FOR SELECT
+USING (
+  bucket_id = 'chat-attachments' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can update chat attachments in own projects"
+ON storage.objects FOR UPDATE
+USING (
+  bucket_id = 'chat-attachments' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can delete chat attachments from own projects"
+ON storage.objects FOR DELETE
+USING (
+  bucket_id = 'chat-attachments' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);

--- a/backend/tests/test_chat_attachments.py
+++ b/backend/tests/test_chat_attachments.py
@@ -1,0 +1,201 @@
+"""
+Tests for the chat-attachment plumbing.
+
+Covers:
+  - The frontend formatter `_format_message_for_frontend` rendering image
+    blocks alongside text instead of stripping them as if they were tool
+    blocks.
+  - `_rewrite_image_blocks_for_claude` translating persisted
+    `{type:"image", storage_path:...}` blocks into Claude's vision shape
+    `{type:"image", source:{type:"base64", media_type, data}}`.
+  - Pure text content untouched by either pass (backwards compat).
+  - Failure mode: when the storage download returns None, the image
+    block is dropped rather than crashing the whole request.
+"""
+import base64
+from unittest.mock import patch
+
+import pytest
+
+from app.services.data_services.message_service import MessageService
+
+
+@pytest.fixture
+def service():
+    """A MessageService instance with the supabase client unwired — the
+    methods under test don't touch the DB."""
+    svc = MessageService.__new__(MessageService)
+    svc.supabase = None  # type: ignore[attr-defined]
+    svc.table = "messages"  # type: ignore[attr-defined]
+    svc.chats_table = "chats"  # type: ignore[attr-defined]
+    return svc
+
+
+# ==========================================================================
+# _format_message_for_frontend — image blocks survive
+# ==========================================================================
+
+
+class TestFormatForFrontendImageBlocks:
+
+    def test_text_only_message_keeps_string_shape(self, service):
+        """Pure-text user messages must continue to render as plain string
+        content for backwards compatibility with every existing chat in
+        the DB."""
+        msg = {
+            "id": "m1",
+            "role": "user",
+            "content": {"text": "Hello world"},
+            "created_at": "2026-05-08T00:00:00Z",
+        }
+        out = service._format_message_for_frontend(msg)
+        assert out["content"] == "Hello world"
+        assert out["error"] is False
+
+    def test_block_content_with_image_returns_typed_blocks(self, service):
+        """When the persisted content is a list with image blocks, the
+        formatter returns a typed-block list — not a flat string — so
+        the chat-bubble renderer can show the image alongside text."""
+        with patch(
+            "app.services.integrations.supabase.storage_service.get_chat_attachment_url",
+            return_value="https://signed.example.com/abc.png",
+        ):
+            msg = {
+                "id": "m1",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "storage_path": "p1/c1/att1/screenshot.png",
+                        "media_type": "image/png",
+                        "filename": "screenshot.png",
+                    },
+                    {"type": "text", "text": "What's in this?"},
+                ],
+                "created_at": "2026-05-08T00:00:00Z",
+            }
+            out = service._format_message_for_frontend(msg)
+        assert isinstance(out["content"], list)
+        # Image block re-signed with a fresh URL, internal storage_path stripped
+        assert out["content"][0] == {
+            "type": "image",
+            "url": "https://signed.example.com/abc.png",
+            "media_type": "image/png",
+            "filename": "screenshot.png",
+        }
+        assert out["content"][1] == {"type": "text", "text": "What's in this?"}
+
+    def test_block_content_without_images_falls_back_to_text(self, service):
+        """Tool-use / tool-result blocks (no image) keep the legacy text-
+        join behaviour."""
+        msg = {
+            "id": "m1",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "tool_use", "name": "search_sources"},
+                {"type": "text", "text": "World"},
+            ],
+            "created_at": "2026-05-08T00:00:00Z",
+        }
+        out = service._format_message_for_frontend(msg)
+        assert out["content"] == "Hello\n\nWorld"
+
+
+# ==========================================================================
+# _rewrite_image_blocks_for_claude — vision-shape translation
+# ==========================================================================
+
+
+class TestRewriteImageBlocksForClaude:
+
+    def test_pure_string_content_unchanged(self, service):
+        assert service._rewrite_image_blocks_for_claude("hi") == "hi"
+
+    def test_dict_text_content_unchanged(self, service):
+        # build_api_messages handles the dict→string extraction before
+        # this runs; the rewriter shouldn't touch dicts.
+        original = {"text": "hi"}
+        assert service._rewrite_image_blocks_for_claude(original) == original
+
+    def test_text_only_list_unchanged(self, service):
+        """Lists without any image blocks are returned without traversal —
+        important so tool_use/tool_result message chains keep working."""
+        original = [
+            {"type": "text", "text": "Hello"},
+            {"type": "tool_use", "id": "tu_1", "name": "x", "input": {}},
+        ]
+        assert service._rewrite_image_blocks_for_claude(original) is original
+
+    def test_image_block_rewritten_to_base64_source(self, service):
+        """Persisted storage_path image block becomes Claude's vision
+        shape with inline base64."""
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"x" * 32
+        with patch(
+            "app.services.integrations.supabase.storage_service.download_chat_attachment",
+            return_value=png_bytes,
+        ):
+            content = [
+                {
+                    "type": "image",
+                    "storage_path": "p1/c1/att1/screenshot.png",
+                    "media_type": "image/png",
+                    "filename": "screenshot.png",
+                },
+                {"type": "text", "text": "What's in this?"},
+            ]
+            out = service._rewrite_image_blocks_for_claude(content)
+        assert out[0]["type"] == "image"
+        assert out[0]["source"]["type"] == "base64"
+        assert out[0]["source"]["media_type"] == "image/png"
+        assert out[0]["source"]["data"] == base64.standard_b64encode(png_bytes).decode("ascii")
+        # storage_path / filename internal fields are not propagated to
+        # Claude — vision API only needs source.{type,media_type,data}.
+        assert "storage_path" not in out[0]
+        assert "filename" not in out[0]
+        # Text block untouched
+        assert out[1] == {"type": "text", "text": "What's in this?"}
+
+    def test_unreadable_image_is_skipped(self, service):
+        """If storage download returns None (file disappeared, RLS blocked,
+        etc.), the image block is dropped so the rest of the message can
+        still go through to Claude."""
+        with patch(
+            "app.services.integrations.supabase.storage_service.download_chat_attachment",
+            return_value=None,
+        ):
+            content = [
+                {
+                    "type": "image",
+                    "storage_path": "p1/c1/missing/screenshot.png",
+                    "media_type": "image/png",
+                },
+                {"type": "text", "text": "fallback question"},
+            ]
+            out = service._rewrite_image_blocks_for_claude(content)
+        # Image block dropped, text preserved
+        assert len(out) == 1
+        assert out[0] == {"type": "text", "text": "fallback question"}
+
+    def test_multiple_images_all_rewritten(self, service):
+        png = b"\x89PNG\r\n\x1a\n" + b"a"
+        jpg = b"\xff\xd8\xff" + b"b"
+
+        def fake_download(path):
+            if "first" in path:
+                return png
+            return jpg
+
+        with patch(
+            "app.services.integrations.supabase.storage_service.download_chat_attachment",
+            side_effect=fake_download,
+        ):
+            content = [
+                {"type": "image", "storage_path": "p/c/first.png", "media_type": "image/png"},
+                {"type": "image", "storage_path": "p/c/second.jpg", "media_type": "image/jpeg"},
+                {"type": "text", "text": "compare"},
+            ]
+            out = service._rewrite_image_blocks_for_claude(content)
+        assert out[0]["source"]["data"] == base64.standard_b64encode(png).decode("ascii")
+        assert out[1]["source"]["data"] == base64.standard_b64encode(jpg).decode("ascii")
+        assert out[2] == {"type": "text", "text": "compare"}

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -2,13 +2,31 @@
  * ChatInput Component
  * Educational Note: Input area with microphone button for voice input,
  * text field for typing, and send button. Displays partial transcripts
- * in real-time while recording.
+ * in real-time while recording. Also accepts inline image attachments
+ * via paste, drag-and-drop, or the image button — Claude/Gemini-style.
  */
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { Textarea } from '../ui/textarea';
-import { PaperPlaneTilt, Microphone, CodeBlock, StopCircle } from '@phosphor-icons/react';
+import {
+  PaperPlaneTilt,
+  Microphone,
+  CodeBlock,
+  StopCircle,
+  Image as ImageIcon,
+  X,
+} from '@phosphor-icons/react';
 import { usePermissions } from '@/contexts/PermissionsContext';
+
+const ATTACHMENT_ALLOWED_MIMES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/gif',
+]);
+const ATTACHMENT_MAX_BYTES = 5 * 1024 * 1024; // 5MB — Claude vision cap
+const ATTACHMENT_MAX_COUNT = 10;
 
 interface ChatInputProps {
   message: string;
@@ -17,11 +35,16 @@ interface ChatInputProps {
   sending: boolean;
   transcriptionConfigured: boolean;
   rawMode: boolean;
+  attachments: File[];
   onMessageChange: (value: string) => void;
   onSend: () => void;
   onStop: () => void;
   onMicClick: () => void;
   onToggleRawMode: () => void;
+  onAttachmentsChange: (files: File[]) => void;
+  // Surface upload-validation errors to the parent's toast system rather
+  // than alert() — keeps the warm editorial UX the rest of the app uses.
+  onAttachmentError?: (message: string) => void;
 }
 
 export const ChatInput: React.FC<ChatInputProps> = ({
@@ -31,15 +54,25 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   sending,
   transcriptionConfigured,
   rawMode,
+  attachments,
   onMessageChange,
   onSend,
   onStop,
   onMicClick,
   onToggleRawMode,
+  onAttachmentsChange,
+  onAttachmentError,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const { hasPermission } = usePermissions();
-  const canUseVoice = hasPermission("chat_features", "voice_input");
+  const canUseVoice = hasPermission('chat_features', 'voice_input');
+
+  // Track drag-active state for the overlay. Counter, not boolean — when
+  // the user drags over a child element, dragenter/dragleave fire on
+  // each transition; a counter survives those without flickering.
+  const [dragDepth, setDragDepth] = useState(0);
+  const dragActive = dragDepth > 0;
 
   // Display value combines typed message and partial transcript
   const displayMessage = partialTranscript
@@ -47,125 +80,335 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     : message;
 
   // Auto-resize textarea based on content
-  // Educational Note: Wrapping in requestAnimationFrame batches both height changes
-  // (reset to 'auto' + set to scrollHeight) into a single paint cycle, preventing
-  // visible cursor flicker / layout reflow on every keystroke.
   useEffect(() => {
     const textarea = textareaRef.current;
     if (!textarea) return;
-
     const frameId = requestAnimationFrame(() => {
       textarea.style.height = 'auto';
       textarea.style.height = `${Math.min(textarea.scrollHeight, 100)}px`;
     });
-
     return () => cancelAnimationFrame(frameId);
   }, [displayMessage]);
 
-  // Handle key down - Enter sends, Shift+Enter adds new line
+  const acceptFiles = useCallback(
+    (incoming: File[]) => {
+      if (!incoming.length) return;
+      const accepted: File[] = [];
+      for (const file of incoming) {
+        const mime = (file.type || '').toLowerCase();
+        if (!ATTACHMENT_ALLOWED_MIMES.has(mime)) {
+          onAttachmentError?.(
+            `Unsupported format: ${file.name || 'file'}. Use PNG, JPEG, WebP, or GIF.`,
+          );
+          continue;
+        }
+        if (file.size > ATTACHMENT_MAX_BYTES) {
+          onAttachmentError?.(
+            `${file.name || 'Image'} is over the 5MB limit.`,
+          );
+          continue;
+        }
+        accepted.push(file);
+      }
+      if (!accepted.length) return;
+      const next = [...attachments, ...accepted];
+      if (next.length > ATTACHMENT_MAX_COUNT) {
+        onAttachmentError?.(
+          `Maximum ${ATTACHMENT_MAX_COUNT} attachments per message — extras dropped.`,
+        );
+      }
+      onAttachmentsChange(next.slice(0, ATTACHMENT_MAX_COUNT));
+    },
+    [attachments, onAttachmentsChange, onAttachmentError],
+  );
+
+  // Paste handler — clipboard images get pulled out as Files. We
+  // preventDefault on file items so the browser doesn't paste a binary
+  // blob string into the textarea.
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      if (!e.clipboardData) return;
+      const files: File[] = [];
+      for (const item of Array.from(e.clipboardData.items)) {
+        if (item.kind !== 'file') continue;
+        if (!item.type.startsWith('image/')) continue;
+        const f = item.getAsFile();
+        if (f) files.push(f);
+      }
+      if (!files.length) return;
+      e.preventDefault();
+      acceptFiles(files);
+    },
+    [acceptFiles],
+  );
+
+  // Drag-and-drop handlers on the wrapping pill container.
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    if (!Array.from(e.dataTransfer.types || []).includes('Files')) return;
+    e.preventDefault();
+    setDragDepth((d) => d + 1);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (!Array.from(e.dataTransfer.types || []).includes('Files')) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    if (!Array.from(e.dataTransfer.types || []).includes('Files')) return;
+    e.preventDefault();
+    setDragDepth((d) => Math.max(0, d - 1));
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragDepth(0);
+      const files = Array.from(e.dataTransfer.files || []);
+      acceptFiles(files);
+    },
+    [acceptFiles],
+  );
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey && !isRecording) {
-      e.preventDefault(); // Prevent new line
+      e.preventDefault();
       onSend();
     }
-    // Shift+Enter will naturally add a new line (default textarea behavior)
   };
+
+  const removeAttachment = (idx: number) => {
+    onAttachmentsChange(attachments.filter((_, i) => i !== idx));
+  };
+
+  // Send-enabled logic: text OR attachments OR both — no longer text-only.
+  const sendDisabled = (!message.trim() && attachments.length === 0) || isRecording;
 
   return (
     <div className="p-4 pt-2">
-      {/* Floating pill container - mic, textarea, send all inside */}
-      <div className="flex items-center gap-2 border rounded-2xl px-3 py-2 bg-background">
-        {/* Microphone Button — hidden when voice_input permission is disabled */}
-        {canUseVoice && (
+      <div
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        className={`relative rounded-2xl border bg-background transition-colors ${
+          dragActive
+            ? 'border-amber-500 ring-2 ring-amber-200 ring-offset-1'
+            : 'border-border'
+        }`}
+      >
+        {/* Drag-active overlay — soft amber, non-blocking pointer events. */}
+        {dragActive && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-amber-50/85 pointer-events-none">
+            <span className="text-sm font-medium text-amber-700">
+              Drop image to attach
+            </span>
+          </div>
+        )}
+
+        {attachments.length > 0 && (
+          <AttachmentStrip
+            attachments={attachments}
+            onRemove={removeAttachment}
+          />
+        )}
+
+        {/* Floating pill — mic, textarea, image, raw, send. */}
+        <div className="flex items-center gap-2 px-3 py-2">
+          {/* Microphone Button */}
+          {canUseVoice && (
+            <button
+              type="button"
+              onClick={onMicClick}
+              disabled={sending || !transcriptionConfigured}
+              title={
+                !transcriptionConfigured
+                  ? 'Set up ElevenLabs API key in settings'
+                  : sending
+                  ? 'Wait for response to complete'
+                  : isRecording
+                  ? 'Click to stop recording'
+                  : 'Click to start recording'
+              }
+              className={`flex-shrink-0 p-1.5 rounded-full transition-colors ${
+                isRecording
+                  ? 'bg-red-500 text-white animate-pulse'
+                  : 'text-muted-foreground hover:text-foreground'
+              } ${
+                sending || !transcriptionConfigured
+                  ? 'opacity-50 cursor-not-allowed'
+                  : 'cursor-pointer'
+              }`}
+            >
+              <Microphone size={18} />
+            </button>
+          )}
+
+          {/* Image attach button — opens a hidden file input. Mirrors the
+              mic-button visual pattern so the input chrome stays balanced. */}
           <button
             type="button"
-            onClick={onMicClick}
-            disabled={sending || !transcriptionConfigured}
+            onClick={() => fileInputRef.current?.click()}
+            disabled={sending || isRecording || attachments.length >= ATTACHMENT_MAX_COUNT}
             title={
-              !transcriptionConfigured
-                ? 'Set up ElevenLabs API key in settings'
-                : sending
-                ? 'Wait for response to complete'
-                : isRecording
-                ? 'Click to stop recording'
-                : 'Click to start recording'
+              attachments.length >= ATTACHMENT_MAX_COUNT
+                ? `Max ${ATTACHMENT_MAX_COUNT} attachments`
+                : 'Attach image (or paste / drag from desktop)'
             }
-            className={`flex-shrink-0 p-1.5 rounded-full transition-colors ${
+            className={`flex-shrink-0 p-1.5 rounded-full transition-colors text-muted-foreground hover:text-foreground ${
+              sending || isRecording || attachments.length >= ATTACHMENT_MAX_COUNT
+                ? 'opacity-50 cursor-not-allowed'
+                : 'cursor-pointer'
+            }`}
+          >
+            <ImageIcon size={18} />
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/jpg,image/webp,image/gif"
+            multiple
+            className="hidden"
+            onChange={(e) => {
+              const picked = Array.from(e.target.files || []);
+              acceptFiles(picked);
+              // Reset so picking the same file twice in a row still fires onChange.
+              e.target.value = '';
+            }}
+          />
+
+          {/* Textarea */}
+          <Textarea
+            ref={textareaRef}
+            autoFocus
+            placeholder={
               isRecording
-                ? 'bg-red-500 text-white animate-pulse'
+                ? 'Listening...'
+                : !transcriptionConfigured
+                ? 'Type your message... (voice disabled - set API key)'
+                : 'Ask about your sources... (Shift+Enter for new line)'
+            }
+            value={displayMessage}
+            onChange={(e) => onMessageChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            className={`flex-1 py-1.5 min-h-[32px] max-h-[100px] resize-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent ${
+              partialTranscript ? 'text-muted-foreground' : ''
+            }`}
+            disabled={sending || isRecording}
+            rows={1}
+          />
+
+          {/* Raw Mode Toggle */}
+          <button
+            type="button"
+            onClick={onToggleRawMode}
+            title={rawMode ? 'Switch to normal view' : 'Switch to raw message view'}
+            className={`flex-shrink-0 p-1.5 rounded-full transition-colors ${
+              rawMode
+                ? 'bg-amber-600 text-white'
                 : 'text-muted-foreground hover:text-foreground'
-            } ${sending || !transcriptionConfigured ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+            }`}
           >
-            <Microphone size={18} />
+            <CodeBlock size={18} weight={rawMode ? 'bold' : 'regular'} />
           </button>
-        )}
 
-        {/* Textarea - no border, blends with container */}
-        <Textarea
-          ref={textareaRef}
-          autoFocus
-          placeholder={
-            isRecording
-              ? 'Listening...'
-              : !transcriptionConfigured
-              ? 'Type your message... (voice disabled - set API key)'
-              : 'Ask about your sources... (Shift+Enter for new line)'
-          }
-          value={displayMessage}
-          onChange={(e) => onMessageChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          className={`flex-1 py-1.5 min-h-[32px] max-h-[100px] resize-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent ${
-            partialTranscript ? 'text-muted-foreground' : ''
-          }`}
-          disabled={sending || isRecording}
-          rows={1}
-        />
-
-        {/* Raw Mode Toggle */}
-        <button
-          type="button"
-          onClick={onToggleRawMode}
-          title={rawMode ? 'Switch to normal view' : 'Switch to raw message view'}
-          className={`flex-shrink-0 p-1.5 rounded-full transition-colors ${
-            rawMode
-              ? 'bg-amber-600 text-white'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          <CodeBlock size={18} weight={rawMode ? 'bold' : 'regular'} />
-        </button>
-
-        {/* Send / Stop Button */}
-        {sending ? (
-          <button
-            type="button"
-            onClick={onStop}
-            title="Stop responding"
-            className="flex-shrink-0 p-1.5 rounded-full text-red-500 hover:text-red-600 hover:bg-red-50 transition-colors"
-          >
-            <StopCircle size={18} weight="fill" />
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={onSend}
-            disabled={!message.trim() || isRecording}
-            className="flex-shrink-0 p-1.5 rounded-full text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <PaperPlaneTilt size={18} />
-          </button>
-        )}
+          {/* Send / Stop */}
+          {sending ? (
+            <button
+              type="button"
+              onClick={onStop}
+              title="Stop responding"
+              className="flex-shrink-0 p-1.5 rounded-full text-red-500 hover:text-red-600 hover:bg-red-50 transition-colors"
+            >
+              <StopCircle size={18} weight="fill" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onSend}
+              disabled={sendDisabled}
+              className="flex-shrink-0 p-1.5 rounded-full text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <PaperPlaneTilt size={18} />
+            </button>
+          )}
+        </div>
       </div>
 
       <p className="text-xs text-muted-foreground mt-2 text-center">
         {!canUseVoice
-          ? 'Type your message'
+          ? 'Type, paste, or drop an image'
           : isRecording
           ? 'Listening... Click mic to stop'
           : !transcriptionConfigured
           ? 'Voice input requires ElevenLabs API key (Admin Settings)'
-          : 'Click mic to speak, or type your message'}
+          : 'Click mic to speak, type, paste, or drop an image'}
       </p>
     </div>
   );
 };
+
+// ──────────────────────────────────────────────────────────────────────
+// AttachmentStrip — thumbnails for pasted/dropped images, with X-to-remove
+// ──────────────────────────────────────────────────────────────────────
+
+interface AttachmentStripProps {
+  attachments: File[];
+  onRemove: (index: number) => void;
+}
+
+const AttachmentStrip: React.FC<AttachmentStripProps> = ({
+  attachments,
+  onRemove,
+}) => {
+  // Derive blob URLs synchronously via useMemo (no setState-in-effect
+  // antipattern), and use a separate effect ONLY for the revoke-on-
+  // change cleanup so the browser frees the underlying buffer once the
+  // user sends, removes, or unmounts.
+  const previews = useMemo(
+    () => attachments.map((f) => URL.createObjectURL(f)),
+    [attachments],
+  );
+  useEffect(() => {
+    return () => {
+      previews.forEach((u) => URL.revokeObjectURL(u));
+    };
+  }, [previews]);
+
+  if (!attachments.length) return null;
+
+  return (
+    <div className="flex items-center gap-2 px-3 pt-2 overflow-x-auto">
+      {attachments.map((file, idx) => (
+        <div
+          key={`${file.name}-${idx}`}
+          className="relative flex-shrink-0 group"
+          title={`${file.name} · ${formatBytes(file.size)}`}
+        >
+          <img
+            src={previews[idx]}
+            alt={file.name}
+            className="h-16 w-16 rounded-md object-cover border border-border"
+          />
+          <button
+            type="button"
+            onClick={() => onRemove(idx)}
+            className="absolute -top-1.5 -right-1.5 h-5 w-5 rounded-full bg-stone-800/85 text-white flex items-center justify-center opacity-90 hover:opacity-100 transition-opacity"
+            title="Remove"
+            aria-label={`Remove ${file.name}`}
+          >
+            <X size={12} weight="bold" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -12,6 +12,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Ghost, FileText, Copy, Check, DownloadSimple, ArrowDown } from '@phosphor-icons/react';
 import type { Message } from '../../lib/api/chats';
+import { messageContentAsText } from '../../lib/api/chats';
 import { parseCitations } from '../../lib/citations';
 import { CitationBadge } from './CitationBadge';
 import { Separator } from '../ui/separator';
@@ -175,17 +176,62 @@ const markdownComponents: Record<string, React.FC<any>> = {
 
 /**
  * User Message Component
- * Educational Note: Right-aligned bubble style for user messages
+ * Educational Note: Right-aligned bubble style for user messages.
+ * Content is either a plain string (legacy / no-attachment) or a list of
+ * typed blocks `[{type:"image", url, ...}, {type:"text", text}]` when the
+ * user pasted/dropped images. Image blocks render as thumbnails above
+ * the text inside the same bubble.
  */
-const UserMessage: React.FC<{ content: string }> = ({ content }) => (
-  <div className="flex justify-end w-full">
-    <div className="max-w-[80%] min-w-0">
-      <div className="bg-primary text-primary-foreground rounded-2xl rounded-tr-sm px-4 py-2 min-w-0">
-        <p className="text-sm whitespace-pre-wrap break-words">{content}</p>
+type UserMessageBlock =
+  | { type: 'image'; url: string; media_type?: string; filename?: string }
+  | { type: 'text'; text: string };
+
+const UserMessage: React.FC<{ content: string | UserMessageBlock[] }> = ({ content }) => {
+  const isBlocks = Array.isArray(content);
+  const imageBlocks = isBlocks
+    ? (content as UserMessageBlock[]).filter((b): b is Extract<UserMessageBlock, { type: 'image' }> => b.type === 'image')
+    : [];
+  const textValue = isBlocks
+    ? (content as UserMessageBlock[])
+        .filter((b): b is Extract<UserMessageBlock, { type: 'text' }> => b.type === 'text')
+        .map((b) => b.text)
+        .join('\n')
+    : (content as string);
+
+  return (
+    <div className="flex justify-end w-full">
+      <div className="max-w-[80%] min-w-0">
+        <div className="bg-primary text-primary-foreground rounded-2xl rounded-tr-sm px-4 py-2 min-w-0 space-y-2">
+          {imageBlocks.length > 0 && (
+            <div className="flex flex-wrap gap-2 -mx-1">
+              {imageBlocks.map((block, idx) => (
+                <a
+                  key={`${block.url}-${idx}`}
+                  href={block.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  // Open in a new tab so the user can see the full image.
+                  // Bubble cap of ~240px keeps the chat compact.
+                  className="block"
+                  title={block.filename || 'attachment'}
+                >
+                  <img
+                    src={block.url}
+                    alt={block.filename || 'attachment'}
+                    className="max-h-60 max-w-full rounded-lg object-cover border border-primary-foreground/20"
+                  />
+                </a>
+              ))}
+            </div>
+          )}
+          {textValue && (
+            <p className="text-sm whitespace-pre-wrap break-words">{textValue}</p>
+          )}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 /**
  * AI Message Component
@@ -627,8 +673,10 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
             {msg.role === 'user' ? (
               <UserMessage content={msg.content} />
             ) : (
+              // AI messages don't carry image blocks today; coerce to
+              // string so the markdown renderer's prop type stays simple.
               <AIMessage
-                content={msg.content}
+                content={messageContentAsText(msg.content)}
                 projectId={projectId}
                 studioAssetRewriter={studioAssetRewriter}
               />

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -60,6 +60,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
 
   // Chat state
   const [message, setMessage] = useState('');
+  // Inline image attachments (paste, drag-and-drop, or image-button picker).
+  // Cleared on send so the next message starts clean. Lives at panel level
+  // — not ChatInput — so optimistic-render / chat-switch logic can read it.
+  const [attachments, setAttachments] = useState<File[]>([]);
   const [activeChat, setActiveChat] = useState<Chat | null>(null);
   const [showChatList, setShowChatList] = useState(false);
   const [allChats, setAllChats] = useState<ChatMetadata[]>([]);
@@ -470,9 +474,14 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
    * before the API call, so users see their message immediately.
    */
   const handleSend = async () => {
-    if (!message.trim() || !activeChat || sending) return;
+    if (!activeChat || sending) return;
+    // Send-enabled if EITHER the text is non-empty OR there's at least one
+    // attachment. Pure-attachment messages ("here's a screenshot, no
+    // caption") are valid — Claude still answers from the image alone.
+    if (!message.trim() && attachments.length === 0) return;
 
     const userMessage = message.trim();
+    const messageAttachments = attachments;
     const currentChat = activeChat;
     const sendingChatId = currentChat.id;
     const controller = new AbortController();
@@ -480,15 +489,31 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     canonicalUserMessageReceivedRef.current = false;
     assistantDeltaReceivedRef.current = false;
     setMessage('');
+    setAttachments([]);
     setRawMode(false);
     setStreamingAssistantContent('');
     onAddSendingChat(sendingChatId, activeChat.title);
 
-    // Optimistically add user message to UI immediately
+    // Optimistic user-message render. With attachments, the content is a
+    // typed-block list using local blob URLs so the screenshot appears in
+    // the bubble before the network roundtrip — replaceTempWithCanonical
+    // swaps in server-signed URLs once the backend persists.
+    const optimisticContent = messageAttachments.length
+      ? [
+          ...messageAttachments.map((file) => ({
+            type: 'image' as const,
+            url: URL.createObjectURL(file),
+            media_type: file.type,
+            filename: file.name,
+          })),
+          { type: 'text' as const, text: userMessage },
+        ]
+      : userMessage;
+
     const tempUserMessage = {
       id: `temp-${Date.now()}`,
       role: 'user' as const,
-      content: userMessage,
+      content: optimisticContent,
       timestamp: new Date().toISOString(),
     };
 
@@ -602,7 +627,8 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             receivedTerminalSync = applyChatSync(payload.sync);
           },
         },
-        controller.signal
+        controller.signal,
+        messageAttachments,
       );
 
       if (streamResult.terminalEvent) {
@@ -640,8 +666,15 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         log.info('Chat request stopped by user');
       } else {
         const shouldFallback = !canonicalUserMessageReceivedRef.current && !assistantDeltaReceivedRef.current;
+        // The REST fallback (chatsAPI.sendMessage) is text-only — it
+        // can't carry image attachments. If the user attached anything,
+        // skip the silent fallback and surface the error so they can
+        // re-paste/re-drop and retry. Falling back would silently drop
+        // the screenshot, producing a confusing answer to the visual
+        // question they asked.
+        const hasAttachments = messageAttachments.length > 0;
 
-        if (shouldFallback) {
+        if (shouldFallback && !hasAttachments) {
           try {
             const fallbackResult = await chatsAPI.sendMessage(projectId, currentChat.id, userMessage);
             applyFallbackResponse(fallbackResult);
@@ -653,6 +686,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             log.error({ err: fallbackError }, 'failed to send message via fallback');
             errorWithLogs('Failed to send message');
           }
+        } else if (shouldFallback && hasAttachments) {
+          log.warn('stream failed before user_message event with attachments — surfacing error so user can retry');
+          errorWithLogs('Failed to send message — please retry.');
         } else {
           // Stream errored mid-flight after delivering partial events
           // (canonical user_message and/or assistant_delta). Re-sending
@@ -904,11 +940,14 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         sending={sending}
         transcriptionConfigured={transcriptionConfigured}
         rawMode={rawMode}
+        attachments={attachments}
         onMessageChange={setMessage}
         onSend={handleSend}
         onStop={handleStop}
         onMicClick={handleMicClick}
         onToggleRawMode={() => setRawMode((prev) => !prev)}
+        onAttachmentsChange={setAttachments}
+        onAttachmentError={error}
       />
 
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -498,17 +498,34 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     // typed-block list using local blob URLs so the screenshot appears in
     // the bubble before the network roundtrip — replaceTempWithCanonical
     // swaps in server-signed URLs once the backend persists.
+    //
+    // Memory management: each blob URL pins the underlying File data in
+    // browser memory until URL.revokeObjectURL() runs. We track the URLs
+    // created here and revoke them in three places: (a) when the canonical
+    // user message arrives with server-signed URLs (the local blobs are no
+    // longer rendered), (b) when the temp message is removed on send
+    // failure, (c) in the finally block as a defence-in-depth catch-all.
+    const optimisticBlobUrls: string[] = [];
     const optimisticContent = messageAttachments.length
       ? [
-          ...messageAttachments.map((file) => ({
-            type: 'image' as const,
-            url: URL.createObjectURL(file),
-            media_type: file.type,
-            filename: file.name,
-          })),
+          ...messageAttachments.map((file) => {
+            const blobUrl = URL.createObjectURL(file);
+            optimisticBlobUrls.push(blobUrl);
+            return {
+              type: 'image' as const,
+              url: blobUrl,
+              media_type: file.type,
+              filename: file.name,
+            };
+          }),
           { type: 'text' as const, text: userMessage },
         ]
       : userMessage;
+    const revokeOptimisticBlobs = () => {
+      for (const url of optimisticBlobUrls.splice(0)) {
+        URL.revokeObjectURL(url);
+      }
+    };
 
     const tempUserMessage = {
       id: `temp-${Date.now()}`,
@@ -543,6 +560,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           messages: alreadyPresent ? nextMessages : [...nextMessages.filter((msg) => msg.id !== tempUserMessage.id), canonicalUserMessage],
         };
       });
+      // The canonical message renders from server-signed URLs now, so the
+      // local blob URLs are no longer referenced by the DOM. Revoke to free
+      // the underlying File buffers.
+      revokeOptimisticBlobs();
     };
 
     const appendAssistantMessage = (assistantMessage: Chat['messages'][number]) => {
@@ -715,6 +736,11 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     } finally {
       onRemoveSendingChat(sendingChatId);
       abortControllerRef.current = null;
+      // Defence-in-depth: if neither the success path nor any catch
+      // branch ran (shouldn't happen in normal control flow, but JS
+      // exception edges exist), still free the optimistic blob URLs.
+      // No-op if already revoked above.
+      revokeOptimisticBlobs();
     }
   };
 

--- a/frontend/src/lib/api/chats.ts
+++ b/frontend/src/lib/api/chats.ts
@@ -16,13 +16,50 @@ import type { UserUsage } from './settings';
 const log = createLogger('chats-api');
 
 /**
+ * Image block on a user message — rendered inline above the text in the
+ * chat bubble. The backend supplies `url` as a freshly-signed URL on
+ * every read, so the field is short-lived; do not persist it.
+ */
+export interface MessageImageBlock {
+  type: 'image';
+  url: string;
+  media_type?: string;
+  filename?: string;
+}
+
+export interface MessageTextBlock {
+  type: 'text';
+  text: string;
+}
+
+export type MessageContentBlock = MessageImageBlock | MessageTextBlock;
+
+/**
+ * Render a Message['content'] as a plain string. For block-content
+ * messages with image attachments, returns the concatenated text
+ * portion (image blocks are dropped). Use this for any callsite that
+ * needs string operations (.replace, exporters, search index, etc.) —
+ * the rich block representation lives only in the chat-bubble renderer.
+ */
+export function messageContentAsText(content: string | MessageContentBlock[]): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter((b): b is MessageTextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n');
+}
+
+/**
  * Educational Note: A message in the conversation.
- * Each message has a role (user or assistant) and content.
+ * Each message has a role (user or assistant) and content. Content is a
+ * plain string for text-only messages (the common case) and a list of
+ * typed blocks when the user attached an inline image — image blocks
+ * always come before text in the rendered order.
  */
 export interface Message {
   id: string;
   role: 'user' | 'assistant';
-  content: string;
+  content: string | MessageContentBlock[];
   timestamp: string;
   model?: string;
   tokens?: {
@@ -317,18 +354,39 @@ class ChatsAPI {
     chatId: string,
     message: string,
     callbacks?: StreamMessageCallbacks,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    attachments?: File[]
   ): Promise<StreamMessageResult> {
     const token = getAccessToken();
+    // Two transport shapes:
+    //  - JSON (legacy, no attachments) — small body, no boundary parsing.
+    //  - multipart/form-data (with attachments) — backend route detects
+    //    Content-Type and dispatches; image files are uploaded inside
+    //    the same request as the message text. Don't set Content-Type
+    //    manually for FormData — the browser writes the multipart
+    //    boundary automatically and a manual header would corrupt it.
+    const hasAttachments = !!(attachments && attachments.length);
+    const headers: Record<string, string> = {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+    let body: BodyInit;
+    if (hasAttachments) {
+      const form = new FormData();
+      form.append('message', message);
+      attachments!.forEach((file, idx) => {
+        form.append('attachments', file, file.name || `attachment-${idx}`);
+      });
+      body = form;
+    } else {
+      headers['Content-Type'] = 'application/json';
+      body = JSON.stringify({ message });
+    }
     const response = await fetch(
       `${API_BASE_URL}/projects/${projectId}/chats/${chatId}/messages/stream`,
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify({ message }),
+        headers,
+        body,
         signal,
       }
     );

--- a/frontend/src/lib/exportChatMarkdown.ts
+++ b/frontend/src/lib/exportChatMarkdown.ts
@@ -7,6 +7,7 @@
 import { parseCitations } from './citations';
 import { sourcesAPI, type ChunkContent } from './api/sources';
 import type { Chat } from './api/chats';
+import { messageContentAsText } from './api/chats';
 
 /**
  * Convert a title into a filename-safe slug
@@ -79,7 +80,7 @@ export async function exportChatAsMarkdown({
 
   for (const msg of messages) {
     if (msg.role !== 'assistant') continue;
-    const parsed = parseCitations(msg.content);
+    const parsed = parseCitations(messageContentAsText(msg.content));
     for (const entry of parsed.uniqueCitations) {
       if (!globalChunkToFootnote.has(entry.chunkId)) {
         globalChunkToFootnote.set(entry.chunkId, footnoteCounter++);
@@ -122,13 +123,17 @@ export async function exportChatAsMarkdown({
     lines.push(`*${formatDate(msg.timestamp)}*`);
     lines.push('');
 
-    let content = msg.content;
+    // Coerce block-content (user messages with attached images) to a
+    // text-only string for the markdown export — exporters strip image
+    // blocks today; surfacing inline-image attachments in exported MD
+    // is a separate enhancement.
+    let content = messageContentAsText(msg.content);
 
     // Replace citation markers with footnote references in assistant messages
     if (msg.role === 'assistant' && globalChunkToFootnote.size > 0) {
       content = content.replace(
         /\[\[cite:([a-zA-Z0-9_-]+_page_\d+_chunk_\d+)\]\]/g,
-        (_match, chunkId: string) => {
+        (_match: string, chunkId: string) => {
           const footnoteNum = globalChunkToFootnote.get(chunkId);
           return footnoteNum ? `[^${footnoteNum}]` : '';
         }

--- a/frontend/src/lib/exportChatPdf.ts
+++ b/frontend/src/lib/exportChatPdf.ts
@@ -17,6 +17,7 @@ import { Marked } from 'marked';
 import { parseCitations } from './citations';
 import { sourcesAPI, type ChunkContent } from './api/sources';
 import type { Chat } from './api/chats';
+import { messageContentAsText } from './api/chats';
 
 // Isolated marked instance — raw HTML rendering disabled to prevent XSS.
 const pdfMarked = new Marked({
@@ -195,7 +196,10 @@ export function buildChatHtml(
   for (const msg of messages) {
     const isUser = msg.role === 'user';
     const roleName = isUser ? 'You' : 'NoobBook';
-    let renderedContent = pdfMarked.parse(msg.content) as string;
+    // Coerce block-content (user messages with attached images) to a
+    // text-only string for the PDF export — image-block attachments
+    // aren't included in the PDF render today.
+    let renderedContent = pdfMarked.parse(messageContentAsText(msg.content)) as string;
 
     if (!isUser && globalChunkToFootnote.size > 0) {
       renderedContent = renderedContent.replace(
@@ -271,7 +275,7 @@ export async function exportChatAsPdf({
   let footnoteCounter = 1;
   for (const msg of messages) {
     if (msg.role !== 'assistant') continue;
-    const parsed = parseCitations(msg.content);
+    const parsed = parseCitations(messageContentAsText(msg.content));
     for (const entry of parsed.uniqueCitations) {
       if (!globalChunkToFootnote.has(entry.chunkId)) {
         globalChunkToFootnote.set(entry.chunkId, footnoteCounter++);


### PR DESCRIPTION
## Summary
A customer (and the user themselves) reported the friction of having to upload screenshots as **Sources**, wait for processing, then ask about them. Other chat tools (Claude.ai, Gemini, ChatGPT) let users paste/drop an image directly into the chat input and get a one-shot vision answer. This PR brings NoobBook to parity.

## What's new (UX)

- **Paste**: cmd-V a screenshot from clipboard into the textarea → 64×64 thumbnail appears in a new AttachmentStrip above the input.
- **Drag-and-drop**: drag a PNG/JPEG/WebP/GIF onto the input → soft amber overlay ("Drop image to attach") → drop → same result.
- **Image button**: clicks a hidden `<input type="file" accept="image/*" multiple>` so mobile (camera-roll) and click-to-pick still work.
- **Send button is enabled by either text OR attachments** — pure-attachment messages are valid.
- **Optimistic preview** in the user bubble before the network roundtrip — local blob URL renders the screenshot inline; replaced with the server-signed URL after persist.
- **Multi-image** per message (capped at 10).
- **Validation** client- and server-side: 5MB / image, allowed MIMEs only, count cap, server returns clear errors that surface as toasts.

## Architecture

Single-round-trip multipart request to the existing `/messages/stream` endpoint — Content-Type-dispatched (JSON path unchanged for text-only messages, full backwards compat).

| Layer | Change |
|---|---|
| `ChatInput.tsx` | onPaste / drag handlers / AttachmentStrip / image button |
| `ChatPanel.tsx` | Attachments state + optimistic block-content render |
| `ChatMessages.tsx` | Block-aware user-bubble — image thumbnails above text |
| `chats.ts` | `streamMessage` accepts `attachments?: File[]`, switches to FormData |
| `messages/routes.py` | New `_parse_message_request` — multipart / JSON dispatch, validate + upload + build content blocks |
| `main_chat_service.py` | Accepts str OR List[Dict] payload; `_extract_user_text` helper |
| `message_service.py` | `_format_message_for_frontend` emits typed-block list when images present; new `_rewrite_image_blocks_for_claude` maps persisted image blocks → Anthropic vision shape |
| `chat_service.py` | Cascade-delete chat-attachments storage on chat delete |
| `storage_service.py` | New helpers: `upload_chat_attachment`, `download_chat_attachment`, `get_chat_attachment_url`, `delete_chat_attachments_for_chat` |
| `00027_chat_attachments_bucket.sql` | New bucket + RLS policies (mirrors raw-files / brand-assets) |

`messages.content` was already JSONB and already stored content blocks (text + tool_use + tool_result). Adding `{type:"image", storage_path:...}` blocks is transparent — no schema migration on the messages table.

## Failure modes handled

- Unreadable storage attachment (file disappeared, RLS blocked) → image block silently dropped from the Claude payload, rest of message still goes through.
- Stream POST fails BEFORE the user_message SSE event AND attachments were sent → silent REST fallback (text-only) is skipped, error toast surfaces so the user can retry without losing the screenshot.
- Browser without paste support (iOS Safari) → image button covers it (and adds camera-roll capture).

## Test plan
- [x] `python -m py_compile` clean on every touched backend file
- [x] 7 standalone behaviour cases pass (`_format_message_for_frontend` text-only, image-block, tool-only; `_rewrite_image_blocks_for_claude` string passthrough, text-only list passthrough, image translation, drop-on-unreadable)
- [x] `tsc -b` clean on all 6 touched frontend files
- [x] `eslint` clean on all 6 touched frontend files
- [ ] Backend `pytest backend/tests/test_chat_attachments.py` in CI
- [ ] Manual smoke: paste a screenshot → ask "what's in this?" → verify Claude returns a vision-aware answer
- [ ] Manual smoke: drag a 12MB PNG → verify rejection toast
- [ ] Manual smoke: drag an SVG → verify rejection toast
- [ ] Manual smoke: refresh page → verify the screenshot still renders in the user bubble (signed-URL re-fetched)
- [ ] Manual smoke: delete the chat → verify chat-attachments bucket prefix cleared
- [ ] Manual smoke: send pure-text message → verify JSON path runs, no FormData

## Out of scope (defer)

- Server-side image downscaling (Pillow) — defer to v2; 5MB cap is sufficient for screenshots
- Non-image attachments (PDFs, docs, audio) — those still go via the proper Sources flow
- Pasting URLs as image links — chat already handles URLs as text; rendering `<img>` from a URL is a separate behaviour change
- Replacing the existing image-source flow — that stays for searchable RAG sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)
