### PR TITLE
hotfix: 00028 CREATE POLICY IF NOT EXISTS unsupported on PG 15 (deploy broken)

### DIFF
--- a/backend/supabase/migrations/00028_chat_attachments_rls_permissive.sql
+++ b/backend/supabase/migrations/00028_chat_attachments_rls_permissive.sql
@@ -33,12 +33,14 @@ DROP POLICY IF EXISTS "Users can delete chat attachments from own projects" ON s
 -- Supabase storage API directly with their JWT and read/write/delete
 -- attachments across every other user's projects and chats.
 --
--- `IF NOT EXISTS` keeps the migration idempotent across re-applies
--- (fresh DB clones, partial-state recoveries, test resets) — the
--- DROP POLICY IF EXISTS above already handles the existing-policy case;
--- IF NOT EXISTS handles the case where the policy survived but the
--- migration tracker did not.
-CREATE POLICY IF NOT EXISTS "Chat attachments — backend-mediated full access"
+-- Idempotency: the four DROP POLICY IF EXISTS statements above clear
+-- the slate before this CREATE runs, so re-applying the migration is
+-- safe even though `CREATE POLICY` itself doesn't accept IF NOT EXISTS
+-- on PostgreSQL 15 — Supabase's pinned version (CREATE POLICY's
+-- IF NOT EXISTS form only landed in PG 17). An earlier draft of this
+-- file used IF NOT EXISTS and aborted the migrate container with
+-- exit 3 / syntax error on the prod deploy.
+CREATE POLICY "Chat attachments — backend-mediated full access"
 ON storage.objects FOR ALL
 TO service_role
 USING (bucket_id = 'chat-attachments')


### PR DESCRIPTION
## Summary
**Production deploy is currently broken.** PR #213 (chat-attachments RLS fix, merged at `be945f7`) used `CREATE POLICY IF NOT EXISTS`, which Postgres 15 doesn't support. Migrate container fails with `service "migrate" didn't complete successfully: exit 3` and the entire deploy fails.

```
2026-05-08 18:30:43.083889 Container migrate-...  Started
2026-05-08 18:30:44.290331 Container migrate-...  service "migrate" didn't complete successfully: exit 3
2026-05-08 18:30:44.408763 Deployment failed
```

## Root cause
- Supabase pins `supabase/postgres:15.8.1.085`.
- `CREATE POLICY` got an `IF NOT EXISTS` form **in Postgres 17**.
- My commit message on PR #213 wrongly claimed "PG 14+ supports it" — PG 14 added `IF NOT EXISTS` for `CREATE TABLE`, not `CREATE POLICY`. Greptile flagged the missing-idempotency original concern; my fix introduced a different syntax error.

## Recovery state on the prod DB
Each `DROP POLICY IF EXISTS` is its own auto-committed statement, so the four DROPs from 00028 ran successfully before the parser hit the `CREATE POLICY IF NOT EXISTS` and failed. Current state:
- Old 00027 policies: gone (DROPs succeeded).
- New permissive policy: never created.
- `schema_migrations` tracker: 00028 NOT recorded (insert step never ran).

So the bucket has NO RLS policies right now, and chat-attachment uploads still fail (just with a different error).

## Fix
- Drop `IF NOT EXISTS` from the `CREATE POLICY`.
- Idempotency is preserved by the four `DROP POLICY IF EXISTS` above (they clear the slate before CREATE runs, so re-applies are safe).

## Files changed
- `backend/supabase/migrations/00028_chat_attachments_rls_permissive.sql` (+8 / −6)

## Test plan
- [ ] Merge → Coolify deploys → migrate container hits 00028 → DROPs no-op (already dropped from prior failed run), CREATE succeeds, tracker records 00028
- [ ] Drag-and-drop a screenshot in chat → upload succeeds
- [ ] If urgent, can also be applied manually via `psql` against `supabase-db` using the same SQL — same outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)
