### PR TITLE
Release: hotfix #216 — unblock prod deploy (PG 15 syntax fix)

### DIFF
--- a/backend/supabase/migrations/00028_chat_attachments_rls_permissive.sql
+++ b/backend/supabase/migrations/00028_chat_attachments_rls_permissive.sql
@@ -33,12 +33,14 @@ DROP POLICY IF EXISTS "Users can delete chat attachments from own projects" ON s
 -- Supabase storage API directly with their JWT and read/write/delete
 -- attachments across every other user's projects and chats.
 --
--- `IF NOT EXISTS` keeps the migration idempotent across re-applies
--- (fresh DB clones, partial-state recoveries, test resets) — the
--- DROP POLICY IF EXISTS above already handles the existing-policy case;
--- IF NOT EXISTS handles the case where the policy survived but the
--- migration tracker did not.
-CREATE POLICY IF NOT EXISTS "Chat attachments — backend-mediated full access"
+-- Idempotency: the four DROP POLICY IF EXISTS statements above clear
+-- the slate before this CREATE runs, so re-applying the migration is
+-- safe even though `CREATE POLICY` itself doesn't accept IF NOT EXISTS
+-- on PostgreSQL 15 — Supabase's pinned version (CREATE POLICY's
+-- IF NOT EXISTS form only landed in PG 17). An earlier draft of this
+-- file used IF NOT EXISTS and aborted the migrate container with
+-- exit 3 / syntax error on the prod deploy.
+CREATE POLICY "Chat attachments — backend-mediated full access"
 ON storage.objects FOR ALL
 TO service_role
 USING (bucket_id = 'chat-attachments')


### PR DESCRIPTION
## Summary
Promote develop → main with the hotfix for the broken deploy.

- **#216** — PG 15 doesn't support `CREATE POLICY IF NOT EXISTS` (only added in PG 17). The migrate container was exiting with code 3 / syntax error on every deploy of `be945f7`. Drop `IF NOT EXISTS` — the four `DROP POLICY IF EXISTS` above already ensure idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
