### PR TITLE
fix: hide cancelled studio iterations from output tab after refresh

### DIFF
--- a/backend/app/services/studio_services/studio_index_service.py
+++ b/backend/app/services/studio_services/studio_index_service.py
@@ -443,15 +443,26 @@ def get_job(
 def list_jobs(
     project_id: str,
     job_type: str,
-    source_id: Optional[str] = None
+    source_id: Optional[str] = None,
+    include_cancelled: bool = False,
 ) -> List[Dict[str, Any]]:
     """
     List studio jobs by type, optionally filtered by source.
+
+    Cancelled jobs are filtered out by default — they have no usable
+    output (the worker bailed before persisting anything visible) and
+    showing them in the user-facing studio-output tab as "iteration N"
+    rows confused users into thinking the cancel didn't take effect.
+    Callers that genuinely want the audit trail can pass
+    ``include_cancelled=True``.
 
     Args:
         project_id: The project UUID
         job_type: Job type string
         source_id: Optional source UUID to filter by
+        include_cancelled: When True, include rows with status="cancelled".
+            Default False so the studio-output tab and bootstrap call
+            don't surface ghost iterations.
 
     Returns:
         List of job records (flattened), newest first
@@ -467,6 +478,8 @@ def list_jobs(
         )
         if source_id:
             query = query.eq("source_id", source_id)
+        if not include_cancelled:
+            query = query.neq("status", "cancelled")
 
         response = query.execute()
         return [_map_job(row) for row in (response.data or [])]
@@ -475,22 +488,32 @@ def list_jobs(
         return []
 
 
-def list_jobs_grouped(project_id: str) -> Dict[str, List[Dict[str, Any]]]:
+def list_jobs_grouped(
+    project_id: str,
+    include_cancelled: bool = False,
+) -> Dict[str, List[Dict[str, Any]]]:
     """
     List all studio jobs for a project, grouped by job_type.
 
     Educational Note: This supports Studio bootstrap without issuing one
     request per section. Callers can filter by source client-side.
+
+    Cancelled jobs are filtered out by default for the same reason
+    list_jobs does — they have no usable output and showing them as
+    iteration rows in the studio-output tab confused users into thinking
+    the Stop button didn't take effect.
     """
     try:
         client = _get_client()
-        response = (
+        query = (
             client.table("studio_jobs")
             .select("*")
             .eq("project_id", project_id)
             .order("created_at", desc=True)
-            .execute()
         )
+        if not include_cancelled:
+            query = query.neq("status", "cancelled")
+        response = query.execute()
 
         grouped: Dict[str, List[Dict[str, Any]]] = {}
         for row in (response.data or []):

--- a/backend/app/services/studio_services/studio_index_service.py
+++ b/backend/app/services/studio_services/studio_index_service.py
@@ -479,7 +479,13 @@ def list_jobs(
         if source_id:
             query = query.eq("source_id", source_id)
         if not include_cancelled:
-            query = query.neq("status", "cancelled")
+            # Postgres three-valued logic: `status != 'cancelled'` evaluates
+            # to NULL (not TRUE) when status IS NULL — so a plain
+            # `.neq("status", "cancelled")` would silently drop any NULL-
+            # status rows. create_job always writes status="pending" today,
+            # but the explicit OR keeps any future codepath that omits
+            # status from disappearing from the output tab.
+            query = query.or_("status.neq.cancelled,status.is.null")
 
         response = query.execute()
         return [_map_job(row) for row in (response.data or [])]
@@ -512,7 +518,13 @@ def list_jobs_grouped(
             .order("created_at", desc=True)
         )
         if not include_cancelled:
-            query = query.neq("status", "cancelled")
+            # Postgres three-valued logic: `status != 'cancelled'` evaluates
+            # to NULL (not TRUE) when status IS NULL — so a plain
+            # `.neq("status", "cancelled")` would silently drop any NULL-
+            # status rows. create_job always writes status="pending" today,
+            # but the explicit OR keeps any future codepath that omits
+            # status from disappearing from the output tab.
+            query = query.or_("status.neq.cancelled,status.is.null")
         response = query.execute()
 
         grouped: Dict[str, List[Dict[str, Any]]] = {}


### PR DESCRIPTION
## Summary
**Bug** (customer-reported): clicking Stop on a studio task removes the chip from the active-tasks bar (✅ correct), but **refreshing the page** shows the cancelled iteration still listed in the studio-output tab as an empty "iteration N" row. Looks like the Stop didn't take effect even though the worker actually did bail.

## Root cause
`list_jobs` / `list_jobs_grouped` in `studio_index_service.py` had no status filter — cancelled rows came back alongside `ready` / `error` / `processing`. Every `list_X_jobs` route (audio, video, ad, ...) + the studio bootstrap delegate to these helpers, so all of them were leaking cancelled rows to the frontend tab.

## Fix
Added `include_cancelled=False` (default) to both helpers, with a `.neq("status", "cancelled")` clause on the Supabase query. Cancelled rows stay in the DB for audit / future debugging but never surface in the user-facing tab. Existing routes call with default args, so they get the filter for free — no other wiring needed.

## Files changed
- `backend/app/services/studio_services/studio_index_service.py` (+27 / −4)

## Test plan
- [ ] Kick off a long studio job (audio overview) → click Stop in active-tasks bar → refresh page → confirm the cancelled iteration is GONE from the output tab
- [ ] Verify normal `ready` iterations still appear (control)
- [ ] Verify `error` iterations still appear (control)
- [ ] If using `parent_job_id` (edit-an-existing flow): cancelled parent stays in DB and `get_X_job` (singular) still returns it for `get_audio_job(parent_job_id)` lookups — those don't go through `list_jobs`

## Related
- PR #211: original cooperative cancellation
- PR #210 (closed): V1 stop button — its docstring noted "the bar emptying IS the feedback" for in-flight jobs. This PR closes the loop for the post-refresh case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
