### PR TITLE
studio: cooperative Stop button across all 18 agents

### DIFF
--- a/backend/app/api/studio/__init__.py
+++ b/backend/app/api/studio/__init__.py
@@ -80,6 +80,7 @@ from app.api.studio import marketing_strategies  # noqa: F401
 from app.api.studio import blogs  # noqa: F401
 from app.api.studio import business_reports  # noqa: F401
 from app.api.studio import job_groups  # noqa: F401
+from app.api.studio import job_actions  # noqa: F401
 
 # Educational Note: The noqa comments tell flake8 to ignore the
 # "imported but unused" warning. We import to register routes,

--- a/backend/app/api/studio/job_actions.py
+++ b/backend/app/api/studio/job_actions.py
@@ -100,8 +100,35 @@ def cancel_studio_job(project_id: str, job_id: str):
         completed_at=now_iso,
         cancelled_at=now_iso,  # stored inside job_data JSONB
     )
+
+    # Second race window: the worker may have written ready/error in the
+    # gap between our initial `get_job` (which saw `processing` and let
+    # us through) and the `update_job` above. The clobber matrix would
+    # then drop our cancelled write — `updated` reflects the worker's
+    # winning row, NOT a cancellation. Branch on the actual final status
+    # so the frontend never sees `{status:'cancelled'}` when the DB is
+    # something else.
+    final = updated or job
+    final_status = final.get("status")
+
+    if final_status == "ready":
+        return jsonify({
+            "success": True,
+            "status": "ready",
+            "late": True,
+            "job": final,
+        }), 200
+
+    if final_status == "error":
+        return jsonify({
+            "success": False,
+            "status": "error",
+            "job": final,
+        }), 409
+
+    # Normal cooperative cancel — DB row landed `cancelled` as expected.
     return jsonify({
         "success": True,
-        "status": "cancelled",
-        "job": updated or job,
+        "status": final_status or "cancelled",
+        "job": final,
     }), 200

--- a/backend/app/api/studio/job_actions.py
+++ b/backend/app/api/studio/job_actions.py
@@ -1,0 +1,104 @@
+"""
+Studio job actions — currently just `cancel`.
+
+A studio job runs in a background ThreadPoolExecutor worker (via
+`task_service.submit_task`). The agent service code periodically calls
+`raise_if_cancelled(project_id, job_id)` at natural boundaries (start of
+work, top of generation loop, before expensive external calls) to give
+the user a way to stop a long-running generation.
+
+This route is the trigger end of that loop. It:
+
+  1. Looks up the job; 404 if missing.
+  2. Branches on the current status — three of them are terminal and
+     handled inline (idempotent ``cancelled``, race-with-finished
+     ``ready``, already-failed ``error``). Otherwise we proceed.
+  3. Calls ``task_service.cancel_tasks_for_target(job_id)`` so the
+     worker's next breakpoint trips immediately (in-memory hint, no DB
+     read). The DB write below is the durable backstop.
+  4. Calls ``studio_index_service.update_job(status='cancelled', ...)``.
+     The clobber matrix in update_job rejects late ``ready`` writes from
+     the worker if they race in after this — the DB row is the single
+     source of truth for the final state.
+
+Race semantics — what the caller sees:
+  * Normal cooperative cancel (status was processing/pending) → 200,
+    ``{success, status:'cancelled', job}``.
+  * Worker finished AFTER user clicked Stop but BEFORE this route ran →
+    we observe ``status='ready'`` and return ``{success, status:'ready',
+    late:true, job}``. Frontend rolls its optimistic 'cancelling' state
+    back and surfaces "Generation finished before cancel — keeping the
+    result."
+  * Worker errored prior → 409 ``{success:false, status:'error', job}``.
+    Cancel is moot.
+  * Job already cancelled → 200 idempotent ``{success, status:'cancelled',
+    job}``. Double-confirm and replay-safe.
+  * Project / job not found → 404.
+
+The cancel intent is project-scoped via the existing `before_request`
+hook on `studio_bp` that calls `verify_project_access`. Cross-project
+cancels are not possible because `get_job` requires both ids match.
+"""
+from datetime import datetime
+
+from flask import jsonify
+
+from app.api.studio import studio_bp
+from app.services.background_services.task_service import task_service
+from app.services.studio_services import studio_index_service
+
+
+@studio_bp.route(
+    "/projects/<project_id>/studio/jobs/<job_id>/cancel",
+    methods=["POST"],
+)
+def cancel_studio_job(project_id: str, job_id: str):
+    job = studio_index_service.get_job(project_id, job_id)
+    if not job:
+        return jsonify({"success": False, "error": "job not found"}), 404
+
+    current_status = job.get("status")
+
+    if current_status == "cancelled":
+        # Idempotent — second confirm or two-tab race lands here.
+        return jsonify({
+            "success": True,
+            "status": "cancelled",
+            "job": job,
+        }), 200
+
+    if current_status == "ready":
+        # Worker beat us; the result is real. Tell the frontend to roll
+        # its optimistic cancel state back and keep the output. The
+        # `late` flag is the signal for that UI behavior.
+        return jsonify({
+            "success": True,
+            "status": "ready",
+            "late": True,
+            "job": job,
+        }), 200
+
+    if current_status == "error":
+        return jsonify({
+            "success": False,
+            "status": "error",
+            "job": job,
+        }), 409
+
+    # Live job (pending or processing) — actually cancel.
+    # In-memory hint first so the worker's next breakpoint trips before
+    # the DB roundtrip below.
+    task_service.cancel_tasks_for_target(job_id)
+
+    now_iso = datetime.utcnow().isoformat()
+    updated = studio_index_service.update_job(
+        project_id, job_id,
+        status="cancelled",
+        completed_at=now_iso,
+        cancelled_at=now_iso,  # stored inside job_data JSONB
+    )
+    return jsonify({
+        "success": True,
+        "status": "cancelled",
+        "job": updated or job,
+    }), 200

--- a/backend/app/api/studio/job_actions.py
+++ b/backend/app/api/studio/job_actions.py
@@ -39,7 +39,7 @@ The cancel intent is project-scoped via the existing `before_request`
 hook on `studio_bp` that calls `verify_project_access`. Cross-project
 cancels are not possible because `get_job` requires both ids match.
 """
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import jsonify
 
@@ -90,7 +90,10 @@ def cancel_studio_job(project_id: str, job_id: str):
     # the DB roundtrip below.
     task_service.cancel_tasks_for_target(job_id)
 
-    now_iso = datetime.utcnow().isoformat()
+    # `datetime.utcnow()` is deprecated in 3.12+ — use a timezone-aware
+    # value so the ISO string carries an explicit offset and matches what
+    # the rest of the studio_jobs callers store.
+    now_iso = datetime.now(timezone.utc).isoformat()
     updated = studio_index_service.update_job(
         project_id, job_id,
         status="cancelled",

--- a/backend/app/services/ai_agents/marketing_strategy_agent_service.py
+++ b/backend/app/services/ai_agents/marketing_strategy_agent_service.py
@@ -67,6 +67,10 @@ class MarketingStrategyAgentService:
             started_at=started_at
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if Stop
+        # already arrived between API accept and worker start.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         # Get source content (if source provided)
         source_content = ""
         if source_id:

--- a/backend/app/services/ai_agents/prd_agent_service.py
+++ b/backend/app/services/ai_agents/prd_agent_service.py
@@ -69,6 +69,10 @@ class PRDAgentService:
             started_at=started_at
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if Stop
+        # already arrived between API accept and worker start.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         # Get source content (if source provided)
         source_content = ""
         if source_id:

--- a/backend/app/services/ai_agents/wireframe_agent_service.py
+++ b/backend/app/services/ai_agents/wireframe_agent_service.py
@@ -85,6 +85,10 @@ class WireframeAgentService:
             started_at=started_at.isoformat(),
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if Stop
+        # already arrived between API accept and worker start.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         logger.info("Starting wireframe agent job %s", job_id[:8])
 
         try:

--- a/backend/app/services/studio_services/ad_creative_service.py
+++ b/backend/app/services/studio_services/ad_creative_service.py
@@ -75,6 +75,10 @@ class AdCreativeService:
             started_at=datetime.now().isoformat()
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if the user
+        # already clicked Stop before this background thread woke up.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         # Step 1: Build image prompts from the user's direction directly.
         # We used to ask Haiku to fan the user prompt out into three
         # different angles (hero / lifestyle / aspirational), but that

--- a/backend/app/services/studio_services/audio_overview_service.py
+++ b/backend/app/services/studio_services/audio_overview_service.py
@@ -106,6 +106,11 @@ class AudioOverviewService:
             started_at=datetime.now().isoformat()
         )
 
+        # Cooperative cancellation breakpoint #1 — entry. If the user
+        # already clicked Stop between the API route accepting the job
+        # and this thread waking up, abort cleanly before doing any work.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         # Step 1: Get source metadata
         source = source_index_service.get_source_from_index(project_id, source_id)
         if not source:
@@ -173,6 +178,12 @@ class AudioOverviewService:
                 completed_at=datetime.now().isoformat()
             )
             return {"success": False, "error": "Script file not found in storage"}
+
+        # Cooperative cancellation breakpoint #4 — before TTS. ElevenLabs
+        # calls can run 10-30s for long scripts; without this, the worker
+        # would burn the full TTS spend even if the user clicked Stop
+        # before audio generation began.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
 
         audio_result = tts_service.generate_audio_bytes(text=script_text)
 
@@ -315,6 +326,12 @@ class AudioOverviewService:
         max_iterations = 5 if not is_large else self.MAX_ITERATIONS
 
         for iteration in range(1, max_iterations + 1):
+            # Cooperative cancellation breakpoint #2/3 — top of script
+            # generation loop. Each iteration is a Claude call that can
+            # take 5-30s; the user's Stop click should not have to wait
+            # for the full call before taking effect.
+            studio_index_service.raise_if_cancelled(project_id, job_id)
+
             # Update progress
             studio_index_service.update_audio_job(
                 project_id, job_id,

--- a/backend/app/services/studio_services/flash_cards_service.py
+++ b/backend/app/services/studio_services/flash_cards_service.py
@@ -133,6 +133,10 @@ class FlashCardsService:
             started_at=datetime.now().isoformat()
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if Stop
+        # already arrived between API accept and worker start.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         try:
             # Get source metadata
             source = source_index_service.get_source_from_index(project_id, source_id)

--- a/backend/app/services/studio_services/flow_diagram_service.py
+++ b/backend/app/services/studio_services/flow_diagram_service.py
@@ -139,6 +139,10 @@ class FlowDiagramService:
             started_at=datetime.now().isoformat()
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if Stop
+        # already arrived between API accept and worker start.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         try:
             # Get source content (if source provided)
             source_name = "Direction Only"

--- a/backend/app/services/studio_services/infographic_service.py
+++ b/backend/app/services/studio_services/infographic_service.py
@@ -137,6 +137,10 @@ class InfographicService:
             started_at=datetime.now().isoformat()
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if Stop
+        # already arrived between API accept and worker start.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         try:
             # Get source content if a source is provided
             content = ""

--- a/backend/app/services/studio_services/mind_map_service.py
+++ b/backend/app/services/studio_services/mind_map_service.py
@@ -134,6 +134,10 @@ class MindMapService:
             started_at=datetime.now().isoformat()
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if Stop
+        # already arrived between API accept and worker start.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         try:
             # Get source metadata
             source = source_index_service.get_source_from_index(project_id, source_id)

--- a/backend/app/services/studio_services/quiz_service.py
+++ b/backend/app/services/studio_services/quiz_service.py
@@ -133,6 +133,10 @@ class QuizService:
             started_at=datetime.now().isoformat()
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if Stop
+        # already arrived between API accept and worker start.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         try:
             # Get source metadata
             source = source_index_service.get_source_from_index(project_id, source_id)

--- a/backend/app/services/studio_services/social_posts_service.py
+++ b/backend/app/services/studio_services/social_posts_service.py
@@ -99,6 +99,10 @@ class SocialPostsService:
             started_at=datetime.now().isoformat()
         )
 
+        # Cooperative cancellation breakpoint — abort cleanly if Stop
+        # already arrived between API accept and worker start.
+        studio_index_service.raise_if_cancelled(project_id, job_id)
+
         # Step 1: Generate copy and image prompts with Claude
         content_result = self._generate_content(
             project_id=project_id,

--- a/backend/app/services/studio_services/studio_index_service.py
+++ b/backend/app/services/studio_services/studio_index_service.py
@@ -97,36 +97,72 @@ def purge_job_storage(project_id: str, job_id: str) -> None:
     """
     Best-effort cleanup of a cancelled job's storage prefix.
 
-    Lists ``studio-outputs/<project_id>/<job_id>/`` and removes everything.
+    Lists ``studio-outputs/<project_id>/<job_id>/`` and removes everything
+    underneath, recursively. Some agent paths nest more than one level
+    (presentation writes to ``slides/`` and ``screenshots/``;
+    ``slides/`` itself contains base-styles.css alongside per-slide HTML).
+    A bounded BFS catches all of them.
+
     Never raises — storage failures during cleanup shouldn't bubble up
     into the worker's exception handling. Logs and moves on.
     """
+    # Cap recursion depth + total visited prefixes so a buggy storage
+    # listing can't push us into an infinite walk. Real studio output
+    # trees are 2-3 levels deep at most.
+    MAX_DEPTH = 5
+    MAX_VISITED = 1000
+
     try:
         from app.services.integrations.supabase import storage_service
 
-        prefix = f"{project_id}/{job_id}"
         client = storage_service._get_client()  # noqa: SLF001 — package-internal
         bucket = client.storage.from_(storage_service.BUCKET_STUDIO)
-        listed = bucket.list(prefix, {"limit": 10000}) or []
-        # storage3 returns objects from the *immediate* prefix only; recurse
-        # into common nested subdirs so partial AI output lives die too.
+
+        root_prefix = f"{project_id}/{job_id}"
+        # BFS over storage prefixes. storage3.list() returns immediate
+        # children only — directory-like entries don't have "id" or
+        # "metadata" populated, while files do. We still attempt to
+        # recurse into anything we can't definitively classify; the
+        # nested list call simply returns [] for a real file.
         paths_to_delete: List[str] = []
-        for entry in listed:
-            name = entry.get("name") if isinstance(entry, dict) else None
-            if not name:
-                continue
-            paths_to_delete.append(f"{prefix}/{name}")
-            # If this entry is itself a folder, fan out one level.
+        queue: List[tuple] = [(root_prefix, 0)]
+        visited = 0
+
+        while queue and visited < MAX_VISITED:
+            current_prefix, depth = queue.pop(0)
+            visited += 1
             try:
-                nested = bucket.list(f"{prefix}/{name}", {"limit": 10000}) or []
-                for n in nested:
-                    nname = n.get("name") if isinstance(n, dict) else None
-                    if nname:
-                        paths_to_delete.append(f"{prefix}/{name}/{nname}")
+                entries = bucket.list(current_prefix, {"limit": 10000}) or []
             except Exception:  # noqa: BLE001 — best-effort
-                pass
+                continue
+            for entry in entries:
+                name = entry.get("name") if isinstance(entry, dict) else None
+                if not name:
+                    continue
+                child = f"{current_prefix}/{name}"
+                paths_to_delete.append(child)
+                # Heuristic: entries with no metadata + no id behave like
+                # directories. Recurse into them up to MAX_DEPTH.
+                is_likely_folder = (
+                    isinstance(entry, dict)
+                    and not entry.get("id")
+                    and not entry.get("metadata")
+                )
+                if is_likely_folder and depth < MAX_DEPTH:
+                    queue.append((child, depth + 1))
+
         if paths_to_delete:
-            bucket.remove(paths_to_delete)
+            # Supabase storage `remove` accepts a batch; chunk to stay
+            # safely under any per-call limit.
+            CHUNK = 200
+            for i in range(0, len(paths_to_delete), CHUNK):
+                try:
+                    bucket.remove(paths_to_delete[i : i + CHUNK])
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    logger.warning(
+                        "Partial storage purge failure for job %s: %s",
+                        job_id, exc,
+                    )
             logger.info(
                 "Purged %d storage objects for cancelled studio job %s",
                 len(paths_to_delete), job_id,

--- a/backend/app/services/studio_services/studio_index_service.py
+++ b/backend/app/services/studio_services/studio_index_service.py
@@ -51,6 +51,92 @@ _TOP_COLUMNS = {
 }
 
 
+# ============================================================================
+# Cooperative cancellation primitives
+# ============================================================================
+
+class StudioJobCancelled(Exception):
+    """
+    Raised by `raise_if_cancelled` at agent breakpoints when a Stop request
+    has landed for the in-flight job. Distinct from generic Exception so
+    `with_failure_guard` can route it to the cleanup branch instead of the
+    error branch.
+    """
+
+
+def is_job_cancelled(project_id: str, job_id: str) -> bool:
+    """
+    True if a Stop request has landed for this job.
+
+    Two-source check:
+      1. ``task_service.is_target_cancelled(job_id)`` — in-memory hint set
+         by the cancel route. Microsecond-fast, lets the worker's first
+         breakpoint trip before the next DB poll lands.
+      2. ``studio_jobs.status == 'cancelled'`` — durable, survives process
+         restart. Falls back here only when the in-memory hint is False so
+         we don't pay for a DB read on every breakpoint in the happy path.
+    """
+    # Local import to dodge a circular: task_service imports nothing from
+    # this file, but our background_services package gets pulled in during
+    # app boot via auth flows that touch studio_index_service indirectly.
+    from app.services.background_services import task_service
+
+    if task_service.is_target_cancelled(job_id):
+        return True
+    row = get_job(project_id, job_id)
+    return bool(row and row.get("status") == "cancelled")
+
+
+def raise_if_cancelled(project_id: str, job_id: str) -> None:
+    """Convenience breakpoint — raise if Stop has landed, else no-op."""
+    if is_job_cancelled(project_id, job_id):
+        raise StudioJobCancelled(f"studio job {job_id} cancelled by user")
+
+
+def purge_job_storage(project_id: str, job_id: str) -> None:
+    """
+    Best-effort cleanup of a cancelled job's storage prefix.
+
+    Lists ``studio-outputs/<project_id>/<job_id>/`` and removes everything.
+    Never raises — storage failures during cleanup shouldn't bubble up
+    into the worker's exception handling. Logs and moves on.
+    """
+    try:
+        from app.services.integrations.supabase import storage_service
+
+        prefix = f"{project_id}/{job_id}"
+        client = storage_service._get_client()  # noqa: SLF001 — package-internal
+        bucket = client.storage.from_(storage_service.BUCKET_STUDIO)
+        listed = bucket.list(prefix, {"limit": 10000}) or []
+        # storage3 returns objects from the *immediate* prefix only; recurse
+        # into common nested subdirs so partial AI output lives die too.
+        paths_to_delete: List[str] = []
+        for entry in listed:
+            name = entry.get("name") if isinstance(entry, dict) else None
+            if not name:
+                continue
+            paths_to_delete.append(f"{prefix}/{name}")
+            # If this entry is itself a folder, fan out one level.
+            try:
+                nested = bucket.list(f"{prefix}/{name}", {"limit": 10000}) or []
+                for n in nested:
+                    nname = n.get("name") if isinstance(n, dict) else None
+                    if nname:
+                        paths_to_delete.append(f"{prefix}/{name}/{nname}")
+            except Exception:  # noqa: BLE001 — best-effort
+                pass
+        if paths_to_delete:
+            bucket.remove(paths_to_delete)
+            logger.info(
+                "Purged %d storage objects for cancelled studio job %s",
+                len(paths_to_delete), job_id,
+            )
+    except Exception as exc:  # noqa: BLE001 — never raise on cleanup
+        logger.warning(
+            "Storage purge failed for cancelled job %s: %s", job_id, exc,
+        )
+
+
 def _get_client():
     """Get Supabase client, raising error if not configured."""
     if not is_supabase_enabled():
@@ -126,6 +212,34 @@ def create_job(
         return None
 
 
+# Allowed transitions for the studio_jobs.status column. Every other
+# transition is silently dropped (current row returned unmodified, log at
+# INFO). The DB row's status is the single source of truth for whether a
+# job ended in `ready`, `error`, or `cancelled` — once any of those lands,
+# the column is frozen and concurrent late writes (e.g. worker writes
+# `ready` after the cancel route already wrote `cancelled`) cannot
+# overwrite it. Same-status writes are idempotent no-ops.
+_STATUS_TRANSITIONS: Dict[str, set] = {
+    "pending":    {"pending", "processing", "ready", "error", "cancelled"},
+    "processing": {"pending", "processing", "ready", "error", "cancelled"},
+    "ready":      {"ready"},
+    "error":      {"error"},
+    "cancelled":  {"cancelled"},
+}
+
+
+def _status_transition_allowed(from_status: Optional[str], to_status: str) -> bool:
+    """True if ``from_status -> to_status`` should commit. None counts as
+    pending (newly-created rows). Unknown statuses default to permissive
+    so a future status value doesn't silently break writes."""
+    if from_status is None:
+        return True
+    allowed = _STATUS_TRANSITIONS.get(from_status)
+    if allowed is None:
+        return True
+    return to_status in allowed
+
+
 def update_job(
     project_id: str,
     job_id: str,
@@ -142,10 +256,15 @@ def update_job(
 
     Returns:
         Updated job record (flattened) or None if not found
+
+    Race-safety: when ``status`` is being changed and the current row is
+    already in a terminal state (ready/error/cancelled), the write is
+    dropped instead of clobbering. The dropped transition is logged at
+    INFO; the caller still gets the current row back. This is what makes
+    the cancel route and a near-simultaneous worker `ready` write produce
+    a coherent final state instead of last-write-wins.
     """
     try:
-        client = _get_client()
-
         # Separate top-level columns from job_data fields
         top_level = {}
         job_data_updates = {}
@@ -160,9 +279,29 @@ def update_job(
                 else:
                     job_data_updates[k] = v
 
+        # If we're changing status, fetch current row first and apply the
+        # transition matrix. Pure job_data updates (no status change) skip
+        # this — they're additive and can't violate terminal-state safety.
+        # _get_client is intentionally deferred so a dropped write doesn't
+        # touch the Supabase client at all (cheaper, easier to test).
+        new_status = top_level.get("status")
+        current_for_data: Optional[Dict[str, Any]] = None
+        if new_status is not None:
+            current_for_data = get_job(project_id, job_id)
+            if not current_for_data:
+                return None
+            current_status = current_for_data.get("status")
+            if not _status_transition_allowed(current_status, new_status):
+                logger.info(
+                    "Studio job %s status transition dropped: %s -> %s "
+                    "(terminal state, write rejected)",
+                    job_id, current_status, new_status,
+                )
+                return current_for_data
+
         # Merge job_data updates via fetch-merge-update
         if job_data_updates:
-            current = get_job(project_id, job_id)
+            current = current_for_data or get_job(project_id, job_id)
             if not current:
                 return None
             # Rebuild current job_data (fields not in top-level columns)
@@ -179,6 +318,7 @@ def update_job(
         if not top_level:
             return get_job(project_id, job_id)
 
+        client = _get_client()
         response = (
             client.table("studio_jobs")
             .update(top_level)
@@ -218,6 +358,19 @@ def with_failure_guard(callable_func):
         job_id = kwargs.get("job_id")
         try:
             return callable_func(*args, **kwargs)
+        except StudioJobCancelled:
+            # User cancelled mid-generation. The cancel route already wrote
+            # status='cancelled' before we got here (and the clobber matrix
+            # would drop any 'error' write we tried to issue anyway). Best-
+            # effort cleanup of partial output, then swallow — task_service
+            # marks the background_tasks row cancelled separately.
+            logger.info(
+                "Studio job %s cancelled by user; running storage cleanup",
+                job_id,
+            )
+            if project_id and job_id:
+                purge_job_storage(project_id, job_id)
+            return None
         except Exception as exc:  # noqa: BLE001 — re-raised below
             logger.exception(
                 "Studio job %s (%s) crashed: %s",

--- a/backend/app/services/tool_executors/blog_agent_executor.py
+++ b/backend/app/services/tool_executors/blog_agent_executor.py
@@ -101,6 +101,11 @@ class BlogAgentExecutor:
             """Background task to run the blog agent."""
             logger.info("Starting blog agent for job %s", job_id[:8])
             try:
+                # Cooperative cancellation breakpoint — abort cleanly if
+                # Stop already arrived. Routes to StudioJobCancelled
+                # except below; cleanup happens in purge_job_storage.
+                studio_index_service.raise_if_cancelled(project_id, job_id)
+
                 blog_agent_service.generate_blog_post(
                     project_id=project_id,
                     source_id=source_id,
@@ -115,9 +120,15 @@ class BlogAgentExecutor:
                     previous_markdown=previous_markdown,
                     previous_title=previous_title
                 )
+            except studio_index_service.StudioJobCancelled:
+                logger.info("Blog job %s cancelled by user", job_id[:8])
+                studio_index_service.purge_job_storage(project_id, job_id)
+                return
             except Exception as e:
                 logger.exception("Blog agent failed for job %s", job_id[:8])
-                # Update job on error
+                # Update job on error. Clobber matrix in update_job will
+                # silently drop this write if a concurrent cancel set
+                # status='cancelled' first.
                 studio_index_service.update_blog_job(
                     project_id, job_id,
                     status="error",

--- a/backend/app/services/tool_executors/business_report_agent_executor.py
+++ b/backend/app/services/tool_executors/business_report_agent_executor.py
@@ -104,6 +104,10 @@ class BusinessReportAgentExecutor:
             """Background task to run the business report agent."""
             logger.info("Starting business report agent for job %s", job_id[:8])
             try:
+                # Cooperative cancellation breakpoint — abort cleanly if
+                # Stop already arrived.
+                studio_index_service.raise_if_cancelled(project_id, job_id)
+
                 business_report_agent_service.generate_business_report(
                     project_id=project_id,
                     source_id=source_id,
@@ -117,9 +121,13 @@ class BusinessReportAgentExecutor:
                     previous_markdown=previous_markdown,
                     previous_title=previous_title
                 )
+            except studio_index_service.StudioJobCancelled:
+                logger.info("Business report job %s cancelled by user", job_id[:8])
+                studio_index_service.purge_job_storage(project_id, job_id)
+                return
             except Exception as e:
                 logger.exception("Business report agent failed for job %s", job_id[:8])
-                # Update job on error
+                # Clobber matrix drops error → cancelled writes.
                 studio_index_service.update_business_report_job(
                     project_id, job_id,
                     status="error",

--- a/backend/app/services/tool_executors/component_agent_executor.py
+++ b/backend/app/services/tool_executors/component_agent_executor.py
@@ -80,6 +80,10 @@ class ComponentAgentExecutor:
             """Background task to run the component agent."""
             logger.info("Starting component agent for job %s", job_id[:8])
             try:
+                # Cooperative cancellation breakpoint — abort cleanly if
+                # Stop already arrived.
+                studio_index_service.raise_if_cancelled(project_id, job_id)
+
                 component_agent_service.generate_components(
                     project_id=project_id,
                     source_id=source_id,
@@ -89,9 +93,13 @@ class ComponentAgentExecutor:
                     previous_components=previous_components,
                     edit_instructions=edit_instructions
                 )
+            except studio_index_service.StudioJobCancelled:
+                logger.info("Component job %s cancelled by user", job_id[:8])
+                studio_index_service.purge_job_storage(project_id, job_id)
+                return
             except Exception as e:
                 logger.exception("Component agent failed for job %s", job_id[:8])
-                # Update job on error
+                # Clobber matrix drops error → cancelled writes.
                 studio_index_service.update_component_job(
                     project_id, job_id,
                     status="error",

--- a/backend/app/services/tool_executors/email_agent_executor.py
+++ b/backend/app/services/tool_executors/email_agent_executor.py
@@ -96,6 +96,10 @@ class EmailAgentExecutor:
             """Background task to run the email agent."""
             logger.info("Starting email agent for job %s", job_id[:8])
             try:
+                # Cooperative cancellation breakpoint — abort cleanly if
+                # Stop already arrived.
+                studio_index_service.raise_if_cancelled(project_id, job_id)
+
                 email_agent_service.generate_template(
                     project_id=project_id,
                     source_id=source_id,
@@ -106,9 +110,13 @@ class EmailAgentExecutor:
                     previous_markdown=previous_markdown,
                     previous_title=previous_title
                 )
+            except studio_index_service.StudioJobCancelled:
+                logger.info("Email job %s cancelled by user", job_id[:8])
+                studio_index_service.purge_job_storage(project_id, job_id)
+                return
             except Exception as e:
                 logger.exception("Email agent failed for job %s", job_id[:8])
-                # Update job on error
+                # Clobber matrix drops error → cancelled writes.
                 studio_index_service.update_email_job(
                     project_id, job_id,
                     status="error",

--- a/backend/app/services/tool_executors/presentation_agent_executor.py
+++ b/backend/app/services/tool_executors/presentation_agent_executor.py
@@ -100,6 +100,10 @@ class PresentationAgentExecutor:
             logger.info("Starting presentation agent for job %s", job_id[:8])
             temp_dir = None
             try:
+                # Cooperative cancellation breakpoint #1 — entry. Abort
+                # cleanly if Stop already arrived.
+                studio_index_service.raise_if_cancelled(project_id, job_id)
+
                 # Phase 1: Generate HTML slides (writes to Supabase Storage)
                 result = presentation_agent_service.generate_presentation(
                     project_id=project_id,
@@ -120,6 +124,12 @@ class PresentationAgentExecutor:
                 if not slide_files:
                     logger.warning("No slides to export for job %s", job_id[:8])
                     return
+
+                # Cooperative cancellation breakpoint #2 — between slide
+                # generation and the Playwright screenshot phase.
+                # Screenshots can take 30-60s; if Stop arrived during the
+                # Phase 1 Claude loop, this is the right place to bail.
+                studio_index_service.raise_if_cancelled(project_id, job_id)
 
                 # Update status
                 studio_index_service.update_presentation_job(
@@ -235,9 +245,14 @@ class PresentationAgentExecutor:
                     )
                     logger.error("PPTX export failed for job %s", job_id[:8])
 
+            except studio_index_service.StudioJobCancelled:
+                logger.info("Presentation job %s cancelled by user", job_id[:8])
+                studio_index_service.purge_job_storage(project_id, job_id)
+                # Fall through to finally for temp_dir cleanup.
+                return
             except Exception as e:
                 logger.exception("Presentation agent failed for job %s", job_id[:8])
-                # Update job on error
+                # Clobber matrix drops error → cancelled writes.
                 studio_index_service.update_presentation_job(
                     project_id, job_id,
                     status="error",

--- a/backend/app/services/tool_executors/video_executor.py
+++ b/backend/app/services/tool_executors/video_executor.py
@@ -90,6 +90,12 @@ class VideoExecutor:
             """Background task to generate video."""
             logger.info("Starting video generation for job %s", job_id[:8])
             try:
+                # Cooperative cancellation breakpoint — abort if Stop
+                # already arrived. The except StudioJobCancelled below
+                # routes us to clean cleanup; the error path stays for
+                # genuine crashes.
+                studio_index_service.raise_if_cancelled(project_id, job_id)
+
                 video_service.generate_video(
                     project_id=project_id,
                     job_id=job_id,
@@ -101,9 +107,16 @@ class VideoExecutor:
                     edit_instructions=edit_instructions,
                     previous_prompt=previous_prompt
                 )
+            except studio_index_service.StudioJobCancelled:
+                logger.info("Video job %s cancelled by user", job_id[:8])
+                studio_index_service.purge_job_storage(project_id, job_id)
+                return
             except Exception as e:
                 logger.exception("Video generation failed for job %s", job_id[:8])
-                # Update job on error
+                # Update job on error. Clobber matrix in update_job will
+                # silently drop this write if a concurrent cancel already
+                # set status='cancelled', so we never overwrite a user's
+                # cancel with a misleading 'error'.
                 studio_index_service.update_video_job(
                     project_id, job_id,
                     status="error",

--- a/backend/app/services/tool_executors/website_agent_executor.py
+++ b/backend/app/services/tool_executors/website_agent_executor.py
@@ -91,6 +91,10 @@ class WebsiteAgentExecutor:
             """Background task to run the website agent."""
             logger.info("Starting website agent for job %s", job_id[:8])
             try:
+                # Cooperative cancellation breakpoint — abort cleanly if
+                # Stop already arrived.
+                studio_index_service.raise_if_cancelled(project_id, job_id)
+
                 website_agent_service.generate_website(
                     project_id=project_id,
                     source_id=source_id,
@@ -100,9 +104,13 @@ class WebsiteAgentExecutor:
                     previous_markdown=previous_markdown,
                     previous_title=previous_title
                 )
+            except studio_index_service.StudioJobCancelled:
+                logger.info("Website job %s cancelled by user", job_id[:8])
+                studio_index_service.purge_job_storage(project_id, job_id)
+                return
             except Exception as e:
                 logger.exception("Website agent failed for job %s", job_id[:8])
-                # Update job on error
+                # Clobber matrix drops error → cancelled writes.
                 studio_index_service.update_website_job(
                     project_id, job_id,
                     status="error",

--- a/backend/tests/test_studio_cancellation.py
+++ b/backend/tests/test_studio_cancellation.py
@@ -1,0 +1,322 @@
+"""
+Tests for cooperative studio-job cancellation.
+
+Covers the three layers from the design:
+  Layer 1: raise_if_cancelled trips on either signal source (in-memory
+           task_service set OR studio_jobs.status = "cancelled").
+  Layer 2a: with_failure_guard handles StudioJobCancelled distinctly from
+            generic exceptions — it does NOT call update_job (which would
+            be no-op'd by the clobber matrix anyway), DOES run storage
+            cleanup, and swallows the exception so the worker thread
+            finishes cleanly.
+  Layer 2b: update_job's status-transition matrix refuses cross-terminal
+            writes — `cancelled <-> ready`, `cancelled <-> error`,
+            and any from-terminal write. Same-status writes are allowed
+            (idempotent).
+
+The previous PR #211 test suite is restored verbatim where its semantics
+still match this implementation, with the with_failure_guard tests
+updated for the new "swallow + cleanup" cancel branch and a parametrized
+matrix test added for completeness.
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.services.background_services import task_service
+from app.services.studio_services import studio_index_service
+from app.services.studio_services.studio_index_service import StudioJobCancelled
+
+
+# task_service.is_target_cancelled is a METHOD on the singleton instance,
+# not a module-level function — so the string-path `patch("...task_service.
+# is_target_cancelled")` fails to resolve. patch.object on the singleton is
+# the correct mock for these tests.
+
+
+# ==========================================================================
+# Layer 1 — raise_if_cancelled
+# ==========================================================================
+
+
+class TestRaiseIfCancelled:
+
+    def test_no_cancel_is_noop(self):
+        """Neither signal active → raise_if_cancelled returns silently."""
+        with patch.object(
+            task_service, "is_target_cancelled", return_value=False,
+        ), patch(
+            "app.services.studio_services.studio_index_service.get_job",
+            return_value={"status": "processing"},
+        ):
+            studio_index_service.raise_if_cancelled("p1", "j1")  # no exception
+
+    def test_in_memory_set_trips(self):
+        """task_service._cancelled_tasks set hit → raises immediately."""
+        with patch.object(
+            task_service, "is_target_cancelled", return_value=True,
+        ), patch(
+            "app.services.studio_services.studio_index_service.get_job",
+            return_value={"status": "processing"},
+        ):
+            with pytest.raises(StudioJobCancelled):
+                studio_index_service.raise_if_cancelled("p1", "j1")
+
+    def test_db_status_cancelled_trips(self):
+        """In-memory set miss but DB row says cancelled → still raises.
+        Covers the cross-process case (cancel issued from a different
+        pod / after a worker restart)."""
+        with patch.object(
+            task_service, "is_target_cancelled", return_value=False,
+        ), patch(
+            "app.services.studio_services.studio_index_service.get_job",
+            return_value={"status": "cancelled"},
+        ):
+            with pytest.raises(StudioJobCancelled):
+                studio_index_service.raise_if_cancelled("p1", "j1")
+
+    def test_missing_job_is_noop(self):
+        """get_job returns None (job deleted concurrently) → don't raise.
+        The route would have returned 404 to the user; the worker should
+        finish or fail naturally rather than throwing on a phantom cancel."""
+        with patch.object(
+            task_service, "is_target_cancelled", return_value=False,
+        ), patch(
+            "app.services.studio_services.studio_index_service.get_job",
+            return_value=None,
+        ):
+            studio_index_service.raise_if_cancelled("p1", "j1")  # no exception
+
+
+# ==========================================================================
+# Layer 2a — with_failure_guard cancel branch
+# ==========================================================================
+
+
+class TestWithFailureGuardCancelBranch:
+
+    def test_studio_job_cancelled_swallowed_and_cleaned(self):
+        """When the wrapped function raises StudioJobCancelled, the guard:
+          - does NOT call update_job (the cancel route already wrote
+            status='cancelled' and the clobber matrix would drop our
+            write anyway);
+          - DOES call purge_job_storage to remove orphan partial files;
+          - SWALLOWS the exception (returns None) so the worker thread
+            ends cleanly without a stack trace in logs.
+        """
+        def cancelled_worker(*, project_id, job_id, **_):
+            raise StudioJobCancelled("user clicked stop")
+
+        wrapped = studio_index_service.with_failure_guard(cancelled_worker)
+        with patch(
+            "app.services.studio_services.studio_index_service.update_job"
+        ) as mock_update, patch(
+            "app.services.studio_services.studio_index_service.purge_job_storage"
+        ) as mock_purge:
+            result = wrapped(project_id="p1", job_id="j1")
+
+        assert result is None
+        mock_update.assert_not_called()
+        mock_purge.assert_called_once_with("p1", "j1")
+
+    def test_other_exceptions_still_flip_to_error_and_reraise(self):
+        """Non-cancellation exceptions still get the existing 'error'
+        treatment (and re-raise so task_service marks background_tasks
+        failed for observability)."""
+        def crashing_worker(*, project_id, job_id, **_):
+            raise RuntimeError("boom")
+
+        wrapped = studio_index_service.with_failure_guard(crashing_worker)
+        with patch(
+            "app.services.studio_services.studio_index_service.update_job"
+        ) as mock_update, patch(
+            "app.services.studio_services.studio_index_service.purge_job_storage"
+        ) as mock_purge:
+            with pytest.raises(RuntimeError):
+                wrapped(project_id="p1", job_id="j1")
+
+        mock_update.assert_called_once()
+        kwargs = mock_update.call_args.kwargs
+        assert kwargs.get("status") == "error"
+        # purge runs only on the cancel path, NOT on generic crashes —
+        # the studio_jobs row stays in `error` and partial files stay
+        # available for a manual retry.
+        mock_purge.assert_not_called()
+
+
+# ==========================================================================
+# Layer 2b — update_job clobber-protection matrix
+# ==========================================================================
+
+
+_FORBIDDEN_TRANSITIONS = [
+    # from_status, to_status
+    ("ready", "pending"),
+    ("ready", "processing"),
+    ("ready", "error"),
+    ("ready", "cancelled"),
+    ("error", "pending"),
+    ("error", "processing"),
+    ("error", "ready"),
+    ("error", "cancelled"),
+    ("cancelled", "pending"),
+    ("cancelled", "processing"),
+    ("cancelled", "ready"),
+    ("cancelled", "error"),
+]
+
+
+_ALLOWED_TRANSITIONS = [
+    ("pending", "pending"),
+    ("pending", "processing"),
+    ("pending", "ready"),
+    ("pending", "error"),
+    ("pending", "cancelled"),
+    ("processing", "pending"),  # allowed by matrix; in practice unused
+    ("processing", "processing"),
+    ("processing", "ready"),
+    ("processing", "error"),
+    ("processing", "cancelled"),
+    ("ready", "ready"),
+    ("error", "error"),
+    ("cancelled", "cancelled"),
+]
+
+
+class TestUpdateJobClobberMatrix:
+
+    @pytest.mark.parametrize("from_status,to_status", _FORBIDDEN_TRANSITIONS)
+    def test_forbidden_transition_drops_write(self, from_status, to_status):
+        """Each forbidden transition: the existing row is returned
+        unchanged and Supabase is never touched."""
+        existing = {
+            "id": "j1",
+            "project_id": "p1",
+            "status": from_status,
+            "tag_for_test": from_status,
+        }
+        with patch(
+            "app.services.studio_services.studio_index_service.get_job",
+            return_value=existing,
+        ), patch(
+            "app.services.studio_services.studio_index_service._get_client"
+        ) as mock_client:
+            result = studio_index_service.update_job(
+                "p1", "j1", status=to_status,
+            )
+        assert result == existing
+        mock_client.assert_not_called()
+
+    @pytest.mark.parametrize("from_status,to_status", _ALLOWED_TRANSITIONS)
+    def test_allowed_transition_writes(self, from_status, to_status):
+        """Each allowed transition: Supabase update is called."""
+        existing = {"id": "j1", "project_id": "p1", "status": from_status}
+        updated = {**existing, "status": to_status}
+
+        class _FakeResp:
+            data = [updated]
+
+        class _FakeBuilder:
+            def update(self, _payload):
+                return self
+            def eq(self, *_, **__):
+                return self
+            def execute(self):
+                return _FakeResp()
+
+        class _FakeClient:
+            def table(self, _name):
+                return _FakeBuilder()
+
+        with patch(
+            "app.services.studio_services.studio_index_service.get_job",
+            return_value=existing,
+        ), patch(
+            "app.services.studio_services.studio_index_service._get_client",
+            return_value=_FakeClient(),
+        ), patch(
+            "app.services.studio_services.studio_index_service._map_job",
+            return_value=updated,
+        ):
+            result = studio_index_service.update_job(
+                "p1", "j1", status=to_status,
+            )
+        assert result == updated
+
+    def test_pure_jobdata_update_skips_status_check(self):
+        """Updates that don't change `status` skip the matrix entirely
+        (e.g. progress message bumps mid-generation)."""
+        existing = {
+            "id": "j1", "project_id": "p1", "status": "processing",
+            "progress": "Step 1",
+        }
+
+        class _FakeResp:
+            data = [{**existing, "progress": "Step 2"}]
+
+        class _FakeBuilder:
+            def update(self, _payload):
+                return self
+            def eq(self, *_, **__):
+                return self
+            def execute(self):
+                return _FakeResp()
+
+        class _FakeClient:
+            def table(self, _name):
+                return _FakeBuilder()
+
+        with patch(
+            "app.services.studio_services.studio_index_service.get_job",
+            return_value=existing,
+        ), patch(
+            "app.services.studio_services.studio_index_service._get_client",
+            return_value=_FakeClient(),
+        ), patch(
+            "app.services.studio_services.studio_index_service._map_job",
+            side_effect=lambda r: r,
+        ):
+            result = studio_index_service.update_job(
+                "p1", "j1", progress="Step 2",
+            )
+        # The matrix was never invoked (no `status` in updates), so the
+        # write went through normally.
+        assert result.get("progress") == "Step 2"
+
+
+# ==========================================================================
+# is_job_cancelled — two-source check
+# ==========================================================================
+
+
+class TestIsJobCancelled:
+
+    def test_in_memory_short_circuits_db(self):
+        """When the in-memory hint says True, we don't pay for the DB
+        read."""
+        with patch.object(
+            task_service, "is_target_cancelled", return_value=True,
+        ), patch(
+            "app.services.studio_services.studio_index_service.get_job",
+        ) as mock_get:
+            assert studio_index_service.is_job_cancelled("p1", "j1") is True
+        mock_get.assert_not_called()
+
+    def test_db_consulted_when_memory_misses(self):
+        """In-memory miss → fall back to DB."""
+        with patch.object(
+            task_service, "is_target_cancelled", return_value=False,
+        ), patch(
+            "app.services.studio_services.studio_index_service.get_job",
+            return_value={"status": "cancelled"},
+        ):
+            assert studio_index_service.is_job_cancelled("p1", "j1") is True
+
+    def test_neither_signal(self):
+        with patch.object(
+            task_service, "is_target_cancelled", return_value=False,
+        ), patch(
+            "app.services.studio_services.studio_index_service.get_job",
+            return_value={"status": "processing"},
+        ):
+            assert studio_index_service.is_job_cancelled("p1", "j1") is False

--- a/frontend/src/components/studio/ads/AdProgressIndicator.tsx
+++ b/frontend/src/components/studio/ads/AdProgressIndicator.tsx
@@ -6,16 +6,26 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { AdJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 import { PartialImagesPreview } from '../shared/PartialImagesPreview';
 
 interface AdProgressIndicatorProps {
   currentAdJob: AdJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const AdProgressIndicator: React.FC<AdProgressIndicatorProps> = ({
   currentAdJob,
+  projectId,
 }) => {
   if (!currentAdJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentAdJob?.id) return;
+    await cancelStudioJob(projectId, currentAdJob.id);
+  };
 
   return (
     <div className="p-2 bg-primary/5 rounded-md border border-primary/20 overflow-hidden">
@@ -31,6 +41,9 @@ export const AdProgressIndicator: React.FC<AdProgressIndicatorProps> = ({
         </div>
       </div>
       <PartialImagesPreview urls={currentAdJob.partial_images} />
+    {projectId && currentAdJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/ads/AdProgressIndicator.tsx
+++ b/frontend/src/components/studio/ads/AdProgressIndicator.tsx
@@ -39,11 +39,11 @@ export const AdProgressIndicator: React.FC<AdProgressIndicatorProps> = ({
             {currentAdJob.progress || 'Starting...'}
           </p>
         </div>
+        {projectId && currentAdJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
       <PartialImagesPreview urls={currentAdJob.partial_images} />
-    {projectId && currentAdJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/audio/AudioProgressIndicator.tsx
+++ b/frontend/src/components/studio/audio/AudioProgressIndicator.tsx
@@ -7,15 +7,25 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { AudioJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface AudioProgressIndicatorProps {
   currentAudioJob: AudioJob | null;
+  /** Project the job belongs to — used to wire the cancel API. */
+  projectId?: string;
 }
 
 export const AudioProgressIndicator: React.FC<AudioProgressIndicatorProps> = ({
   currentAudioJob,
+  projectId,
 }) => {
   if (!currentAudioJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentAudioJob?.id) return;
+    await cancelStudioJob(projectId, currentAudioJob.id);
+  };
 
   return (
     <div className="p-2 bg-primary/5 rounded-md border border-primary/20 overflow-hidden">
@@ -29,6 +39,9 @@ export const AudioProgressIndicator: React.FC<AudioProgressIndicatorProps> = ({
             {currentAudioJob.progress || 'Starting...'}
           </p>
         </div>
+        {projectId && currentAudioJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/studio/blog/BlogProgressIndicator.tsx
+++ b/frontend/src/components/studio/blog/BlogProgressIndicator.tsx
@@ -55,11 +55,11 @@ export const BlogProgressIndicator: React.FC<BlogProgressIndicatorProps> = ({ cu
           )}
         </div>
         <Article size={12} className="text-indigo-500 flex-shrink-0" />
+        {projectId && currentBlogJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
       <PartialImagesPreview urls={currentBlogJob?.partial_images} className="mt-0" />
-    {projectId && currentBlogJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/blog/BlogProgressIndicator.tsx
+++ b/frontend/src/components/studio/blog/BlogProgressIndicator.tsx
@@ -7,13 +7,17 @@
 import React from 'react';
 import { Article, Spinner } from '@phosphor-icons/react';
 import type { BlogJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 import { PartialImagesPreview } from '../shared/PartialImagesPreview';
 
 interface BlogProgressIndicatorProps {
   currentBlogJob: BlogJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
-export const BlogProgressIndicator: React.FC<BlogProgressIndicatorProps> = ({ currentBlogJob }) => {
+export const BlogProgressIndicator: React.FC<BlogProgressIndicatorProps> = ({ currentBlogJob, projectId }) => {
   // Determine progress message based on job state
   const getProgressMessage = () => {
     if (!currentBlogJob) return 'Starting blog post generation...';
@@ -27,6 +31,11 @@ export const BlogProgressIndicator: React.FC<BlogProgressIndicatorProps> = ({ cu
     }
 
     return status;
+  };
+
+  const handleCancel = async () => {
+    if (!projectId || !currentBlogJob?.id) return;
+    await cancelStudioJob(projectId, currentBlogJob.id);
   };
 
   return (
@@ -48,6 +57,9 @@ export const BlogProgressIndicator: React.FC<BlogProgressIndicatorProps> = ({ cu
         <Article size={12} className="text-indigo-500 flex-shrink-0" />
       </div>
       <PartialImagesPreview urls={currentBlogJob?.partial_images} className="mt-0" />
+    {projectId && currentBlogJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/businessReport/BusinessReportProgressIndicator.tsx
+++ b/frontend/src/components/studio/businessReport/BusinessReportProgressIndicator.tsx
@@ -61,9 +61,9 @@ export const BusinessReportProgressIndicator: React.FC<BusinessReportProgressInd
         )}
       </div>
       <ChartBar size={12} className="text-teal-500 flex-shrink-0" />
-    {projectId && currentBusinessReportJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
+      {projectId && currentBusinessReportJob?.id && (
+        <StopHoldButton onConfirm={handleCancel} size="sm" />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/studio/businessReport/BusinessReportProgressIndicator.tsx
+++ b/frontend/src/components/studio/businessReport/BusinessReportProgressIndicator.tsx
@@ -7,12 +7,16 @@
 import React from 'react';
 import { ChartBar, Spinner } from '@phosphor-icons/react';
 import type { BusinessReportJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface BusinessReportProgressIndicatorProps {
   currentBusinessReportJob: BusinessReportJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
-export const BusinessReportProgressIndicator: React.FC<BusinessReportProgressIndicatorProps> = ({ currentBusinessReportJob }) => {
+export const BusinessReportProgressIndicator: React.FC<BusinessReportProgressIndicatorProps> = ({ currentBusinessReportJob, projectId }) => {
   // Determine progress message based on job state
   const getProgressMessage = () => {
     if (!currentBusinessReportJob) return 'Starting business report generation...';
@@ -36,6 +40,11 @@ export const BusinessReportProgressIndicator: React.FC<BusinessReportProgressInd
     return status;
   };
 
+  const handleCancel = async () => {
+    if (!projectId || !currentBusinessReportJob?.id) return;
+    await cancelStudioJob(projectId, currentBusinessReportJob.id);
+  };
+
   return (
     <div className="flex items-center gap-2 p-1.5 bg-teal-50 dark:bg-teal-950/30 rounded border border-teal-200 dark:border-teal-800/50">
       <div className="p-1 bg-teal-500/10 rounded">
@@ -52,6 +61,9 @@ export const BusinessReportProgressIndicator: React.FC<BusinessReportProgressInd
         )}
       </div>
       <ChartBar size={12} className="text-teal-500 flex-shrink-0" />
+    {projectId && currentBusinessReportJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/components/ComponentProgressIndicator.tsx
+++ b/frontend/src/components/studio/components/ComponentProgressIndicator.tsx
@@ -38,10 +38,10 @@ export const ComponentProgressIndicator: React.FC<ComponentProgressIndicatorProp
             {currentComponentJob.status_message || 'Starting...'}
           </p>
         </div>
+        {projectId && currentComponentJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
-    {projectId && currentComponentJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/components/ComponentProgressIndicator.tsx
+++ b/frontend/src/components/studio/components/ComponentProgressIndicator.tsx
@@ -6,15 +6,25 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { ComponentJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface ComponentProgressIndicatorProps {
   currentComponentJob: ComponentJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const ComponentProgressIndicator: React.FC<ComponentProgressIndicatorProps> = ({
   currentComponentJob,
+  projectId,
 }) => {
   if (!currentComponentJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentComponentJob?.id) return;
+    await cancelStudioJob(projectId, currentComponentJob.id);
+  };
 
   return (
     <div className="p-2 bg-blue-500/5 rounded-md border border-blue-500/20 overflow-hidden">
@@ -29,6 +39,9 @@ export const ComponentProgressIndicator: React.FC<ComponentProgressIndicatorProp
           </p>
         </div>
       </div>
+    {projectId && currentComponentJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/email/EmailProgressIndicator.tsx
+++ b/frontend/src/components/studio/email/EmailProgressIndicator.tsx
@@ -39,11 +39,11 @@ export const EmailProgressIndicator: React.FC<EmailProgressIndicatorProps> = ({
             {currentEmailJob.status_message || 'Starting...'}
           </p>
         </div>
+        {projectId && currentEmailJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
       <PartialImagesPreview urls={currentEmailJob.partial_images} />
-    {projectId && currentEmailJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/email/EmailProgressIndicator.tsx
+++ b/frontend/src/components/studio/email/EmailProgressIndicator.tsx
@@ -6,16 +6,26 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { EmailJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 import { PartialImagesPreview } from '../shared/PartialImagesPreview';
 
 interface EmailProgressIndicatorProps {
   currentEmailJob: EmailJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const EmailProgressIndicator: React.FC<EmailProgressIndicatorProps> = ({
   currentEmailJob,
+  projectId,
 }) => {
   if (!currentEmailJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentEmailJob?.id) return;
+    await cancelStudioJob(projectId, currentEmailJob.id);
+  };
 
   return (
     <div className="p-2 bg-blue-500/5 rounded-md border border-blue-500/20 overflow-hidden">
@@ -31,6 +41,9 @@ export const EmailProgressIndicator: React.FC<EmailProgressIndicatorProps> = ({
         </div>
       </div>
       <PartialImagesPreview urls={currentEmailJob.partial_images} />
+    {projectId && currentEmailJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/flashcards/FlashCardProgressIndicator.tsx
+++ b/frontend/src/components/studio/flashcards/FlashCardProgressIndicator.tsx
@@ -39,10 +39,10 @@ export const FlashCardProgressIndicator: React.FC<FlashCardProgressIndicatorProp
             {currentFlashCardJob.progress || 'Starting...'}
           </p>
         </div>
+        {projectId && currentFlashCardJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
-    {projectId && currentFlashCardJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/flashcards/FlashCardProgressIndicator.tsx
+++ b/frontend/src/components/studio/flashcards/FlashCardProgressIndicator.tsx
@@ -7,15 +7,25 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { FlashCardJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface FlashCardProgressIndicatorProps {
   currentFlashCardJob: FlashCardJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const FlashCardProgressIndicator: React.FC<FlashCardProgressIndicatorProps> = ({
   currentFlashCardJob,
+  projectId,
 }) => {
   if (!currentFlashCardJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentFlashCardJob?.id) return;
+    await cancelStudioJob(projectId, currentFlashCardJob.id);
+  };
 
   return (
     <div className="p-2 bg-purple-500/5 rounded-md border border-purple-500/20 overflow-hidden">
@@ -30,6 +40,9 @@ export const FlashCardProgressIndicator: React.FC<FlashCardProgressIndicatorProp
           </p>
         </div>
       </div>
+    {projectId && currentFlashCardJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/flow-diagrams/FlowDiagramProgressIndicator.tsx
+++ b/frontend/src/components/studio/flow-diagrams/FlowDiagramProgressIndicator.tsx
@@ -7,15 +7,25 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { FlowDiagramJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface FlowDiagramProgressIndicatorProps {
   currentFlowDiagramJob: FlowDiagramJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const FlowDiagramProgressIndicator: React.FC<FlowDiagramProgressIndicatorProps> = ({
   currentFlowDiagramJob,
+  projectId,
 }) => {
   if (!currentFlowDiagramJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentFlowDiagramJob?.id) return;
+    await cancelStudioJob(projectId, currentFlowDiagramJob.id);
+  };
 
   return (
     <div className="p-2 bg-cyan-500/5 rounded-md border border-cyan-500/20 overflow-hidden">
@@ -30,6 +40,9 @@ export const FlowDiagramProgressIndicator: React.FC<FlowDiagramProgressIndicator
           </p>
         </div>
       </div>
+    {projectId && currentFlowDiagramJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/flow-diagrams/FlowDiagramProgressIndicator.tsx
+++ b/frontend/src/components/studio/flow-diagrams/FlowDiagramProgressIndicator.tsx
@@ -39,10 +39,10 @@ export const FlowDiagramProgressIndicator: React.FC<FlowDiagramProgressIndicator
             {currentFlowDiagramJob.progress || 'Starting...'}
           </p>
         </div>
+        {projectId && currentFlowDiagramJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
-    {projectId && currentFlowDiagramJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/infographic/InfographicProgressIndicator.tsx
+++ b/frontend/src/components/studio/infographic/InfographicProgressIndicator.tsx
@@ -7,16 +7,26 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { InfographicJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 import { PartialImagesPreview } from '../shared/PartialImagesPreview';
 
 interface InfographicProgressIndicatorProps {
   currentInfographicJob: InfographicJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const InfographicProgressIndicator: React.FC<InfographicProgressIndicatorProps> = ({
   currentInfographicJob,
+  projectId,
 }) => {
   if (!currentInfographicJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentInfographicJob?.id) return;
+    await cancelStudioJob(projectId, currentInfographicJob.id);
+  };
 
   return (
     <div className="p-2 bg-amber-500/5 rounded-md border border-amber-500/20 overflow-hidden">
@@ -32,6 +42,9 @@ export const InfographicProgressIndicator: React.FC<InfographicProgressIndicator
         </div>
       </div>
       <PartialImagesPreview urls={currentInfographicJob.partial_images} />
+    {projectId && currentInfographicJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/infographic/InfographicProgressIndicator.tsx
+++ b/frontend/src/components/studio/infographic/InfographicProgressIndicator.tsx
@@ -40,11 +40,11 @@ export const InfographicProgressIndicator: React.FC<InfographicProgressIndicator
             {currentInfographicJob.progress || 'Starting...'}
           </p>
         </div>
+        {projectId && currentInfographicJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
       <PartialImagesPreview urls={currentInfographicJob.partial_images} />
-    {projectId && currentInfographicJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/marketingStrategy/MarketingStrategyProgressIndicator.tsx
+++ b/frontend/src/components/studio/marketingStrategy/MarketingStrategyProgressIndicator.tsx
@@ -45,10 +45,10 @@ export const MarketingStrategyProgressIndicator: React.FC<MarketingStrategyProgr
             {currentMarketingStrategyJob.total_sections > 0 && ` (${progress}%)`}
           </p>
         </div>
+        {projectId && currentMarketingStrategyJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
-    {projectId && currentMarketingStrategyJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/marketingStrategy/MarketingStrategyProgressIndicator.tsx
+++ b/frontend/src/components/studio/marketingStrategy/MarketingStrategyProgressIndicator.tsx
@@ -7,13 +7,18 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { MarketingStrategyJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface MarketingStrategyProgressIndicatorProps {
   currentMarketingStrategyJob: MarketingStrategyJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const MarketingStrategyProgressIndicator: React.FC<MarketingStrategyProgressIndicatorProps> = ({
   currentMarketingStrategyJob,
+  projectId,
 }) => {
   if (!currentMarketingStrategyJob) return null;
 
@@ -21,6 +26,11 @@ export const MarketingStrategyProgressIndicator: React.FC<MarketingStrategyProgr
   const progress = currentMarketingStrategyJob.total_sections > 0
     ? Math.round((currentMarketingStrategyJob.sections_written / currentMarketingStrategyJob.total_sections) * 100)
     : 0;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentMarketingStrategyJob?.id) return;
+    await cancelStudioJob(projectId, currentMarketingStrategyJob.id);
+  };
 
   return (
     <div className="p-2 bg-emerald-500/5 rounded-md border border-emerald-500/20 overflow-hidden">
@@ -36,6 +46,9 @@ export const MarketingStrategyProgressIndicator: React.FC<MarketingStrategyProgr
           </p>
         </div>
       </div>
+    {projectId && currentMarketingStrategyJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/mindmap/MindMapProgressIndicator.tsx
+++ b/frontend/src/components/studio/mindmap/MindMapProgressIndicator.tsx
@@ -39,10 +39,10 @@ export const MindMapProgressIndicator: React.FC<MindMapProgressIndicatorProps> =
             {currentMindMapJob.progress || 'Starting...'}
           </p>
         </div>
+        {projectId && currentMindMapJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
-    {projectId && currentMindMapJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/mindmap/MindMapProgressIndicator.tsx
+++ b/frontend/src/components/studio/mindmap/MindMapProgressIndicator.tsx
@@ -7,15 +7,25 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { MindMapJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface MindMapProgressIndicatorProps {
   currentMindMapJob: MindMapJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const MindMapProgressIndicator: React.FC<MindMapProgressIndicatorProps> = ({
   currentMindMapJob,
+  projectId,
 }) => {
   if (!currentMindMapJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentMindMapJob?.id) return;
+    await cancelStudioJob(projectId, currentMindMapJob.id);
+  };
 
   return (
     <div className="p-2 bg-blue-500/5 rounded-md border border-blue-500/20 overflow-hidden">
@@ -30,6 +40,9 @@ export const MindMapProgressIndicator: React.FC<MindMapProgressIndicatorProps> =
           </p>
         </div>
       </div>
+    {projectId && currentMindMapJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/prd/PRDProgressIndicator.tsx
+++ b/frontend/src/components/studio/prd/PRDProgressIndicator.tsx
@@ -45,10 +45,10 @@ export const PRDProgressIndicator: React.FC<PRDProgressIndicatorProps> = ({
             {currentPRDJob.total_sections > 0 && ` (${progress}%)`}
           </p>
         </div>
+        {projectId && currentPRDJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
-    {projectId && currentPRDJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/prd/PRDProgressIndicator.tsx
+++ b/frontend/src/components/studio/prd/PRDProgressIndicator.tsx
@@ -7,13 +7,18 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { PRDJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface PRDProgressIndicatorProps {
   currentPRDJob: PRDJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const PRDProgressIndicator: React.FC<PRDProgressIndicatorProps> = ({
   currentPRDJob,
+  projectId,
 }) => {
   if (!currentPRDJob) return null;
 
@@ -21,6 +26,11 @@ export const PRDProgressIndicator: React.FC<PRDProgressIndicatorProps> = ({
   const progress = currentPRDJob.total_sections > 0
     ? Math.round((currentPRDJob.sections_written / currentPRDJob.total_sections) * 100)
     : 0;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentPRDJob?.id) return;
+    await cancelStudioJob(projectId, currentPRDJob.id);
+  };
 
   return (
     <div className="p-2 bg-amber-500/5 rounded-md border border-amber-500/20 overflow-hidden">
@@ -36,6 +46,9 @@ export const PRDProgressIndicator: React.FC<PRDProgressIndicatorProps> = ({
           </p>
         </div>
       </div>
+    {projectId && currentPRDJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/presentations/PresentationProgressIndicator.tsx
+++ b/frontend/src/components/studio/presentations/PresentationProgressIndicator.tsx
@@ -44,10 +44,10 @@ export const PresentationProgressIndicator: React.FC<PresentationProgressIndicat
             {progressText}
           </p>
         </div>
+        {projectId && currentPresentationJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
-    {projectId && currentPresentationJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/presentations/PresentationProgressIndicator.tsx
+++ b/frontend/src/components/studio/presentations/PresentationProgressIndicator.tsx
@@ -7,13 +7,18 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { PresentationJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface PresentationProgressIndicatorProps {
   currentPresentationJob: PresentationJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const PresentationProgressIndicator: React.FC<PresentationProgressIndicatorProps> = ({
   currentPresentationJob,
+  projectId,
 }) => {
   if (!currentPresentationJob) return null;
 
@@ -21,6 +26,11 @@ export const PresentationProgressIndicator: React.FC<PresentationProgressIndicat
   const progressText = currentPresentationJob.slides_created > 0
     ? `${currentPresentationJob.slides_created}/${currentPresentationJob.total_slides || '?'} slides`
     : currentPresentationJob.status_message || 'Starting...';
+
+  const handleCancel = async () => {
+    if (!projectId || !currentPresentationJob?.id) return;
+    await cancelStudioJob(projectId, currentPresentationJob.id);
+  };
 
   return (
     <div className="p-2 bg-amber-500/5 rounded-md border border-amber-500/20">
@@ -35,6 +45,9 @@ export const PresentationProgressIndicator: React.FC<PresentationProgressIndicat
           </p>
         </div>
       </div>
+    {projectId && currentPresentationJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/quiz/QuizProgressIndicator.tsx
+++ b/frontend/src/components/studio/quiz/QuizProgressIndicator.tsx
@@ -7,15 +7,25 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { QuizJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface QuizProgressIndicatorProps {
   currentQuizJob: QuizJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const QuizProgressIndicator: React.FC<QuizProgressIndicatorProps> = ({
   currentQuizJob,
+  projectId,
 }) => {
   if (!currentQuizJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentQuizJob?.id) return;
+    await cancelStudioJob(projectId, currentQuizJob.id);
+  };
 
   return (
     <div className="p-2 bg-orange-500/5 rounded-md border border-orange-500/20 overflow-hidden">
@@ -30,6 +40,9 @@ export const QuizProgressIndicator: React.FC<QuizProgressIndicatorProps> = ({
           </p>
         </div>
       </div>
+    {projectId && currentQuizJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/quiz/QuizProgressIndicator.tsx
+++ b/frontend/src/components/studio/quiz/QuizProgressIndicator.tsx
@@ -39,10 +39,10 @@ export const QuizProgressIndicator: React.FC<QuizProgressIndicatorProps> = ({
             {currentQuizJob.progress || 'Starting...'}
           </p>
         </div>
+        {projectId && currentQuizJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
-    {projectId && currentQuizJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/sections/AdSection.tsx
+++ b/frontend/src/components/studio/sections/AdSection.tsx
@@ -53,7 +53,7 @@ export const AdSection: React.FC = () => {
       <ConfigErrorBanner message={configError} />
 
       {isGeneratingAd && (
-        <AdProgressIndicator currentAdJob={currentAdJob} />
+        <AdProgressIndicator currentAdJob={currentAdJob} projectId={projectId} />
       )}
 
       {hasAdSignal && savedAdJobs.map((job, i) => (

--- a/frontend/src/components/studio/sections/AudioSection.tsx
+++ b/frontend/src/components/studio/sections/AudioSection.tsx
@@ -73,7 +73,7 @@ export const AudioSection: React.FC = () => {
       />
 
       {isGeneratingAudio && (
-        <AudioProgressIndicator currentAudioJob={currentAudioJob} />
+        <AudioProgressIndicator currentAudioJob={currentAudioJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/BlogSection.tsx
+++ b/frontend/src/components/studio/sections/BlogSection.tsx
@@ -52,7 +52,7 @@ export const BlogSection: React.FC = () => {
       <ConfigErrorBanner message={configError} />
 
       {isGeneratingBlog && (
-        <BlogProgressIndicator currentBlogJob={currentBlogJob} />
+        <BlogProgressIndicator currentBlogJob={currentBlogJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/BusinessReportSection.tsx
+++ b/frontend/src/components/studio/sections/BusinessReportSection.tsx
@@ -48,7 +48,7 @@ export const BusinessReportSection: React.FC = () => {
   return (
     <>
       {isGeneratingBusinessReport && (
-        <BusinessReportProgressIndicator currentBusinessReportJob={currentBusinessReportJob} />
+        <BusinessReportProgressIndicator currentBusinessReportJob={currentBusinessReportJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/ComponentSection.tsx
+++ b/frontend/src/components/studio/sections/ComponentSection.tsx
@@ -46,7 +46,7 @@ export const ComponentSection: React.FC = () => {
   return (
     <>
       {isGeneratingComponents && (
-        <ComponentProgressIndicator currentComponentJob={currentComponentJob} />
+        <ComponentProgressIndicator currentComponentJob={currentComponentJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/EmailSection.tsx
+++ b/frontend/src/components/studio/sections/EmailSection.tsx
@@ -51,7 +51,7 @@ export const EmailSection: React.FC = () => {
       <ConfigErrorBanner message={configError} />
 
       {isGeneratingEmail && (
-        <EmailProgressIndicator currentEmailJob={currentEmailJob} />
+        <EmailProgressIndicator currentEmailJob={currentEmailJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/FlashCardSection.tsx
+++ b/frontend/src/components/studio/sections/FlashCardSection.tsx
@@ -47,7 +47,7 @@ export const FlashCardSection: React.FC = () => {
   return (
     <>
       {isGeneratingFlashCards && (
-        <FlashCardProgressIndicator currentFlashCardJob={currentFlashCardJob} />
+        <FlashCardProgressIndicator currentFlashCardJob={currentFlashCardJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/FlowDiagramSection.tsx
+++ b/frontend/src/components/studio/sections/FlowDiagramSection.tsx
@@ -51,7 +51,7 @@ export const FlowDiagramSection: React.FC = () => {
       <ConfigErrorBanner message={configError} />
 
       {isGeneratingFlowDiagram && (
-        <FlowDiagramProgressIndicator currentFlowDiagramJob={currentFlowDiagramJob} />
+        <FlowDiagramProgressIndicator currentFlowDiagramJob={currentFlowDiagramJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/InfographicSection.tsx
+++ b/frontend/src/components/studio/sections/InfographicSection.tsx
@@ -51,7 +51,7 @@ export const InfographicSection: React.FC = () => {
       <ConfigErrorBanner message={configError} />
 
       {isGeneratingInfographic && (
-        <InfographicProgressIndicator currentInfographicJob={currentInfographicJob} />
+        <InfographicProgressIndicator currentInfographicJob={currentInfographicJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/MarketingStrategySection.tsx
+++ b/frontend/src/components/studio/sections/MarketingStrategySection.tsx
@@ -47,7 +47,7 @@ export const MarketingStrategySection: React.FC = () => {
   return (
     <>
       {isGeneratingMarketingStrategy && (
-        <MarketingStrategyProgressIndicator currentMarketingStrategyJob={currentMarketingStrategyJob} />
+        <MarketingStrategyProgressIndicator currentMarketingStrategyJob={currentMarketingStrategyJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/MindMapSection.tsx
+++ b/frontend/src/components/studio/sections/MindMapSection.tsx
@@ -47,7 +47,7 @@ export const MindMapSection: React.FC = () => {
   return (
     <>
       {isGeneratingMindMap && (
-        <MindMapProgressIndicator currentMindMapJob={currentMindMapJob} />
+        <MindMapProgressIndicator currentMindMapJob={currentMindMapJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/PRDSection.tsx
+++ b/frontend/src/components/studio/sections/PRDSection.tsx
@@ -47,7 +47,7 @@ export const PRDSection: React.FC = () => {
   return (
     <>
       {isGeneratingPRD && (
-        <PRDProgressIndicator currentPRDJob={currentPRDJob} />
+        <PRDProgressIndicator currentPRDJob={currentPRDJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/PresentationSection.tsx
+++ b/frontend/src/components/studio/sections/PresentationSection.tsx
@@ -52,7 +52,7 @@ export const PresentationSection: React.FC = () => {
       <ConfigErrorBanner message={configError} />
 
       {isGeneratingPresentation && (
-        <PresentationProgressIndicator currentPresentationJob={currentPresentationJob} />
+        <PresentationProgressIndicator currentPresentationJob={currentPresentationJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/QuizSection.tsx
+++ b/frontend/src/components/studio/sections/QuizSection.tsx
@@ -48,7 +48,7 @@ export const QuizSection: React.FC = () => {
   return (
     <>
       {isGeneratingQuiz && (
-        <QuizProgressIndicator currentQuizJob={currentQuizJob} />
+        <QuizProgressIndicator currentQuizJob={currentQuizJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/SocialSection.tsx
+++ b/frontend/src/components/studio/sections/SocialSection.tsx
@@ -52,7 +52,7 @@ export const SocialSection: React.FC = () => {
       <ConfigErrorBanner message={configError} />
 
       {isGeneratingSocialPosts && (
-        <SocialPostProgressIndicator currentSocialPostJob={currentSocialPostJob} />
+        <SocialPostProgressIndicator currentSocialPostJob={currentSocialPostJob} projectId={projectId} />
       )}
 
       {hasSocialSignal && savedSocialPostJobs.map((job) => (

--- a/frontend/src/components/studio/sections/VideoSection.tsx
+++ b/frontend/src/components/studio/sections/VideoSection.tsx
@@ -48,7 +48,7 @@ export const VideoSection: React.FC = () => {
   return (
     <>
       {isGeneratingVideo && (
-        <VideoProgressIndicator currentVideoJob={currentVideoJob} />
+        <VideoProgressIndicator currentVideoJob={currentVideoJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/WebsiteSection.tsx
+++ b/frontend/src/components/studio/sections/WebsiteSection.tsx
@@ -52,7 +52,7 @@ export const WebsiteSection: React.FC = () => {
       <ConfigErrorBanner message={configError} />
 
       {isGeneratingWebsite && (
-        <WebsiteProgressIndicator currentWebsiteJob={currentWebsiteJob} />
+        <WebsiteProgressIndicator currentWebsiteJob={currentWebsiteJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/sections/WireframeSection.tsx
+++ b/frontend/src/components/studio/sections/WireframeSection.tsx
@@ -51,7 +51,7 @@ export const WireframeSection: React.FC = () => {
       <ConfigErrorBanner message={configError} />
 
       {isGeneratingWireframe && (
-        <WireframeProgressIndicator currentWireframeJob={currentWireframeJob} />
+        <WireframeProgressIndicator currentWireframeJob={currentWireframeJob} projectId={projectId} />
       )}
 
       {filteredJobs.map((job) => (

--- a/frontend/src/components/studio/shared/CancelledJobRow.tsx
+++ b/frontend/src/components/studio/shared/CancelledJobRow.tsx
@@ -1,0 +1,118 @@
+/**
+ * CancelledJobRow — shared row component for studio jobs the user
+ * cancelled mid-generation.
+ *
+ * The previous Stop attempt deleted cancelled jobs from the output tab
+ * (a server-side filter dropping rows with status='cancelled'). Users
+ * couldn't tell whether they'd cancelled or whether the product had
+ * silently failed, and there was no path back to a re-run. That UX
+ * regression was the main reason for the PR #221 revert.
+ *
+ * This row is the antidote: cancelled jobs stay visible in the list,
+ * with an editorial amber treatment (NOT red — red is reserved for
+ * `error`) and a one-click "Generate again" affordance that re-triggers
+ * the same agent with the same inputs.
+ */
+import React from 'react';
+import { XCircle, ArrowsClockwise } from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
+
+interface CancelledJobLike {
+  id: string;
+  /** ISO timestamp when the cancel landed (stored in job_data.cancelled_at). */
+  cancelled_at?: string | null;
+  /** Falls back to completed_at or updated_at if cancelled_at isn't set. */
+  completed_at?: string | null;
+  updated_at?: string | null;
+  /** Title / direction the user gave so the row says what got cancelled. */
+  direction?: string | null;
+  source_name?: string | null;
+}
+
+export interface CancelledJobRowProps {
+  job: CancelledJobLike;
+  /** Triggers a fresh generation with the same inputs. The hook owning the
+   *  agent's state should re-call its start handler with the cancelled
+   *  job's `direction` / `source_id` etc. */
+  onGenerateAgain: () => void;
+  /** Optional tail content (e.g. an iconographic source preview). */
+  trailing?: React.ReactNode;
+  className?: string;
+}
+
+const formatTime = (iso?: string | null): string => {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+};
+
+export const CancelledJobRow: React.FC<CancelledJobRowProps> = ({
+  job,
+  onGenerateAgain,
+  trailing,
+  className,
+}) => {
+  const stamp =
+    job.cancelled_at || job.completed_at || job.updated_at || null;
+  const time = formatTime(stamp);
+  const subject =
+    (job.direction && job.direction.trim()) ||
+    job.source_name ||
+    'Untitled generation';
+
+  return (
+    <div
+      role="listitem"
+      className={cn(
+        'group relative flex items-start gap-3 rounded-lg border border-amber-200/70 bg-amber-50/40 px-3 py-2.5',
+        'transition-colors hover:bg-amber-50',
+        className,
+      )}
+    >
+      {/* 3px amber stripe down the left edge. Visually anchors the row
+          as "this was your decision" rather than a system error. */}
+      <span
+        aria-hidden
+        className="absolute inset-y-1.5 left-0 w-[3px] rounded-r-full bg-amber-500"
+      />
+
+      <XCircle
+        size={20}
+        weight="fill"
+        className="mt-0.5 flex-shrink-0 text-amber-600"
+        aria-hidden
+      />
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-stone-800" title={subject}>
+          {subject}
+        </p>
+        <p className="mt-0.5 text-[11px] font-serif italic text-stone-600">
+          Cancelled{time ? ` · ${time}` : ''}
+        </p>
+      </div>
+
+      <div className="flex flex-shrink-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={onGenerateAgain}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium',
+            'text-amber-700 transition-colors hover:bg-amber-100 hover:text-amber-900',
+            'focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-amber-50',
+          )}
+          aria-label={`Generate again: ${subject}`}
+        >
+          <ArrowsClockwise size={12} weight="bold" />
+          Generate again
+        </button>
+        {trailing}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/studio/shared/StopHoldButton.tsx
+++ b/frontend/src/components/studio/shared/StopHoldButton.tsx
@@ -1,0 +1,201 @@
+/**
+ * StopHoldButton — type-"stop"-to-confirm cancellation control.
+ *
+ * The previous studio Stop button (PR #211) shipped as a small icon-only
+ * button that swapped to red on hover. Users tapped it accidentally; even
+ * after a window.confirm() was added (PR #219) muscle memory bypassed it.
+ * Net: jobs disappeared silently, the PR was reverted.
+ *
+ * This control is structurally incompatible with accidental clicks. The
+ * Stop icon opens a shadcn Dialog (NOT window.confirm) where the user
+ * must type the literal word "stop" to enable the destructive action.
+ * The Confirm button stays disabled until the input matches.
+ *
+ *   [ ◯ Stop ] → click → modal: "Type **stop** to confirm" → submit
+ *
+ * Editorial language for the modal copy reuses the rest of the app's
+ * voice (italic font-serif headline, calm body copy reassuring the user
+ * that re-running is one click). Errors during the cancel POST surface
+ * as an inline pill inside the modal so the user can retry without
+ * re-typing.
+ */
+import React, { useCallback, useState } from 'react';
+import { Stop, CircleNotch, Warning } from '@phosphor-icons/react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+export interface StopHoldButtonProps {
+  /**
+   * Fired when the user types "stop" and clicks Confirm. Should perform
+   * the cancel API call. May throw or reject — the modal will surface
+   * the error inline and stay open so the user can retry.
+   */
+  onConfirm: () => Promise<void> | void;
+  /** Optional disabled state (e.g. while the parent is still booting). */
+  disabled?: boolean;
+  /** Tooltip / aria-label override. Default "Stop generation". */
+  label?: string;
+  /** Compact/full size — controls the icon button dimensions. */
+  size?: 'sm' | 'md';
+}
+
+const CONFIRM_TOKEN = 'stop';
+
+export const StopHoldButton: React.FC<StopHoldButtonProps> = ({
+  onConfirm,
+  disabled = false,
+  label = 'Stop generation',
+  size = 'md',
+}) => {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset modal state on close so reopening starts fresh. Done via the
+  // open-handler, NOT a useEffect — eslint flags `setState` calls inside
+  // effects, and the open-handler is the only place `open` flips.
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (submitting) return; // user pressed Esc mid-cancel; ignore
+      if (!next) {
+        setValue('');
+        setError(null);
+      }
+      setOpen(next);
+    },
+    [submitting],
+  );
+
+  const canConfirm = value.trim().toLowerCase() === CONFIRM_TOKEN && !submitting;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canConfirm) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm();
+      setOpen(false);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Could not cancel — try again';
+      setError(message);
+      setSubmitting(false);
+    }
+  }, [canConfirm, onConfirm]);
+
+  const dimensions = size === 'sm' ? 'h-7 w-7' : 'h-8 w-8';
+  const iconSize = size === 'sm' ? 14 : 16;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        aria-label={label}
+        title={label}
+        className={cn(
+          'inline-flex flex-shrink-0 items-center justify-center rounded-md',
+          dimensions,
+          'border border-stone-200 bg-white text-stone-500',
+          'transition-colors hover:border-amber-300 hover:bg-amber-50 hover:text-amber-700',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-white',
+          'disabled:cursor-not-allowed disabled:opacity-40',
+        )}
+      >
+        <Stop size={iconSize} weight="fill" />
+      </button>
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-[440px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 font-serif italic text-stone-900">
+              <Warning size={18} weight="fill" className="text-amber-600" />
+              Cancel this generation?
+            </DialogTitle>
+            <DialogDescription className="text-stone-600">
+              We can&apos;t recover the in-flight work. You can re-run with the
+              same inputs in one click after.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-2 py-2">
+            <label
+              htmlFor="stop-confirm-input"
+              className="text-xs font-medium text-stone-700"
+            >
+              Type <span className="font-mono font-semibold text-amber-700">stop</span> to confirm
+            </label>
+            <Input
+              id="stop-confirm-input"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && canConfirm) {
+                  e.preventDefault();
+                  handleSubmit();
+                }
+              }}
+              placeholder="stop"
+              autoFocus
+              disabled={submitting}
+              className="font-mono"
+              aria-invalid={!!error}
+            />
+            {error && (
+              <p
+                role="alert"
+                className="mt-1 inline-flex items-center gap-1.5 rounded-md border border-rose-200 bg-rose-50/70 px-2 py-1 text-[11px] font-medium text-rose-700"
+              >
+                <Warning size={11} weight="fill" />
+                {error}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setOpen(false)}
+              disabled={submitting}
+            >
+              Keep going
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canConfirm}
+              className={cn(
+                'bg-amber-600 text-white hover:bg-amber-700',
+                submitting && 'cursor-wait',
+              )}
+            >
+              {submitting ? (
+                <>
+                  <CircleNotch size={14} className="mr-1.5 animate-spin" />
+                  Cancelling…
+                </>
+              ) : (
+                <>
+                  <Stop size={14} weight="fill" className="mr-1.5" />
+                  Cancel generation
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/frontend/src/components/studio/social/SocialPostProgressIndicator.tsx
+++ b/frontend/src/components/studio/social/SocialPostProgressIndicator.tsx
@@ -40,11 +40,11 @@ export const SocialPostProgressIndicator: React.FC<SocialPostProgressIndicatorPr
             {currentSocialPostJob.progress || 'Starting...'}
           </p>
         </div>
+        {projectId && currentSocialPostJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
       <PartialImagesPreview urls={currentSocialPostJob.partial_images} />
-    {projectId && currentSocialPostJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/social/SocialPostProgressIndicator.tsx
+++ b/frontend/src/components/studio/social/SocialPostProgressIndicator.tsx
@@ -7,16 +7,26 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { SocialPostJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 import { PartialImagesPreview } from '../shared/PartialImagesPreview';
 
 interface SocialPostProgressIndicatorProps {
   currentSocialPostJob: SocialPostJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const SocialPostProgressIndicator: React.FC<SocialPostProgressIndicatorProps> = ({
   currentSocialPostJob,
+  projectId,
 }) => {
   if (!currentSocialPostJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentSocialPostJob?.id) return;
+    await cancelStudioJob(projectId, currentSocialPostJob.id);
+  };
 
   return (
     <div className="p-2 bg-cyan-500/5 rounded-md border border-cyan-500/20 overflow-hidden">
@@ -32,6 +42,9 @@ export const SocialPostProgressIndicator: React.FC<SocialPostProgressIndicatorPr
         </div>
       </div>
       <PartialImagesPreview urls={currentSocialPostJob.partial_images} />
+    {projectId && currentSocialPostJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/video/VideoProgressIndicator.tsx
+++ b/frontend/src/components/studio/video/VideoProgressIndicator.tsx
@@ -45,10 +45,10 @@ export const VideoProgressIndicator: React.FC<VideoProgressIndicatorProps> = ({
             </p>
           )}
         </div>
+        {projectId && currentVideoJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
-    {projectId && currentVideoJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/video/VideoProgressIndicator.tsx
+++ b/frontend/src/components/studio/video/VideoProgressIndicator.tsx
@@ -8,15 +8,25 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { VideoJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface VideoProgressIndicatorProps {
   currentVideoJob: VideoJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const VideoProgressIndicator: React.FC<VideoProgressIndicatorProps> = ({
   currentVideoJob,
+  projectId,
 }) => {
   if (!currentVideoJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentVideoJob?.id) return;
+    await cancelStudioJob(projectId, currentVideoJob.id);
+  };
 
   return (
     <div className="p-2 bg-orange-500/5 rounded-md border border-orange-500/20">
@@ -36,6 +46,9 @@ export const VideoProgressIndicator: React.FC<VideoProgressIndicatorProps> = ({
           )}
         </div>
       </div>
+    {projectId && currentVideoJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/website/WebsiteProgressIndicator.tsx
+++ b/frontend/src/components/studio/website/WebsiteProgressIndicator.tsx
@@ -40,11 +40,11 @@ export const WebsiteProgressIndicator: React.FC<WebsiteProgressIndicatorProps> =
             {currentWebsiteJob.status_message || 'Starting...'}
           </p>
         </div>
+        {projectId && currentWebsiteJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
       <PartialImagesPreview urls={currentWebsiteJob.partial_images} />
-    {projectId && currentWebsiteJob?.id && (
-      <StopHoldButton onConfirm={handleCancel} size="sm" />
-    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/website/WebsiteProgressIndicator.tsx
+++ b/frontend/src/components/studio/website/WebsiteProgressIndicator.tsx
@@ -7,16 +7,26 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { WebsiteJob } from '@/lib/api/studio';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 import { PartialImagesPreview } from '../shared/PartialImagesPreview';
 
 interface WebsiteProgressIndicatorProps {
   currentWebsiteJob: WebsiteJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const WebsiteProgressIndicator: React.FC<WebsiteProgressIndicatorProps> = ({
   currentWebsiteJob,
+  projectId,
 }) => {
   if (!currentWebsiteJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentWebsiteJob?.id) return;
+    await cancelStudioJob(projectId, currentWebsiteJob.id);
+  };
 
   return (
     <div className="p-2 bg-purple-500/5 rounded-md border border-purple-500/20">
@@ -32,6 +42,9 @@ export const WebsiteProgressIndicator: React.FC<WebsiteProgressIndicatorProps> =
         </div>
       </div>
       <PartialImagesPreview urls={currentWebsiteJob.partial_images} />
+    {projectId && currentWebsiteJob?.id && (
+      <StopHoldButton onConfirm={handleCancel} size="sm" />
+    )}
     </div>
   );
 };

--- a/frontend/src/components/studio/wireframes/WireframeProgressIndicator.tsx
+++ b/frontend/src/components/studio/wireframes/WireframeProgressIndicator.tsx
@@ -7,15 +7,25 @@
 import React from 'react';
 import { SpinnerGap } from '@phosphor-icons/react';
 import type { WireframeJob } from '@/lib/api/studio/wireframes';
+import { cancelStudioJob } from '@/lib/api/studio';
+import { StopHoldButton } from '../shared/StopHoldButton';
 
 interface WireframeProgressIndicatorProps {
   currentWireframeJob: WireframeJob | null;
+  /** Project the job belongs to — wires the cancel API. */
+  projectId?: string;
 }
 
 export const WireframeProgressIndicator: React.FC<WireframeProgressIndicatorProps> = ({
   currentWireframeJob,
+  projectId,
 }) => {
   if (!currentWireframeJob) return null;
+
+  const handleCancel = async () => {
+    if (!projectId || !currentWireframeJob?.id) return;
+    await cancelStudioJob(projectId, currentWireframeJob.id);
+  };
 
   return (
     <div className="p-2 bg-purple-500/5 rounded-md border border-purple-500/20 overflow-hidden">
@@ -29,6 +39,9 @@ export const WireframeProgressIndicator: React.FC<WireframeProgressIndicatorProp
             {currentWireframeJob.progress || 'Starting...'}
           </p>
         </div>
+        {projectId && currentWireframeJob?.id && (
+          <StopHoldButton onConfirm={handleCancel} size="sm" />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/lib/api/studio/ads.ts
+++ b/frontend/src/lib/api/studio/ads.ts
@@ -170,7 +170,7 @@ export const adsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/audio.ts
+++ b/frontend/src/lib/api/studio/audio.ts
@@ -195,7 +195,7 @@ export const audioAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/blogs.ts
+++ b/frontend/src/lib/api/studio/blogs.ts
@@ -275,7 +275,7 @@ export const blogsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/businessReports.ts
+++ b/frontend/src/lib/api/studio/businessReports.ts
@@ -292,7 +292,7 @@ export const businessReportsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/components.ts
+++ b/frontend/src/lib/api/studio/components.ts
@@ -201,7 +201,7 @@ export const componentsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/emails.ts
+++ b/frontend/src/lib/api/studio/emails.ts
@@ -236,7 +236,7 @@ export const emailsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/flash-cards.ts
+++ b/frontend/src/lib/api/studio/flash-cards.ts
@@ -178,7 +178,7 @@ export const flashCardsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/flow-diagrams.ts
+++ b/frontend/src/lib/api/studio/flow-diagrams.ts
@@ -179,7 +179,7 @@ export const flowDiagramsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/index.ts
+++ b/frontend/src/lib/api/studio/index.ts
@@ -13,7 +13,41 @@ import { createLogger } from '@/lib/logger';
 const log = createLogger('studio-api');
 
 // Shared types
-export type JobStatus = 'pending' | 'processing' | 'ready' | 'error';
+//
+// `'cancelled'` is the user-initiated terminal state set by the cancel
+// route (POST /projects/<id>/studio/jobs/<id>/cancel). Every per-agent
+// pollJobStatus must treat it as terminal so the polling loop exits and
+// the section UI flips to the CancelledJobRow affordance with a
+// "Generate again" action.
+export type JobStatus = 'pending' | 'processing' | 'ready' | 'error' | 'cancelled';
+
+/** Response shape from the studio cancel route. */
+export interface CancelStudioJobResponse {
+  success: boolean;
+  /** Final status the row landed on. `'ready'` means the worker beat
+   *  the cancel and the result was preserved. */
+  status: JobStatus;
+  /** Set when the worker finished `ready` after the user clicked Stop
+   *  but before this route ran — UI should roll its optimistic
+   *  "cancelling" state back and surface a "kept the result" pill. */
+  late?: boolean;
+  job?: Record<string, unknown>;
+  error?: string;
+}
+
+/**
+ * Cancel an in-flight studio generation. Race-safe — see
+ * `backend/app/api/studio/job_actions.py` for the four status branches.
+ */
+export async function cancelStudioJob(
+  projectId: string,
+  jobId: string,
+): Promise<CancelStudioJobResponse> {
+  const response = await axios.post<CancelStudioJobResponse>(
+    `${API_BASE_URL}/projects/${projectId}/studio/jobs/${jobId}/cancel`,
+  );
+  return response.data;
+}
 
 /**
  * Response for API status checks (TTS, Gemini, etc.)

--- a/frontend/src/lib/api/studio/infographics.ts
+++ b/frontend/src/lib/api/studio/infographics.ts
@@ -198,7 +198,7 @@ export const infographicsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/marketingStrategies.ts
+++ b/frontend/src/lib/api/studio/marketingStrategies.ts
@@ -224,7 +224,7 @@ export const marketingStrategiesAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/mind-maps.ts
+++ b/frontend/src/lib/api/studio/mind-maps.ts
@@ -180,7 +180,7 @@ export const mindMapsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/prds.ts
+++ b/frontend/src/lib/api/studio/prds.ts
@@ -224,7 +224,7 @@ export const prdsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/presentations.ts
+++ b/frontend/src/lib/api/studio/presentations.ts
@@ -296,7 +296,7 @@ export const presentationsAPI = {
         return job;
       }
 
-      if (job.status === 'error') {
+      if (job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/quizzes.ts
+++ b/frontend/src/lib/api/studio/quizzes.ts
@@ -190,7 +190,7 @@ export const quizzesAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/social-posts.ts
+++ b/frontend/src/lib/api/studio/social-posts.ts
@@ -208,7 +208,7 @@ export const socialPostsAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/videos.ts
+++ b/frontend/src/lib/api/studio/videos.ts
@@ -211,7 +211,7 @@ export const videosAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/websites.ts
+++ b/frontend/src/lib/api/studio/websites.ts
@@ -243,7 +243,7 @@ export const websitesAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 

--- a/frontend/src/lib/api/studio/wireframes.ts
+++ b/frontend/src/lib/api/studio/wireframes.ts
@@ -192,7 +192,7 @@ export const wireframesAPI = {
         onProgress(job);
       }
 
-      if (job.status === 'ready' || job.status === 'error') {
+      if (job.status === 'ready' || job.status === 'error' || job.status === 'cancelled') {
         return job;
       }
 


### PR DESCRIPTION
Re-introduces studio cancellation that was reverted in #221, with the UX failure mode addressed at the design level rather than patched after the fact.

## Why the previous attempt (#211) was reverted

Three-layer cooperative cancellation was technically sound. The UX killed it:

- Tiny icon-only Stop button in the dense `ActiveTasksBar` swap-to-red on hover → users accidentally clicked it
- `window.confirm()` dialog (PR #219) was bypassed via muscle memory
- Cancelled rows were filtered out of the output tab → silent loss of work → support tickets → revert

## What's different this time

| Failure mode | New design |
|---|---|
| Accidental click on tiny icon | **Type-`stop`-to-confirm** shadcn `<Dialog>` — Confirm button stays disabled until input matches. Physically incompatible with click-throughs. |
| Dense bar = footgun | **Per-section placement only** — Stop sits inside each agent's ProgressIndicator. ActiveTasksBar stays passive. |
| Cancelled = silently deleted | **Cancelled jobs stay visible** — zero filters drop \`status='cancelled'\` rows. New `CancelledJobRow` shared component (amber stripe, italic serif, \"Generate again\"). |
| Red destructive UI | **Editorial amber** — red is reserved for \`error\` (something broke). Cancelled is \"user chose this\". |

## Architecture

```
USER → modal: type \"stop\" → confirm
  ↓ POST /api/v1/projects/<pid>/studio/jobs/<jid>/cancel
job_actions.cancel_studio_job (4 status branches: 200 cancelled / 200 ready+late / 409 error / 200 idempotent)
  ↓ task_service.cancel_tasks_for_target  (in-memory hint)
  ↓ studio_index_service.update_job(status='cancelled')
      ← clobber matrix: refuses cross-terminal writes

WORKER (already running)
  ↓ raise_if_cancelled at agent breakpoints
  ↓ raises StudioJobCancelled
with_failure_guard catches Cancelled FIRST → purge_job_storage → swallow
```

The DB row's \`status\` is the single source of truth. The clobber matrix in \`update_job\` makes the worker-vs-cancel race deterministic regardless of who arrives first.

## Backend (~26 files)

- **\`studio_index_service.py\`** — \`StudioJobCancelled\` exception, \`is_job_cancelled\` (two-source check: in-memory + DB), \`raise_if_cancelled\` breakpoint helper, \`purge_job_storage\` (best-effort orphan cleanup), **clobber matrix in \`update_job\`** (5×5 transitions; cross-terminal writes dropped), cancel branch in \`with_failure_guard\` (catches Cancelled before generic Exception).
- **\`app/api/studio/job_actions.py\`** — new POST cancel route with race-aware response shapes including the \`late: true\` flag for the worker-finished-during-cancel race.
- **18 agent entry points** — entry breakpoint in each (\`raise_if_cancelled\`); audio gains 3 breakpoints (entry, top of script-gen loop, before TTS), presentation gains 2 (entry, before Playwright). Executor-pattern files (video, blog, component, website, email, presentation, business_report) gain explicit \`StudioJobCancelled\` handler in their try/except so the cancel routes to cleanup instead of writing 'error'.
- **\`tests/test_studio_cancellation.py\`** — 35 tests covering primitives, clobber matrix (parametrized over all 25 transitions), and the failure-guard cancel branch.

**No DB migration.** \`studio_jobs.status\` is plain TEXT; 'cancelled' is already valid. \`cancelled_at\` lives in \`job_data\` JSONB.

## Frontend (~52 files)

- **\`studio/shared/StopHoldButton.tsx\`** — type-\`stop\` shadcn Dialog. Italic serif headline, calm body copy reassuring users that re-running is one click. Inline error pill on cancel-API failure (no toast pile-up).
- **\`studio/shared/CancelledJobRow.tsx\`** — shared cancelled-state row (amber stripe, italic serif \"Cancelled · HH:MM\", \"Generate again\"). Shipped as shared component for future ListItem integration.
- **\`lib/api/studio/index.ts\`** — \`cancelStudioJob(projectId, jobId)\` helper, \`JobStatus\` union extended with 'cancelled'.
- **18 per-agent API clients** — one-line extension of \`pollJobStatus\` terminal-status check to include 'cancelled' so polling exits cleanly.
- **18 ProgressIndicators** — receive \`projectId\` prop, render \`<StopHoldButton onConfirm={cancel}>\` next to the spinner. Identical pattern.
- **18 sections** — pass \`projectId={projectId}\` to their indicator.

## Verification

- ✅ 275 backend tests pass (35 new + 240 existing). Clobber matrix tested parametrically over all 25 status transitions.
- ✅ \`npm run lint\` clean (0 errors)
- ✅ \`npm run build\` clean (no TS errors)
- ✅ All 18 agents: type-check pass

## Test plan

- [ ] Open audio generation → click Stop → modal opens → type \"stop\" → Confirm → row flips to cancelled within ~5s
- [ ] Try clicking Stop without typing → Confirm button stays disabled
- [ ] Try typing \"stp\" / \"STOP\" / \" stop \" → only valid \"stop\" enables Confirm (case-insensitive trim)
- [ ] Start audio → wait until script-gen iteration → cancel → cooperative breakpoint trips, no orphan partial files in \`/studio-outputs/\` prefix
- [ ] Late-ready race: hard to trigger manually but covered by tests
- [ ] Refresh page during cancellation → cancelled row still cancelled
- [ ] Two tabs open, cancel in tab A → tab B's poll exits within ~5s

## What's deferred (follow-up PRs)

- ListItem integration of \`CancelledJobRow\` per-agent so cancelled jobs show \"Generate again\" inline (component already shipped, needs per-agent re-trigger handler wiring)
- ActiveTasksBar 600ms \`reading-breathe\` fade-out on row removal
- Additional mid-loop breakpoints in non-audio non-presentation agents (entry breakpoint already gives Stop \"works\" semantics; extra breakpoints just shorten cancel latency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)