### PR TITLE
fix(chat): preserve image preview in user bubble after AI response

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -549,21 +549,51 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       // (`Cannot read properties of undefined (reading 'id')`).
       if (!canonicalUserMessage?.id) return;
       canonicalUserMessageReceivedRef.current = true;
+      // Carry the optimistic blob URLs onto the canonical message's image
+      // blocks. The server-signed URLs aren't always reachable from the
+      // browser in the active session (proxy / cache / momentary RLS race),
+      // and an earlier revision swapped to them on this event — making the
+      // image vanish from the bubble the moment the AI started answering.
+      // Local blob URLs are guaranteed-live for the page lifetime, so we
+      // keep them for *this* session; on full page refresh, the persisted
+      // image blocks rebuild from a fresh signed URL via the formatter.
+      let mergedCanonical: Chat['messages'][number] = canonicalUserMessage;
+      if (
+        Array.isArray(canonicalUserMessage.content) &&
+        optimisticBlobUrls.length > 0
+      ) {
+        let blobIdx = 0;
+        const mergedContent = (canonicalUserMessage.content as Array<{ type: string; url?: string }>).map(
+          (block) => {
+            if (block.type === 'image' && optimisticBlobUrls[blobIdx]) {
+              const blobUrl = optimisticBlobUrls[blobIdx];
+              blobIdx += 1;
+              return { ...block, url: blobUrl };
+            }
+            return block;
+          },
+        );
+        mergedCanonical = {
+          ...canonicalUserMessage,
+          content: mergedContent as Chat['messages'][number]['content'],
+        };
+      }
       setActiveChat((prev) => {
         if (!prev) return null;
         const nextMessages = prev.messages.map((msg) =>
-          msg.id === tempUserMessage.id ? canonicalUserMessage : msg
+          msg.id === tempUserMessage.id ? mergedCanonical : msg
         );
-        const alreadyPresent = nextMessages.some((msg) => msg.id === canonicalUserMessage.id);
+        const alreadyPresent = nextMessages.some((msg) => msg.id === mergedCanonical.id);
         return {
           ...prev,
-          messages: alreadyPresent ? nextMessages : [...nextMessages.filter((msg) => msg.id !== tempUserMessage.id), canonicalUserMessage],
+          messages: alreadyPresent ? nextMessages : [...nextMessages.filter((msg) => msg.id !== tempUserMessage.id), mergedCanonical],
         };
       });
-      // The canonical message renders from server-signed URLs now, so the
-      // local blob URLs are no longer referenced by the DOM. Revoke to free
-      // the underlying File buffers.
-      revokeOptimisticBlobs();
+      // Intentionally NOT revoking optimisticBlobUrls here — the merged
+      // canonical message is still pointing at them. They'll be released
+      // when the browser tab navigates away. The small per-image
+      // (≤5MB cap) memory cost is the trade-off for a working preview
+      // throughout the session.
     };
 
     const appendAssistantMessage = (assistantMessage: Chat['messages'][number]) => {
@@ -736,11 +766,15 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     } finally {
       onRemoveSendingChat(sendingChatId);
       abortControllerRef.current = null;
-      // Defence-in-depth: if neither the success path nor any catch
-      // branch ran (shouldn't happen in normal control flow, but JS
-      // exception edges exist), still free the optimistic blob URLs.
-      // No-op if already revoked above.
-      revokeOptimisticBlobs();
+      // Only revoke optimistic blob URLs if we never got a canonical
+      // user message to attach them to (send-aborted, fallback-error,
+      // user-cancelled). When the canonical did arrive, the merged
+      // message is still pointing at these blob URLs — revoking here
+      // would be the bug we're fixing. The browser will free them when
+      // the tab navigates.
+      if (!canonicalUserMessageReceivedRef.current) {
+        revokeOptimisticBlobs();
+      }
     }
   };
 

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -560,17 +560,24 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       let mergedCanonical: Chat['messages'][number] = canonicalUserMessage;
       if (
         Array.isArray(canonicalUserMessage.content) &&
+        Array.isArray(optimisticContent) &&
         optimisticBlobUrls.length > 0
       ) {
         // Build a filename → blobUrl lookup from the optimistic blocks so
         // the merge is order-independent (the server may return image blocks
         // in a different sequence than the client built them).
         const blobByFilename = new Map<string, string>();
-        optimisticContent.forEach((block) => {
-          if (typeof block === 'object' && block.type === 'image' && block.filename && block.url) {
-            if (!blobByFilename.has(block.filename)) blobByFilename.set(block.filename, block.url);
+        for (const block of optimisticContent) {
+          if (
+            typeof block === 'object' &&
+            block.type === 'image' &&
+            block.filename &&
+            block.url &&
+            !blobByFilename.has(block.filename)
+          ) {
+            blobByFilename.set(block.filename, block.url);
           }
-        });
+        }
         const mergedContent = (canonicalUserMessage.content as Array<{ type: string; url?: string; filename?: string }>).map(
           (block) => {
             if (block.type === 'image' && block.filename) {

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -562,13 +562,20 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         Array.isArray(canonicalUserMessage.content) &&
         optimisticBlobUrls.length > 0
       ) {
-        let blobIdx = 0;
-        const mergedContent = (canonicalUserMessage.content as Array<{ type: string; url?: string }>).map(
+        // Build a filename → blobUrl lookup from the optimistic blocks so
+        // the merge is order-independent (the server may return image blocks
+        // in a different sequence than the client built them).
+        const blobByFilename = new Map<string, string>();
+        optimisticContent.forEach((block) => {
+          if (typeof block === 'object' && block.type === 'image' && block.filename && block.url) {
+            if (!blobByFilename.has(block.filename)) blobByFilename.set(block.filename, block.url);
+          }
+        });
+        const mergedContent = (canonicalUserMessage.content as Array<{ type: string; url?: string; filename?: string }>).map(
           (block) => {
-            if (block.type === 'image' && optimisticBlobUrls[blobIdx]) {
-              const blobUrl = optimisticBlobUrls[blobIdx];
-              blobIdx += 1;
-              return { ...block, url: blobUrl };
+            if (block.type === 'image' && block.filename) {
+              const blobUrl = blobByFilename.get(block.filename);
+              if (blobUrl) return { ...block, url: blobUrl };
             }
             return block;
           },


### PR DESCRIPTION
## Summary
**Customer-reported**: chat-image preview disappears the moment the AI starts answering. Repro:
1. Drag/paste image + caption "what's this"
2. Optimistic preview shows the image fine ✅
3. Backend persists, SSE `user_message` event arrives
4. Image vanishes from the user bubble — only filename "batcat.jpg" alt-text + caption remain ❌

## Root cause
`replaceTempWithCanonicalUser` swapped the optimistic temp message (with `URL.createObjectURL(file)` blob URLs) for the canonical persisted message (with server-signed URLs from `_format_blocks_with_images` → `get_chat_attachment_url`). Then `revokeOptimisticBlobs()` fired, freeing the blob URLs. If the server-signed URL isn't browser-reachable in the active session — proxy / cache / momentary RLS race — the `<img>` falls back to its `alt={filename}` text.

## Fix
When the canonical user_message arrives, **carry the optimistic blob URLs onto its image blocks** (replace `block.url` with the corresponding blob URL while keeping `id` / `media_type` / `filename` from the canonical). Don't revoke the blobs on the canonical path — the merged message is still pointing at them.

The `finally` block now revokes ONLY when no canonical arrived (cancel / error / fallback), so the leak is bounded.

## Trade-off
Blob URLs stay alive until the tab navigates away. With the 5MB-per-image cap × ≤10 attachments per message, upper-bound session memory growth is negligible. On full page refresh the persisted image blocks rebuild from a fresh server signed URL via the formatter, so the next session starts clean.

## Files changed
- `frontend/src/components/chat/ChatPanel.tsx` (+46 / −12)

## Test plan
- [ ] Drag image + send → image visible in bubble during composition, send, AI streaming, AND after AI response (the regression)
- [ ] Send pure-text message → no regression (no blob URLs created, no diff)
- [ ] Cancel mid-send → blob URLs revoked via finally branch (no leak)
- [ ] Refresh page → image still renders via fresh signed URL from server
- [ ] Multiple attachments in one message → all blob URLs carried correctly (index-matched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
