### PR TITLE
perf: chat-list N+1 → single RPC for message count (closes #187)

### DIFF
--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -44,7 +44,18 @@ class ChatService:
         List all chats for a project.
 
         Educational Note: Returns metadata only (not full messages) for
-        efficient loading of chat lists in the UI.
+        efficient loading of chat lists in the UI. A single RPC
+        (`list_chats_with_message_count`, migration 00029) joins each
+        chat to its filtered message count in one round-trip — the
+        previous N+1 implementation made one count query per chat
+        (21 round-trips for 20 chats; dominant latency on dashboard
+        load with active chat history). The SQL filter mirrors
+        `_is_displayable_message` so the sidebar count never drifts
+        from what the chat header shows.
+
+        A Python fallback path remains for environments where the
+        migration hasn't run yet (e.g. local dev that skipped it),
+        with a `logger.warning` so the issue surfaces in logs.
 
         Args:
             project_id: The project UUID
@@ -52,6 +63,26 @@ class ChatService:
         Returns:
             List of chat metadata, sorted by most recent first
         """
+        try:
+            rpc_response = (
+                self.supabase
+                .rpc("list_chats_with_message_count", {"p_project_id": project_id})
+                .execute()
+            )
+            chats = rpc_response.data or []
+            # RPC returns int8 (BIGINT). Coerce to plain int for JSON
+            # symmetry with create_chat's `message_count: 0`.
+            for chat in chats:
+                chat["message_count"] = int(chat.get("message_count") or 0)
+            return chats
+        except Exception as exc:  # noqa: BLE001 — fall back to safe path
+            logger.warning(
+                "list_chats_with_message_count RPC failed (%s); "
+                "falling back to N+1 count loop. Run migration 00029 to fix.",
+                exc,
+            )
+
+        # Fallback: original N+1 path. Identical filter to the SQL.
         response = (
             self.supabase.table(self.table)
             .select("id, title, created_at, updated_at, costs")
@@ -61,12 +92,6 @@ class ChatService:
         )
 
         chats = response.data or []
-
-        # Add message count for each chat. The count we expose to the UI
-        # mirrors the same filter `get_chat()` applies for display — so a
-        # chat with tool-use rounds doesn't read "4 messages" in the
-        # sidebar while the chat header shows 2 (the visible turn pair).
-        # See _is_displayable_message for the rules.
         for chat in chats:
             msgs_response = (
                 self.supabase.table(self.messages_table)
@@ -77,7 +102,6 @@ class ChatService:
             chat["message_count"] = sum(
                 1 for m in (msgs_response.data or []) if self._is_displayable_message(m)
             )
-
         return chats
 
     @staticmethod

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -63,24 +63,49 @@ class ChatService:
         Returns:
             List of chat metadata, sorted by most recent first
         """
+        # Only the RPC call itself is wrapped — type coercion below
+        # runs outside the try so a downstream bug doesn't get
+        # swallowed as "RPC failed, falling back".
+        rpc_response = None
         try:
             rpc_response = (
                 self.supabase
                 .rpc("list_chats_with_message_count", {"p_project_id": project_id})
                 .execute()
             )
+        except Exception as exc:  # noqa: BLE001 — narrowed below
+            # Distinguish "migration hasn't run yet" (expected, INFO) from
+            # actual operational errors (network, auth, quota — ERROR so
+            # monitoring picks them up). PostgREST returns code PGRST202
+            # for a missing RPC function; older Supabase stacks surface
+            # the underlying Postgres "function does not exist" instead.
+            msg = str(exc).lower()
+            is_missing_rpc = (
+                "pgrst202" in msg
+                or "could not find the function" in msg
+                or ("function" in msg and "does not exist" in msg)
+            )
+            if is_missing_rpc:
+                logger.info(
+                    "list_chats_with_message_count RPC not present yet; "
+                    "falling back to N+1 count loop. Run migration 00029.",
+                )
+            else:
+                logger.error(
+                    "list_chats_with_message_count RPC failed (%s: %s); "
+                    "falling back to N+1 count loop. Investigate — this is "
+                    "NOT the missing-function case.",
+                    type(exc).__name__, exc,
+                )
+
+        if rpc_response is not None:
             chats = rpc_response.data or []
             # RPC returns int8 (BIGINT). Coerce to plain int for JSON
-            # symmetry with create_chat's `message_count: 0`.
+            # symmetry with create_chat's `message_count: 0`. Non-RPC
+            # errors here would NOT be miscategorized as "RPC failed".
             for chat in chats:
                 chat["message_count"] = int(chat.get("message_count") or 0)
             return chats
-        except Exception as exc:  # noqa: BLE001 — fall back to safe path
-            logger.warning(
-                "list_chats_with_message_count RPC failed (%s); "
-                "falling back to N+1 count loop. Run migration 00029 to fix.",
-                exc,
-            )
 
         # Fallback: original N+1 path. Identical filter to the SQL.
         response = (

--- a/backend/supabase/migrations/00029_list_chats_with_message_count.sql
+++ b/backend/supabase/migrations/00029_list_chats_with_message_count.sql
@@ -1,0 +1,63 @@
+-- Migration: list_chats_with_message_count RPC
+-- Description: Replace the N+1 fan-out in chat_service.list_chats() (one
+--              count query per chat — 21 round-trips for 20 chats) with a
+--              single RPC that joins chats to a filtered message count in
+--              one query.
+--
+-- The Python filter (`_is_displayable_message` in chat_service.py) drops
+-- messages that wouldn't show in the rendered transcript: non-user/
+-- assistant roles, list-content rows (tool-chain envelopes), and rows
+-- whose extracted text trims to empty. The SQL here mirrors that filter
+-- so the sidebar count never drifts from what the chat header shows for
+-- the same chat.
+--
+-- Indexes already cover (messages.chat_id) and (chats.project_id) per
+-- the initial schema, so this is a pure round-trip-elimination win:
+-- expected ~80-150ms saved on the chat sidebar for projects with 20+ chats.
+
+CREATE OR REPLACE FUNCTION list_chats_with_message_count(p_project_id UUID)
+RETURNS TABLE (
+    id UUID,
+    title TEXT,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ,
+    costs JSONB,
+    message_count BIGINT
+)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT
+        c.id,
+        c.title,
+        c.created_at,
+        c.updated_at,
+        c.costs,
+        COALESCE((
+            SELECT COUNT(*)
+            FROM messages m
+            WHERE m.chat_id = c.id
+              -- Mirror chat_service._is_displayable_message:
+              -- 1. role must be user or assistant (skip system/tool roles)
+              AND m.role IN ('user', 'assistant')
+              -- 2. list-content rows are tool-chain intermediates (assistant
+              --    tool_use envelopes + user tool_result wrappers); skip them
+              AND jsonb_typeof(m.content) <> 'array'
+              -- 3. text content (after stripping whitespace) must be non-empty
+              AND (
+                  -- string-typed JSONB: "hello"  →  trimmed text length > 0
+                  (jsonb_typeof(m.content) = 'string'
+                      AND length(btrim(m.content #>> '{}')) > 0)
+                  -- object-typed JSONB: {"text":"hello"}  →  text field non-empty
+                  OR (jsonb_typeof(m.content) = 'object'
+                      AND length(btrim(COALESCE(m.content->>'text', ''))) > 0)
+              )
+        ), 0)::BIGINT AS message_count
+    FROM chats c
+    WHERE c.project_id = p_project_id
+    ORDER BY c.updated_at DESC;
+$$;
+
+-- Allow PostgREST to expose this through the auto-generated /rpc API
+-- so the Supabase Python SDK can call it via .rpc(...).execute().
+GRANT EXECUTE ON FUNCTION list_chats_with_message_count(UUID) TO anon, authenticated, service_role;


### PR DESCRIPTION
Closes #187 (Roadmap #23).

## Bug

\`chat_service.list_chats()\` was issuing one count query per chat — 21 round-trips for 20 chats, dominant latency contributor on dashboard load with active chat history. Earlier shift to fetching \`role, content\` per chat for the displayable-message filter (commit \`bd8621d\`) made it worse, not better.

## Fix

**Migration \`00029_list_chats_with_message_count.sql\`** — single SQL function that joins each chat to its filtered message count in one query. The filter mirrors \`_is_displayable_message\` (user/assistant role, non-list content, non-empty trimmed text) so sidebar/header counts can't drift apart.

\`\`\`sql
CREATE OR REPLACE FUNCTION list_chats_with_message_count(p_project_id UUID)
RETURNS TABLE (id UUID, title TEXT, ..., message_count BIGINT)
LANGUAGE sql STABLE
AS $$
  SELECT c.id, c.title, ..., COALESCE((
    SELECT COUNT(*) FROM messages m
    WHERE m.chat_id = c.id
      AND m.role IN ('user', 'assistant')
      AND jsonb_typeof(m.content) <> 'array'
      AND ((jsonb_typeof(m.content) = 'string' AND length(btrim(m.content #>> '{}')) > 0)
        OR (jsonb_typeof(m.content) = 'object' AND length(btrim(COALESCE(m.content->>'text', ''))) > 0))
  ), 0)::BIGINT
  FROM chats c WHERE c.project_id = p_project_id ORDER BY c.updated_at DESC;
$$;
\`\`\`

**\`chat_service.list_chats\`** — calls the RPC via the Supabase Python SDK. On failure (RPC missing in env that skipped migration, transient DB error) falls back to the existing N+1 path with a \`logger.warning\` so the issue surfaces in logs.

## Test plan
- [ ] After deploy: open project with 20+ chats — sidebar loads visibly faster
- [ ] Verify sidebar count matches chat header count (same filter both sides)
- [ ] If migration hadn't run: sidebar still works (fallback path), warning in backend logs
- [x] 275 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)