### PR TITLE
chat: enable prompt caching on the chat hot path (closes #185)

### DIFF
--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -545,6 +545,10 @@ class MainChatService:
                 user_id=resolved_user_id,
                 chat_id=chat_id,
                 tags=["chat"],
+                # Opt the chat hot path into Anthropic prompt caching. The
+                # system prompt + tools array are stable within a chat
+                # session; cache hits are billed at 0.1× the input rate.
+                enable_prompt_cache=True,
             )
             if response_text.strip():
                 accumulated_text_parts.append(response_text)
@@ -648,6 +652,7 @@ class MainChatService:
                     user_id=resolved_user_id,
                     chat_id=chat_id,
                     tags=["chat"],
+                    enable_prompt_cache=True,
                 )
                 if response_text.strip():
                     accumulated_text_parts.append(response_text)

--- a/backend/app/services/integrations/claude/claude_service.py
+++ b/backend/app/services/integrations/claude/claude_service.py
@@ -219,6 +219,7 @@ class ClaudeService:
         user_id: Optional[str] = None,
         chat_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        enable_prompt_cache: bool = False,
     ) -> Dict[str, Any]:
         """
         Send messages to Claude and get a response.
@@ -267,6 +268,7 @@ class ClaudeService:
             tools=tools,
             tool_choice=tool_choice,
             extra_headers=extra_headers,
+            enable_prompt_cache=enable_prompt_cache,
         )
 
         # Make API call (wrapped in Opik parent trace with metadata if enabled)
@@ -333,6 +335,7 @@ class ClaudeService:
         user_id: Optional[str] = None,
         chat_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        enable_prompt_cache: bool = False,
     ) -> Dict[str, Any]:
         """
         Stream a Claude response and forward text deltas through a callback.
@@ -356,6 +359,7 @@ class ClaudeService:
             tools=tools,
             tool_choice=tool_choice,
             extra_headers=extra_headers,
+            enable_prompt_cache=enable_prompt_cache,
         )
 
         # Wrap streaming in Opik parent trace with metadata + retry
@@ -415,8 +419,21 @@ class ClaudeService:
         tools: Optional[List[Dict[str, Any]]],
         tool_choice: Optional[Dict[str, Any]],
         extra_headers: Optional[Dict[str, str]],
+        enable_prompt_cache: bool = False,
     ) -> Dict[str, Any]:
-        """Build the shared Anthropic request payload."""
+        """Build the shared Anthropic request payload.
+
+        When `enable_prompt_cache` is True, the system prompt is converted to
+        the structured block form and a `cache_control: {type: "ephemeral"}`
+        breakpoint is attached to it and to the last tool definition. This
+        opts the caller into Anthropic prompt caching, which bills subsequent
+        cache hits at 0.1× the normal input rate.
+
+        Note: Anthropic silently ignores cache_control on blocks below the
+        per-model minimum (~1024 tokens for Sonnet/Opus, ~2048 for Haiku).
+        Sub-minimum blocks are still served — just not cached — so this is
+        safe to enable broadly for the chat hot path.
+        """
         # Build API call parameters
         api_params = {
             "model": model,
@@ -426,13 +443,19 @@ class ClaudeService:
 
         # Add optional parameters only if provided
         if system_prompt:
-            api_params["system"] = system_prompt
+            api_params["system"] = (
+                _system_block_with_cache(system_prompt)
+                if enable_prompt_cache
+                else system_prompt
+            )
 
         if temperature != 0.2:  # Only set if not default
             api_params["temperature"] = temperature
 
         if tools:
-            api_params["tools"] = tools
+            api_params["tools"] = (
+                _tools_with_cache_breakpoint(tools) if enable_prompt_cache else tools
+            )
 
         if tool_choice:
             api_params["tool_choice"] = tool_choice
@@ -486,6 +509,48 @@ class ClaudeService:
         response = client.messages.count_tokens(**api_params)
 
         return response.input_tokens
+
+
+def _system_block_with_cache(system_prompt: str) -> List[Dict[str, Any]]:
+    """
+    Convert a plain string system prompt into Anthropic's structured-block
+    form with a cache_control breakpoint on it.
+
+    The Anthropic API accepts either form — `system="..."` or
+    `system=[{"type":"text", "text":"...", "cache_control":{...}}]` — and
+    cache_control only attaches to the block form.
+
+    Note: Anthropic enforces a minimum cacheable size (~1024 tokens for
+    Sonnet/Opus, ~2048 for Haiku). Smaller blocks are silently served
+    uncached — no error, no discount — so this helper is safe to apply
+    even to short prompts. See:
+    https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+    """
+    return [
+        {
+            "type": "text",
+            "text": system_prompt,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def _tools_with_cache_breakpoint(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Return a shallow-copy tools list with a cache_control breakpoint on the
+    last tool. The breakpoint covers every block up to and including itself,
+    so marking the last tool caches the entire tools array.
+
+    We never mutate the caller's tool dicts in place — chat builds the tools
+    list each turn from registries, and a sticky cache_control field would
+    leak into agents that share the same tool definitions but don't opt into
+    caching.
+    """
+    if not tools:
+        return tools
+    cached = list(tools)
+    cached[-1] = {**cached[-1], "cache_control": {"type": "ephemeral"}}
+    return cached
 
 
 # Singleton instance for easy import

--- a/backend/tests/test_claude_prompt_cache.py
+++ b/backend/tests/test_claude_prompt_cache.py
@@ -1,0 +1,127 @@
+"""
+Tests for prompt-cache wiring in claude_service.
+
+Covers:
+- _system_block_with_cache: converts a plain string into the structured
+  block form with cache_control attached.
+- _tools_with_cache_breakpoint: marks only the LAST tool, never mutates
+  the caller's list, and is a no-op for empty input.
+- ClaudeService._build_api_params: passes through unchanged when
+  enable_prompt_cache=False, applies cache_control on both system and
+  tools when True.
+"""
+from app.services.integrations.claude.claude_service import (
+    ClaudeService,
+    _system_block_with_cache,
+    _tools_with_cache_breakpoint,
+)
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+class TestSystemBlockWithCache:
+
+    def test_wraps_string_in_block_with_ephemeral_cache(self):
+        result = _system_block_with_cache("you are NoobBook")
+        assert result == [
+            {
+                "type": "text",
+                "text": "you are NoobBook",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+    def test_returns_list_form(self):
+        """The Anthropic API only honors cache_control on the block form."""
+        result = _system_block_with_cache("x")
+        assert isinstance(result, list)
+        assert isinstance(result[0], dict)
+
+
+class TestToolsWithCacheBreakpoint:
+
+    def _tools(self):
+        # Match the shape of tools loaded via tool_loader.load_tool().
+        return [
+            {"name": "search_sources", "description": "...", "input_schema": {}},
+            {"name": "store_memory", "description": "...", "input_schema": {}},
+        ]
+
+    def test_marks_last_tool_only(self):
+        result = _tools_with_cache_breakpoint(self._tools())
+        assert "cache_control" not in result[0]
+        assert result[-1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_does_not_mutate_caller_list(self):
+        tools = self._tools()
+        original_last = tools[-1].copy()
+        _tools_with_cache_breakpoint(tools)
+        # The caller's list and dicts must be untouched — chat builds a fresh
+        # tool list per turn but tool defs themselves are module-level.
+        assert "cache_control" not in tools[-1]
+        assert tools[-1] == original_last
+
+    def test_empty_list_is_noop(self):
+        assert _tools_with_cache_breakpoint([]) == []
+
+    def test_single_tool_marked(self):
+        tools = [{"name": "only", "description": "", "input_schema": {}}]
+        result = _tools_with_cache_breakpoint(tools)
+        assert result[0]["cache_control"] == {"type": "ephemeral"}
+
+
+# ===========================================================================
+# _build_api_params integration
+# ===========================================================================
+
+class TestBuildApiParamsCaching:
+
+    def setup_method(self):
+        self.svc = ClaudeService()
+
+    def _build(self, **overrides):
+        defaults = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "system_prompt": "you are NoobBook",
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 1024,
+            "temperature": 0.0,
+            "tools": [
+                {"name": "a", "description": "", "input_schema": {}},
+                {"name": "b", "description": "", "input_schema": {}},
+            ],
+            "tool_choice": None,
+            "extra_headers": None,
+        }
+        defaults.update(overrides)
+        return self.svc._build_api_params(**defaults)
+
+    def test_caching_off_is_legacy_string_system(self):
+        """Default (enable_prompt_cache=False) must keep the legacy contract."""
+        params = self._build(enable_prompt_cache=False)
+        assert params["system"] == "you are NoobBook"
+        assert "cache_control" not in params["tools"][-1]
+
+    def test_caching_on_wraps_system(self):
+        params = self._build(enable_prompt_cache=True)
+        assert isinstance(params["system"], list)
+        assert params["system"][0]["cache_control"] == {"type": "ephemeral"}
+        assert params["system"][0]["text"] == "you are NoobBook"
+
+    def test_caching_on_marks_last_tool(self):
+        params = self._build(enable_prompt_cache=True)
+        assert "cache_control" not in params["tools"][0]
+        assert params["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_caching_on_with_no_tools_does_not_crash(self):
+        params = self._build(enable_prompt_cache=True, tools=None)
+        # No tools key when tools is falsy, but system should still cache.
+        assert "tools" not in params
+        assert params["system"][0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_caching_on_with_no_system_does_not_crash(self):
+        params = self._build(enable_prompt_cache=True, system_prompt=None)
+        assert "system" not in params
+        assert params["tools"][-1]["cache_control"] == {"type": "ephemeral"}


### PR DESCRIPTION
## Summary

Closes #185. The chat system prompt is **~1,258 tokens at minimum**, larger with project memory + user memory + the sources block, and ships uncached on every \`send_message()\` / \`stream_message()\` call. Anthropic prompt caching (\`cache_control: {type: \"ephemeral\"}\`) bills subsequent reads at **0.1×** the input rate — expected savings on warm chats are 80–90% of input-token cost (input is typically 5–20× output).

## What's wired up

- \`claude_service.send_message\` and \`stream_message\` gain an opt-in \`enable_prompt_cache: bool = False\` arg. Default stays False so PDF / image / agent callers — whose system prompts vary per call — are completely unaffected.
- \`_build_api_params\`, when caching is enabled:
  - converts the string \`system_prompt\` into the structured \`[{\"type\":\"text\", \"text\":..., \"cache_control\":{...}}]\` form (cache_control is only honored on the block form),
  - attaches a cache_control breakpoint to the **last tool** in the tools array. The breakpoint covers every block up to itself, so marking the last tool caches the entire tools array.
- \`_tools_with_cache_breakpoint\` never mutates the caller's tool dicts. Chat builds its tools list from module-level registries each turn, and a sticky \`cache_control\` field would leak into agents that share the same tool defs but don't opt into caching.
- \`main_chat_service\` passes \`enable_prompt_cache=True\` at both call sites: the initial turn (line 535) and tool-use loop continuations (line 638).

## Why this can't ship before #186

#186 fixes \`cost_tracking\` to bill \`cache_read_input_tokens\` at 0.1× and \`cache_creation_input_tokens\` at 1.25× — without that, every cache hit this PR produces is billed at the full input rate in the dashboard. The actual API charges are correct; only the dashboard report is wrong. **Land #186 first.**

## Caveats / known limits

Anthropic enforces a per-model minimum for cacheable blocks: ~1024 tokens for Sonnet/Opus, ~2048 for Haiku. Sub-minimum blocks are served normally but never cached (no error, no discount). The chat system prompt clears the Sonnet minimum at baseline; Haiku-driven sub-flows may not. That's fine — they degrade to no-op cache behavior, same as today.

## Test plan

- \`pytest backend/tests/test_claude_prompt_cache.py\` — 11 cases:
  - helper correctness (\`_system_block_with_cache\`, \`_tools_with_cache_breakpoint\`)
  - no mutation of caller-provided tools list
  - default-off keeps the legacy string-system contract
  - enabled-on wraps system, marks last tool, handles None system / None tools without crashing
- [ ] Manual verification (post-#186 merge): send 3 consecutive messages in one chat, inspect \`response.usage.cache_read_input_tokens\` — should be 0 on call 1, non-zero on calls 2 and 3. \`projects.costs.cache_savings\` should rise after call 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)