### PR TITLE
studio: Stop button on in-flight studio tasks in ActiveTasksBar

### DIFF
--- a/backend/app/api/studio/__init__.py
+++ b/backend/app/api/studio/__init__.py
@@ -80,6 +80,7 @@ from app.api.studio import marketing_strategies  # noqa: F401
 from app.api.studio import blogs  # noqa: F401
 from app.api.studio import business_reports  # noqa: F401
 from app.api.studio import job_groups  # noqa: F401
+from app.api.studio import job_actions  # noqa: F401
 
 # Educational Note: The noqa comments tell flake8 to ignore the
 # "imported but unused" warning. We import to register routes,

--- a/backend/app/api/studio/job_actions.py
+++ b/backend/app/api/studio/job_actions.py
@@ -1,0 +1,70 @@
+"""
+Studio Job Actions — generic actions on a studio_jobs row, regardless of
+job_type. Currently exposes a `cancel` action used by the ActiveTasksBar
+Stop button.
+
+Cancellation semantics in v1:
+- The job's status is flipped to "cancelled" immediately.
+- The active-tasks endpoint filters by status in {pending, processing},
+  so the job disappears from the user's status bar straight away.
+- The background worker doesn't have cooperative-cancel hooks today, so
+  it may continue running until completion. When it eventually calls
+  update_job(status="ready"), the cancelled marker can get overwritten —
+  acceptable for v1 because the user-facing affordance (it stops showing
+  in the bar) already feels like "cancelled". Future v2: plumb a
+  cancel_event into the worker the same way main_chat_service does.
+
+Idempotent: re-requesting cancel on an already-terminal job returns 200
+with the current state — saves the frontend from racing the user's
+double-click.
+"""
+from datetime import datetime
+
+from flask import current_app, jsonify
+
+from app.api.studio import studio_bp
+from app.services.studio_services import studio_index_service
+
+
+_TERMINAL_STATUSES = {"ready", "error", "cancelled"}
+
+
+@studio_bp.route(
+    "/projects/<project_id>/studio/jobs/<job_id>/cancel",
+    methods=["POST"],
+)
+def cancel_studio_job(project_id: str, job_id: str):
+    """Cancel an in-flight studio job."""
+    try:
+        job = studio_index_service.get_job(project_id, job_id)
+        if not job:
+            return jsonify({
+                "success": False,
+                "error": f"Job not found: {job_id}",
+            }), 404
+
+        current_status = job.get("status")
+        if current_status in _TERMINAL_STATUSES:
+            # Already done one way or another — return current state so the
+            # caller can update its UI without a 4xx.
+            return jsonify({"success": True, "job": job, "already_terminal": True}), 200
+
+        updated = studio_index_service.update_job(
+            project_id,
+            job_id,
+            status="cancelled",
+            error="Cancelled by user",
+            completed_at=datetime.now().isoformat(),
+        )
+        if not updated:
+            return jsonify({
+                "success": False,
+                "error": "Failed to mark job as cancelled.",
+            }), 500
+
+        return jsonify({"success": True, "job": updated}), 200
+    except Exception as e:
+        current_app.logger.error(
+            f"Error cancelling studio job {job_id} (project {project_id}): {e}"
+        )
+        return jsonify({"success": False, "error": str(e)}), 500

--- a/frontend/src/components/project/ActiveTasksBar.tsx
+++ b/frontend/src/components/project/ActiveTasksBar.tsx
@@ -21,6 +21,7 @@ import {
 } from '@phosphor-icons/react';
 import { API_BASE_URL } from '@/lib/api/client';
 import { sourcesAPI } from '@/lib/api/sources';
+import { cancelStudioJob } from '@/lib/api/studio';
 import axios from 'axios';
 
 interface ActiveTask {
@@ -58,8 +59,14 @@ const TASK_ICONS: Record<string, TaskIconComponent> = {
 };
 
 
+// Task types that expose a Stop affordance — kept narrow so we don't
+// invite cancellation on background tasks (e.g. chat-naming) where it
+// has no meaning.
+const CANCELLABLE_TYPES: ReadonlySet<ActiveTask['type']> = new Set(['source', 'studio']);
+
 const TaskRow: React.FC<{ task: ActiveTask; onCancel?: (taskId: string) => void }> = ({ task, onCancel }) => {
   const Icon = TASK_ICONS[task.type] || Gear;
+  const isCancellable = !!onCancel && CANCELLABLE_TYPES.has(task.type);
 
   return (
     <div className="group/task flex items-center gap-2.5 px-3 py-2 rounded-lg bg-stone-50 border border-stone-100">
@@ -70,11 +77,12 @@ const TaskRow: React.FC<{ task: ActiveTask; onCancel?: (taskId: string) => void 
         <p className="text-xs font-medium text-stone-800 truncate">{task.label}</p>
         <p className="text-[11px] text-stone-500 truncate">{task.detail}</p>
       </div>
-      {onCancel && task.type === 'source' ? (
+      {isCancellable ? (
         <button
-          onClick={() => onCancel(task.id)}
+          onClick={() => onCancel?.(task.id)}
           className="flex-shrink-0 text-stone-300 group-hover/task:text-red-500 transition-colors"
-          title="Stop processing"
+          title={task.type === 'source' ? 'Stop processing' : 'Cancel generation'}
+          aria-label={task.type === 'source' ? 'Stop processing' : 'Cancel generation'}
         >
           <StopCircle size={16} weight="fill" className="hidden group-hover/task:block" />
           <CircleNotch size={14} className="animate-spin text-amber-600 block group-hover/task:hidden" />
@@ -260,17 +268,39 @@ export const ActiveTasksBar: React.FC<ActiveTasksBarProps> = ({
         >
           <div className="px-2.5 pb-2.5 space-y-1.5 max-h-[350px] overflow-y-auto">
             {/* Active tasks */}
-            {allTasks.map((task) => (
-              <TaskRow
-                key={task.id}
-                task={task}
-                onCancel={task.type === 'source' ? async (sourceId) => {
+            {allTasks.map((task) => {
+              // Type-specific cancel dispatch. Both paths optimistically
+              // remove the task from local state so the spinner stops
+              // immediately — the next poll (≤3s) will confirm via the
+              // backend that the task left the active list.
+              const optimisticDrop = (id: string) =>
+                setTasks((prev) => prev.filter((t) => t.id !== id));
+
+              let handleCancel: ((taskId: string) => void) | undefined;
+              if (task.type === 'source') {
+                handleCancel = async (sourceId) => {
+                  optimisticDrop(sourceId);
                   try {
                     await sourcesAPI.cancelProcessing(projectId, sourceId);
-                  } catch { /* ignore */ }
-                } : undefined}
-              />
-            ))}
+                  } catch { /* ignore — next poll will reconcile */ }
+                };
+              } else if (task.type === 'studio') {
+                handleCancel = async (jobId) => {
+                  optimisticDrop(jobId);
+                  try {
+                    await cancelStudioJob(projectId, jobId);
+                  } catch { /* ignore — next poll will reconcile */ }
+                };
+              }
+
+              return (
+                <TaskRow
+                  key={task.id}
+                  task={task}
+                  onCancel={handleCancel}
+                />
+              );
+            })}
             {/* Completed chats with "Open" button */}
             {visibleCompletedChats.map((chat) => (
               <CompletedRow

--- a/frontend/src/lib/api/studio/index.ts
+++ b/frontend/src/lib/api/studio/index.ts
@@ -13,7 +13,29 @@ import { createLogger } from '@/lib/logger';
 const log = createLogger('studio-api');
 
 // Shared types
-export type JobStatus = 'pending' | 'processing' | 'ready' | 'error';
+export type JobStatus = 'pending' | 'processing' | 'ready' | 'error' | 'cancelled';
+
+/**
+ * Cancel an in-flight studio job. The backend flips the job's status to
+ * "cancelled" and the active-tasks endpoint immediately stops listing it.
+ *
+ * Idempotent on the server side — re-issuing on an already-terminal job
+ * (ready/error/cancelled) returns 200 with `already_terminal: true`. The
+ * caller can therefore fire-and-forget without first checking state.
+ */
+export async function cancelStudioJob(
+  projectId: string,
+  jobId: string,
+): Promise<void> {
+  try {
+    await axios.post(
+      `${API_BASE_URL}/projects/${projectId}/studio/jobs/${jobId}/cancel`,
+    );
+  } catch (error) {
+    log.error({ err: error, jobId }, 'failed to cancel studio job');
+    throw error;
+  }
+}
 
 /**
  * Response for API status checks (TTS, Gemini, etc.)


### PR DESCRIPTION
## Summary
Pre-existing UX gap: source-processing rows in the floating **Active Tasks** bar already exposed a Stop affordance (hover the spinner → StopCircle, click to cancel), but **studio rows** (audio overview, presentation, infographic, etc.) were stuck running until completion with no user-visible escape. Customer asked for parity.

## What changes

**Backend** (`backend/app/api/studio/job_actions.py` — new file):
- `POST /projects/<id>/studio/jobs/<job_id>/cancel` route. Idempotent — re-issuing on an already-terminal job returns 200 with `already_terminal: true`. Sets `studio_jobs.status = "cancelled"` and stamps `completed_at`. Registered in `app/api/studio/__init__.py`.

**Frontend** (`frontend/src/lib/api/studio/index.ts` + `frontend/src/components/project/ActiveTasksBar.tsx`):
- New `cancelStudioJob(projectId, jobId)` helper. `JobStatus` type extended with the existing `'cancelled'` state.
- `ActiveTasksBar` opens its Stop affordance to **both** `source` and `studio` rows via a `CANCELLABLE_TYPES` set (keeps it narrow so background / chat-naming tasks don't accidentally get one). Call-site dispatches by `task.type` and **optimistically drops** the row from local state on click — the next 3s poll reconciles via `/active-tasks` (the backend status filter `[pending, processing]` already excludes cancelled rows immediately).

## V1 limitation (documented in the route docstring)

The studio worker doesn't have cooperative cancel hooks today, so it may continue running until completion despite the cancel. The user-facing affordance (it stops showing in the bar) feels like "cancelled" though, which is the customer's actual complaint. **V2 work**: plumb a `cancel_event` into each studio service the same way `main_chat_service` does.

## Test plan
- [x] `python -m py_compile` clean on `job_actions.py` + `__init__.py`
- [x] `tsc -b` clean
- [x] `eslint` clean
- [ ] Manual: kick off a long-running studio job (audio overview, presentation), open the Active Tasks bar, hover the studio row → Stop icon appears → click → row drops out within 3s
- [ ] Manual: cancel an already-completed job (race condition) → backend returns 200 with `already_terminal: true`, no error toast
- [ ] Backwards compat: source rows still cancel as before; chat / background rows still show no Stop affordance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
