### PR TITLE
Sync develop → main: cache cost tracking + chat prompt caching

### DIFF
--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -545,6 +545,10 @@ class MainChatService:
                 user_id=resolved_user_id,
                 chat_id=chat_id,
                 tags=["chat"],
+                # Opt the chat hot path into Anthropic prompt caching. The
+                # system prompt + tools array are stable within a chat
+                # session; cache hits are billed at 0.1× the input rate.
+                enable_prompt_cache=True,
             )
             if response_text.strip():
                 accumulated_text_parts.append(response_text)
@@ -648,6 +652,7 @@ class MainChatService:
                     user_id=resolved_user_id,
                     chat_id=chat_id,
                     tags=["chat"],
+                    enable_prompt_cache=True,
                 )
                 if response_text.strip():
                     accumulated_text_parts.append(response_text)

--- a/backend/app/services/data_services/user_service.py
+++ b/backend/app/services/data_services/user_service.py
@@ -120,6 +120,7 @@ class UserService:
         # Surface spending fields from settings JSONB for the frontend table
         for user in users:
             settings = user.pop("settings", None) or {}
+            settings = self.maybe_reset_expired_spending_period(user["id"], settings)
             user["cost_limit"] = settings.get("cost_limit")
             user["reset_frequency"] = settings.get("reset_frequency")  # daily/weekly/monthly/null
             user["period_spend"] = settings.get("period_spend", 0.0)
@@ -171,6 +172,7 @@ class UserService:
         if resp.data:
             user = resp.data[0]
             settings = user.pop("settings", None) or {}
+            settings = self.maybe_reset_expired_spending_period(user_id, settings)
             user["cost_limit"] = settings.get("cost_limit")
             user["reset_frequency"] = settings.get("reset_frequency")
             user["period_spend"] = settings.get("period_spend", 0.0)
@@ -199,6 +201,50 @@ class UserService:
             .execute()
         )
         return bool(resp.data)
+
+    def maybe_reset_expired_spending_period(
+        self,
+        user_id: str,
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Reset a user's period spend if their configured window has expired.
+
+        The reset is intentionally lazy, but this method is called from both
+        reads and writes so stale weekly/monthly spend does not linger until a
+        specific Claude code path happens to run.
+        """
+        current = dict(settings if settings is not None else self.get_user_settings_raw(user_id))
+        if not current.get("cost_limit") or not current.get("reset_frequency"):
+            return current
+
+        reset_frequency = current["reset_frequency"]
+        period_start = current.get("period_start")
+
+        from app.utils.spending_schedule import (
+            aligned_period_start_iso,
+            is_period_expired,
+        )
+
+        should_reset = not period_start or is_period_expired(period_start, reset_frequency)
+        if not should_reset:
+            return current
+
+        next_settings = {
+            **current,
+            "period_spend": 0.0,
+            "period_start": aligned_period_start_iso(reset_frequency),
+        }
+        if self.save_user_settings(user_id, next_settings):
+            logger.info(
+                "Reset expired %s spending period for user %s",
+                reset_frequency,
+                user_id,
+            )
+            return next_settings
+
+        logger.warning("Failed to persist expired spending-period reset for %s", user_id)
+        return next_settings
 
     def update_spending_config(
         self,
@@ -431,7 +477,7 @@ class UserService:
         project and chat cost updates. Only increments if the user has
         a cost_limit with a reset_frequency configured.
         """
-        settings = self.get_user_settings_raw(user_id)
+        settings = self.maybe_reset_expired_spending_period(user_id)
         if not settings.get("cost_limit") or not settings.get("reset_frequency"):
             return  # No period tracking configured
 

--- a/backend/app/services/integrations/claude/claude_service.py
+++ b/backend/app/services/integrations/claude/claude_service.py
@@ -219,6 +219,7 @@ class ClaudeService:
         user_id: Optional[str] = None,
         chat_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        enable_prompt_cache: bool = False,
     ) -> Dict[str, Any]:
         """
         Send messages to Claude and get a response.
@@ -267,6 +268,7 @@ class ClaudeService:
             tools=tools,
             tool_choice=tool_choice,
             extra_headers=extra_headers,
+            enable_prompt_cache=enable_prompt_cache,
         )
 
         # Make API call (wrapped in Opik parent trace with metadata if enabled)
@@ -333,6 +335,7 @@ class ClaudeService:
         user_id: Optional[str] = None,
         chat_id: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        enable_prompt_cache: bool = False,
     ) -> Dict[str, Any]:
         """
         Stream a Claude response and forward text deltas through a callback.
@@ -356,6 +359,7 @@ class ClaudeService:
             tools=tools,
             tool_choice=tool_choice,
             extra_headers=extra_headers,
+            enable_prompt_cache=enable_prompt_cache,
         )
 
         # Wrap streaming in Opik parent trace with metadata + retry
@@ -415,8 +419,21 @@ class ClaudeService:
         tools: Optional[List[Dict[str, Any]]],
         tool_choice: Optional[Dict[str, Any]],
         extra_headers: Optional[Dict[str, str]],
+        enable_prompt_cache: bool = False,
     ) -> Dict[str, Any]:
-        """Build the shared Anthropic request payload."""
+        """Build the shared Anthropic request payload.
+
+        When `enable_prompt_cache` is True, the system prompt is converted to
+        the structured block form and a `cache_control: {type: "ephemeral"}`
+        breakpoint is attached to it and to the last tool definition. This
+        opts the caller into Anthropic prompt caching, which bills subsequent
+        cache hits at 0.1× the normal input rate.
+
+        Note: Anthropic silently ignores cache_control on blocks below the
+        per-model minimum (~1024 tokens for Sonnet/Opus, ~2048 for Haiku).
+        Sub-minimum blocks are still served — just not cached — so this is
+        safe to enable broadly for the chat hot path.
+        """
         # Build API call parameters
         api_params = {
             "model": model,
@@ -426,13 +443,19 @@ class ClaudeService:
 
         # Add optional parameters only if provided
         if system_prompt:
-            api_params["system"] = system_prompt
+            api_params["system"] = (
+                _system_block_with_cache(system_prompt)
+                if enable_prompt_cache
+                else system_prompt
+            )
 
         if temperature != 0.2:  # Only set if not default
             api_params["temperature"] = temperature
 
         if tools:
-            api_params["tools"] = tools
+            api_params["tools"] = (
+                _tools_with_cache_breakpoint(tools) if enable_prompt_cache else tools
+            )
 
         if tool_choice:
             api_params["tool_choice"] = tool_choice
@@ -486,6 +509,48 @@ class ClaudeService:
         response = client.messages.count_tokens(**api_params)
 
         return response.input_tokens
+
+
+def _system_block_with_cache(system_prompt: str) -> List[Dict[str, Any]]:
+    """
+    Convert a plain string system prompt into Anthropic's structured-block
+    form with a cache_control breakpoint on it.
+
+    The Anthropic API accepts either form — `system="..."` or
+    `system=[{"type":"text", "text":"...", "cache_control":{...}}]` — and
+    cache_control only attaches to the block form.
+
+    Note: Anthropic enforces a minimum cacheable size (~1024 tokens for
+    Sonnet/Opus, ~2048 for Haiku). Smaller blocks are silently served
+    uncached — no error, no discount — so this helper is safe to apply
+    even to short prompts. See:
+    https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+    """
+    return [
+        {
+            "type": "text",
+            "text": system_prompt,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def _tools_with_cache_breakpoint(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Return a shallow-copy tools list with a cache_control breakpoint on the
+    last tool. The breakpoint covers every block up to and including itself,
+    so marking the last tool caches the entire tools array.
+
+    We never mutate the caller's tool dicts in place — chat builds the tools
+    list each turn from registries, and a sticky cache_control field would
+    leak into agents that share the same tool definitions but don't opt into
+    caching.
+    """
+    if not tools:
+        return tools
+    cached = list(tools)
+    cached[-1] = {**cached[-1], "cache_control": {"type": "ephemeral"}}
+    return cached
 
 
 # Singleton instance for easy import

--- a/backend/app/services/integrations/claude/claude_service.py
+++ b/backend/app/services/integrations/claude/claude_service.py
@@ -287,6 +287,11 @@ class ClaudeService:
             trace_name=trace_name,
         )
 
+        # Cache fields are only populated when prompt caching is in play;
+        # default to 0 so non-cached calls behave exactly as before.
+        cache_creation_tokens = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+        cache_read_tokens = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+
         # Track costs if project_id provided (also per-chat if chat_id set)
         if project_id:
             add_cost_usage(
@@ -294,7 +299,10 @@ class ClaudeService:
                 model=response.model,
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
+                user_id=user_id,
                 chat_id=chat_id,
+                cache_creation_tokens=cache_creation_tokens,
+                cache_read_tokens=cache_read_tokens,
             )
 
         # Return raw response data - all parsing happens in claude_parsing_utils
@@ -304,6 +312,8 @@ class ClaudeService:
             "usage": {
                 "input_tokens": response.usage.input_tokens,
                 "output_tokens": response.usage.output_tokens,
+                "cache_creation_input_tokens": cache_creation_tokens,
+                "cache_read_input_tokens": cache_read_tokens,
             },
             "stop_reason": response.stop_reason,
         }
@@ -368,13 +378,19 @@ class ClaudeService:
         trace_input = {"prompt": last_user_msg, "model": model, "message_count": len(messages)}
         response = self._run_tracked(_do_stream, opik_kwargs=opik_kwargs, trace_input=trace_input, trace_name=trace_name)
 
+        cache_creation_tokens = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+        cache_read_tokens = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+
         if project_id:
             add_cost_usage(
                 project_id=project_id,
                 model=response.model,
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
+                user_id=user_id,
                 chat_id=chat_id,
+                cache_creation_tokens=cache_creation_tokens,
+                cache_read_tokens=cache_read_tokens,
             )
 
         return {
@@ -383,6 +399,8 @@ class ClaudeService:
             "usage": {
                 "input_tokens": response.usage.input_tokens,
                 "output_tokens": response.usage.output_tokens,
+                "cache_creation_input_tokens": cache_creation_tokens,
+                "cache_read_input_tokens": cache_read_tokens,
             },
             "stop_reason": response.stop_reason,
         }

--- a/backend/app/utils/cost_tracking.py
+++ b/backend/app/utils/cost_tracking.py
@@ -8,6 +8,10 @@ Pricing (per 1M tokens):
 - Opus:   $5 input, $25 output
 - Sonnet: $3 input, $15 output
 - Haiku:  $1 input, $5 output
+
+Prompt-cache multipliers (Anthropic):
+- cache_creation_input_tokens: 1.25× the input rate (one-time write cost)
+- cache_read_input_tokens:     0.10× the input rate (per cached read)
 """
 import logging
 from typing import Dict, Any, Optional
@@ -22,6 +26,10 @@ PRICING = {
     "sonnet": {"input": 3.0, "output": 15.0},
     "haiku": {"input": 1.0, "output": 5.0},
 }
+
+# Prompt-cache multipliers applied to the per-model input rate.
+CACHE_WRITE_MULTIPLIER = 1.25
+CACHE_READ_MULTIPLIER = 0.10
 
 # Tracked model buckets, in stable order. Used by _get_default_costs and
 # _ensure_cost_structure so the breakdown always shows every model bucket
@@ -53,22 +61,55 @@ def _get_model_key(model_string: str) -> str:
     return "sonnet"
 
 
-def _calculate_cost(model_key: str, input_tokens: int, output_tokens: int) -> float:
+def _calculate_cost(
+    model_key: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
+) -> float:
     """
-    Calculate cost for a single API call.
+    Calculate cost for a single API call, including any prompt-cache usage.
 
     Args:
-        model_key: "sonnet" or "haiku"
-        input_tokens: Number of input tokens
-        output_tokens: Number of output tokens
+        model_key: "opus", "sonnet", or "haiku"
+        input_tokens: Non-cached input tokens (billed at the model's input rate)
+        output_tokens: Output tokens (billed at the model's output rate)
+        cache_creation_tokens: Tokens written to the prompt cache. Billed at
+            1.25× the input rate (one-time, amortized over reads).
+        cache_read_tokens: Tokens served from the prompt cache. Billed at
+            0.1× the input rate.
 
     Returns:
-        Cost in USD
+        Total cost in USD for this single call.
     """
     pricing = PRICING.get(model_key, PRICING["sonnet"])
-    input_cost = (input_tokens / 1_000_000) * pricing["input"]
+    input_rate = pricing["input"]
+    input_cost = (input_tokens / 1_000_000) * input_rate
     output_cost = (output_tokens / 1_000_000) * pricing["output"]
-    return input_cost + output_cost
+    cache_write_cost = (cache_creation_tokens / 1_000_000) * input_rate * CACHE_WRITE_MULTIPLIER
+    cache_read_cost = (cache_read_tokens / 1_000_000) * input_rate * CACHE_READ_MULTIPLIER
+    return input_cost + output_cost + cache_write_cost + cache_read_cost
+
+
+def _calculate_cache_savings(
+    model_key: str,
+    cache_creation_tokens: int,
+    cache_read_tokens: int,
+) -> float:
+    """
+    Compute the net dollar savings produced by prompt caching for this call.
+
+    Compares the actual cache-aware cost against the counterfactual where the
+    same tokens would have been billed at the full input rate. Result can be
+    negative on the first call (only writes, no reads yet) — that's correct;
+    the dashboard should reflect the true net.
+    """
+    pricing = PRICING.get(model_key, PRICING["sonnet"])
+    input_rate = pricing["input"]
+    read_gain = (cache_read_tokens / 1_000_000) * input_rate * (1.0 - CACHE_READ_MULTIPLIER)
+    write_premium = (cache_creation_tokens / 1_000_000) * input_rate * (CACHE_WRITE_MULTIPLIER - 1.0)
+    return read_gain - write_premium
 
 
 def _get_project_service():
@@ -130,7 +171,13 @@ def _save_chat_costs(chat_id: str, costs: Dict[str, Any]) -> bool:
 
 
 def _empty_bucket() -> Dict[str, Any]:
-    return {"input_tokens": 0, "output_tokens": 0, "cost": 0.0}
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cost": 0.0,
+        "cache_creation_tokens": 0,
+        "cache_read_tokens": 0,
+    }
 
 
 def _get_default_costs() -> Dict[str, Any]:
@@ -142,6 +189,7 @@ def _get_default_costs() -> Dict[str, Any]:
     """
     return {
         "total_cost": 0.0,
+        "cache_savings": 0.0,
         "by_model": {key: _empty_bucket() for key in _MODEL_KEYS},
     }
 
@@ -159,14 +207,21 @@ def _ensure_cost_structure(costs: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     # Ensure all required fields exist
     if "total_cost" not in costs:
         costs["total_cost"] = 0.0
+    if "cache_savings" not in costs:
+        costs["cache_savings"] = 0.0
     if "by_model" not in costs:
         costs["by_model"] = {}
     if "images" not in costs:
         costs["images"] = {}
 
     for model in _MODEL_KEYS:
-        if model not in costs["by_model"]:
+        bucket = costs["by_model"].get(model)
+        if bucket is None:
             costs["by_model"][model] = _empty_bucket()
+            continue
+        # Backfill cache fields for projects created before cache tracking.
+        bucket.setdefault("cache_creation_tokens", 0)
+        bucket.setdefault("cache_read_tokens", 0)
 
     return costs
 
@@ -176,6 +231,8 @@ def _apply_usage(
     model: str,
     input_tokens: int,
     output_tokens: int,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
 ) -> Dict[str, Any]:
     """
     Mutate a costs dict in place: add this call's tokens + cost to the
@@ -184,14 +241,25 @@ def _apply_usage(
     Extracted so both project-level and chat-level updates share identical math.
     """
     model_key = _get_model_key(model)
-    call_cost = _calculate_cost(model_key, input_tokens, output_tokens)
+    call_cost = _calculate_cost(
+        model_key,
+        input_tokens,
+        output_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        cache_read_tokens=cache_read_tokens,
+    )
 
     bucket = costs["by_model"][model_key]
     bucket["input_tokens"] += input_tokens
     bucket["output_tokens"] += output_tokens
     bucket["cost"] += call_cost
+    bucket["cache_creation_tokens"] = bucket.get("cache_creation_tokens", 0) + cache_creation_tokens
+    bucket["cache_read_tokens"] = bucket.get("cache_read_tokens", 0) + cache_read_tokens
 
     costs["total_cost"] += call_cost
+    costs["cache_savings"] = costs.get("cache_savings", 0.0) + _calculate_cache_savings(
+        model_key, cache_creation_tokens, cache_read_tokens
+    )
     return costs
 
 
@@ -202,6 +270,8 @@ def add_usage(
     output_tokens: int,
     user_id: Optional[str] = None,
     chat_id: Optional[str] = None,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
 ) -> Optional[Dict[str, Any]]:
     """
     Add API usage to project (and optionally chat) cost tracking.
@@ -215,10 +285,14 @@ def add_usage(
     Args:
         project_id: The project UUID
         model: Full model string (e.g., "claude-sonnet-4-6")
-        input_tokens: Number of input tokens used
+        input_tokens: Number of non-cached input tokens used
         output_tokens: Number of output tokens used
         user_id: Optional owner id (falls back to project lookup)
         chat_id: Optional chat UUID — when set, chat-level costs update too
+        cache_creation_tokens: Anthropic `cache_creation_input_tokens`
+            (billed at 1.25× the input rate).
+        cache_read_tokens: Anthropic `cache_read_input_tokens`
+            (billed at 0.1× the input rate).
 
     Returns:
         Updated project cost tracking data or None if project save failed
@@ -229,7 +303,14 @@ def add_usage(
         if project_costs is None:
             project_costs = _get_default_costs()
         project_costs = _ensure_cost_structure(project_costs)
-        _apply_usage(project_costs, model, input_tokens, output_tokens)
+        _apply_usage(
+            project_costs,
+            model,
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens=cache_creation_tokens,
+            cache_read_tokens=cache_read_tokens,
+        )
 
         if not _save_costs(project_id, project_costs, user_id=user_id):
             logger.warning("Failed to save costs for project %s", project_id)
@@ -241,7 +322,14 @@ def add_usage(
             if chat_costs is None:
                 chat_costs = _get_default_costs()
             chat_costs = _ensure_cost_structure(chat_costs)
-            _apply_usage(chat_costs, model, input_tokens, output_tokens)
+            _apply_usage(
+                chat_costs,
+                model,
+                input_tokens,
+                output_tokens,
+                cache_creation_tokens=cache_creation_tokens,
+                cache_read_tokens=cache_read_tokens,
+            )
 
             if not _save_chat_costs(chat_id, chat_costs):
                 logger.warning("Failed to save costs for chat %s", chat_id)
@@ -256,7 +344,13 @@ def add_usage(
                 pass
         if resolved_user_id:
             model_key = _get_model_key(model)
-            call_cost = _calculate_cost(model_key, input_tokens, output_tokens)
+            call_cost = _calculate_cost(
+                model_key,
+                input_tokens,
+                output_tokens,
+                cache_creation_tokens=cache_creation_tokens,
+                cache_read_tokens=cache_read_tokens,
+            )
             record_user_period_spend(resolved_user_id, call_cost)
 
         return project_costs
@@ -412,6 +506,8 @@ def record_user_only_usage(
     model: str,
     input_tokens: int,
     output_tokens: int,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
 ) -> float:
     """
     Track an API call against a user's period spend without a project.
@@ -426,7 +522,13 @@ def record_user_only_usage(
     if not user_id:
         return 0.0
     model_key = _get_model_key(model)
-    cost = _calculate_cost(model_key, input_tokens, output_tokens)
+    cost = _calculate_cost(
+        model_key,
+        input_tokens,
+        output_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        cache_read_tokens=cache_read_tokens,
+    )
     if cost > 0:
         record_user_period_spend(user_id, cost)
     return cost

--- a/backend/supabase/migrations/00030_chat_attachments_rls_mirror_raw_files.sql
+++ b/backend/supabase/migrations/00030_chat_attachments_rls_mirror_raw_files.sql
@@ -1,0 +1,69 @@
+-- Migration: Chat Attachments RLS — mirror raw-files policy shape
+-- Description: 00028 replaced the four 00027 policies with a single
+--              permissive policy scoped `TO service_role`. That looked
+--              correct on paper but storage uploads kept failing on the
+--              customer's self-hosted deploy with:
+--                "new row violates row-level security policy"
+--              even after 00028 had been applied. raw-files uploads
+--              against the same Supabase instance work fine using the
+--              original 00002 four-policy shape (no TO clause, with the
+--              `auth.uid() = first_folder` check that can never match
+--              for service-role uploads). That means storage-api here
+--              isn't actually evaluating as the `service_role` Postgres
+--              role — it's connecting as a role that bypasses RLS only
+--              when no role-restricted policy intercepts it. Restricting
+--              to `TO service_role` accidentally narrowed the policy
+--              away from the role doing the insert, so the bucket fell
+--              back to RLS-deny.
+--
+--              Fix: drop the 00028 single policy and recreate the same
+--              four-policy shape as raw-files. The check
+--              `auth.uid() = first_folder` is intentionally a no-op for
+--              the backend path (first folder is project_id, not user
+--              id) — what matters is the policies exist without a `TO`
+--              filter so the storage-api connection role can satisfy
+--              them via its own bypass.
+-- Created: 2026-05-12
+
+-- Drop the single permissive policy introduced in 00028.
+DROP POLICY IF EXISTS "Chat attachments — backend-mediated full access" ON storage.objects;
+
+-- Also drop the four 00027 names in case any deploy still has them
+-- around (idempotent on already-clean targets).
+DROP POLICY IF EXISTS "Users can upload chat attachments to own projects"   ON storage.objects;
+DROP POLICY IF EXISTS "Users can read chat attachments from own projects"   ON storage.objects;
+DROP POLICY IF EXISTS "Users can update chat attachments in own projects"   ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete chat attachments from own projects" ON storage.objects;
+
+-- Recreate raw-files-style policies. No TO clause = TO public, mirrors
+-- how raw-files / processed-files / chunks / studio-outputs are scoped
+-- in 00002 and brand-assets in 00007. PG 15 doesn't accept
+-- `CREATE POLICY IF NOT EXISTS`, so the DROPs above clear the slate
+-- for safe re-application.
+CREATE POLICY "Users can upload chat attachments to own projects"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'chat-attachments' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can read chat attachments from own projects"
+ON storage.objects FOR SELECT
+USING (
+  bucket_id = 'chat-attachments' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can update chat attachments in own projects"
+ON storage.objects FOR UPDATE
+USING (
+  bucket_id = 'chat-attachments' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can delete chat attachments from own projects"
+ON storage.objects FOR DELETE
+USING (
+  bucket_id = 'chat-attachments' AND
+  auth.uid()::text = (storage.foldername(name))[1]
+);

--- a/backend/tests/test_claude_prompt_cache.py
+++ b/backend/tests/test_claude_prompt_cache.py
@@ -1,0 +1,127 @@
+"""
+Tests for prompt-cache wiring in claude_service.
+
+Covers:
+- _system_block_with_cache: converts a plain string into the structured
+  block form with cache_control attached.
+- _tools_with_cache_breakpoint: marks only the LAST tool, never mutates
+  the caller's list, and is a no-op for empty input.
+- ClaudeService._build_api_params: passes through unchanged when
+  enable_prompt_cache=False, applies cache_control on both system and
+  tools when True.
+"""
+from app.services.integrations.claude.claude_service import (
+    ClaudeService,
+    _system_block_with_cache,
+    _tools_with_cache_breakpoint,
+)
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+class TestSystemBlockWithCache:
+
+    def test_wraps_string_in_block_with_ephemeral_cache(self):
+        result = _system_block_with_cache("you are NoobBook")
+        assert result == [
+            {
+                "type": "text",
+                "text": "you are NoobBook",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+    def test_returns_list_form(self):
+        """The Anthropic API only honors cache_control on the block form."""
+        result = _system_block_with_cache("x")
+        assert isinstance(result, list)
+        assert isinstance(result[0], dict)
+
+
+class TestToolsWithCacheBreakpoint:
+
+    def _tools(self):
+        # Match the shape of tools loaded via tool_loader.load_tool().
+        return [
+            {"name": "search_sources", "description": "...", "input_schema": {}},
+            {"name": "store_memory", "description": "...", "input_schema": {}},
+        ]
+
+    def test_marks_last_tool_only(self):
+        result = _tools_with_cache_breakpoint(self._tools())
+        assert "cache_control" not in result[0]
+        assert result[-1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_does_not_mutate_caller_list(self):
+        tools = self._tools()
+        original_last = tools[-1].copy()
+        _tools_with_cache_breakpoint(tools)
+        # The caller's list and dicts must be untouched — chat builds a fresh
+        # tool list per turn but tool defs themselves are module-level.
+        assert "cache_control" not in tools[-1]
+        assert tools[-1] == original_last
+
+    def test_empty_list_is_noop(self):
+        assert _tools_with_cache_breakpoint([]) == []
+
+    def test_single_tool_marked(self):
+        tools = [{"name": "only", "description": "", "input_schema": {}}]
+        result = _tools_with_cache_breakpoint(tools)
+        assert result[0]["cache_control"] == {"type": "ephemeral"}
+
+
+# ===========================================================================
+# _build_api_params integration
+# ===========================================================================
+
+class TestBuildApiParamsCaching:
+
+    def setup_method(self):
+        self.svc = ClaudeService()
+
+    def _build(self, **overrides):
+        defaults = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "system_prompt": "you are NoobBook",
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 1024,
+            "temperature": 0.0,
+            "tools": [
+                {"name": "a", "description": "", "input_schema": {}},
+                {"name": "b", "description": "", "input_schema": {}},
+            ],
+            "tool_choice": None,
+            "extra_headers": None,
+        }
+        defaults.update(overrides)
+        return self.svc._build_api_params(**defaults)
+
+    def test_caching_off_is_legacy_string_system(self):
+        """Default (enable_prompt_cache=False) must keep the legacy contract."""
+        params = self._build(enable_prompt_cache=False)
+        assert params["system"] == "you are NoobBook"
+        assert "cache_control" not in params["tools"][-1]
+
+    def test_caching_on_wraps_system(self):
+        params = self._build(enable_prompt_cache=True)
+        assert isinstance(params["system"], list)
+        assert params["system"][0]["cache_control"] == {"type": "ephemeral"}
+        assert params["system"][0]["text"] == "you are NoobBook"
+
+    def test_caching_on_marks_last_tool(self):
+        params = self._build(enable_prompt_cache=True)
+        assert "cache_control" not in params["tools"][0]
+        assert params["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_caching_on_with_no_tools_does_not_crash(self):
+        params = self._build(enable_prompt_cache=True, tools=None)
+        # No tools key when tools is falsy, but system should still cache.
+        assert "tools" not in params
+        assert params["system"][0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_caching_on_with_no_system_does_not_crash(self):
+        params = self._build(enable_prompt_cache=True, system_prompt=None)
+        assert "system" not in params
+        assert params["tools"][-1]["cache_control"] == {"type": "ephemeral"}

--- a/backend/tests/test_cost_tracking.py
+++ b/backend/tests/test_cost_tracking.py
@@ -12,6 +12,8 @@ import pytest
 from app.utils.cost_tracking import (
     _get_model_key,
     _calculate_cost,
+    _calculate_cache_savings,
+    _apply_usage,
     _get_default_costs,
     _ensure_cost_structure,
 )
@@ -111,6 +113,11 @@ class TestGetDefaultCosts:
             assert costs["by_model"][model]["input_tokens"] == 0
             assert costs["by_model"][model]["output_tokens"] == 0
             assert costs["by_model"][model]["cost"] == 0.0
+            assert costs["by_model"][model]["cache_creation_tokens"] == 0
+            assert costs["by_model"][model]["cache_read_tokens"] == 0
+
+    def test_cache_savings_present(self):
+        assert _get_default_costs()["cache_savings"] == 0.0
 
 
 # ===========================================================================
@@ -166,3 +173,134 @@ class TestEnsureCostStructure:
         result = _ensure_cost_structure(costs)
         assert "sonnet" in result["by_model"]
         assert "haiku" in result["by_model"]
+
+    def test_backfills_cache_fields_for_legacy_buckets(self):
+        """Projects created before cache tracking get the new fields seeded to 0."""
+        legacy = {
+            "total_cost": 1.0,
+            "by_model": {
+                "sonnet": {"input_tokens": 100, "output_tokens": 50, "cost": 1.0},
+            },
+        }
+        result = _ensure_cost_structure(legacy)
+        assert result["by_model"]["sonnet"]["cache_creation_tokens"] == 0
+        assert result["by_model"]["sonnet"]["cache_read_tokens"] == 0
+        # Legacy values must still be preserved.
+        assert result["by_model"]["sonnet"]["input_tokens"] == 100
+        assert result["cache_savings"] == 0.0
+
+
+# ===========================================================================
+# Cache-aware cost math
+# ===========================================================================
+
+class TestCalculateCostWithCache:
+
+    def test_cache_creation_is_125_percent_of_input(self):
+        """1M creation tokens at sonnet's $3 input rate = $3.75 (1.25×)."""
+        assert _calculate_cost("sonnet", 0, 0, cache_creation_tokens=1_000_000) == pytest.approx(3.75)
+
+    def test_cache_read_is_10_percent_of_input(self):
+        """1M read tokens at sonnet's $3 input rate = $0.30 (0.1×)."""
+        assert _calculate_cost("sonnet", 0, 0, cache_read_tokens=1_000_000) == pytest.approx(0.30)
+
+    def test_full_call_with_cache(self):
+        """Regular input + output + creation + read all sum together."""
+        # sonnet: input=$3, output=$15
+        # 100k input ($0.30) + 200k output ($3) + 50k creation ($0.1875) + 500k read ($0.15)
+        cost = _calculate_cost(
+            "sonnet",
+            input_tokens=100_000,
+            output_tokens=200_000,
+            cache_creation_tokens=50_000,
+            cache_read_tokens=500_000,
+        )
+        assert cost == pytest.approx(0.30 + 3.0 + 0.1875 + 0.15)
+
+    def test_haiku_cache_pricing(self):
+        """Haiku input rate is $1/1M → creation = $1.25, read = $0.10."""
+        assert _calculate_cost("haiku", 0, 0, cache_creation_tokens=1_000_000) == pytest.approx(1.25)
+        assert _calculate_cost("haiku", 0, 0, cache_read_tokens=1_000_000) == pytest.approx(0.10)
+
+    def test_legacy_call_without_cache_args_unchanged(self):
+        """Existing callers that pass only input/output get identical math."""
+        assert _calculate_cost("sonnet", 1_000_000, 1_000_000) == pytest.approx(18.0)
+
+
+class TestCacheSavings:
+
+    def test_pure_read_savings_is_90_percent_of_input_rate(self):
+        """1M sonnet reads save (1 − 0.1) × $3 = $2.70 vs uncached billing."""
+        assert _calculate_cache_savings("sonnet", 0, 1_000_000) == pytest.approx(2.70)
+
+    def test_pure_creation_is_negative_25_percent_premium(self):
+        """1M sonnet writes cost an extra (1.25 − 1) × $3 = $0.75 over uncached."""
+        assert _calculate_cache_savings("sonnet", 1_000_000, 0) == pytest.approx(-0.75)
+
+    def test_amortized_after_a_few_reads(self):
+        """After one write + 4 reads the math should be net positive."""
+        # 100k creation → -$0.075 premium; 4×100k read → +4×$0.27 = $1.08 gain
+        result = _calculate_cache_savings("sonnet", 100_000, 400_000)
+        assert result == pytest.approx(-0.075 + 1.08)
+
+
+class TestApplyUsage:
+
+    def _fresh(self):
+        return _get_default_costs()
+
+    def test_records_cache_token_counts(self):
+        costs = self._fresh()
+        _apply_usage(
+            costs,
+            "claude-sonnet-4-6",
+            input_tokens=1000,
+            output_tokens=500,
+            cache_creation_tokens=2000,
+            cache_read_tokens=8000,
+        )
+        bucket = costs["by_model"]["sonnet"]
+        assert bucket["cache_creation_tokens"] == 2000
+        assert bucket["cache_read_tokens"] == 8000
+
+    def test_accumulates_across_calls(self):
+        costs = self._fresh()
+        for _ in range(3):
+            _apply_usage(
+                costs,
+                "claude-sonnet-4-6",
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_tokens=100_000,
+            )
+        assert costs["by_model"]["sonnet"]["cache_read_tokens"] == 300_000
+
+    def test_cache_savings_aggregates(self):
+        """Top-level cache_savings rolls up net savings across calls."""
+        costs = self._fresh()
+        _apply_usage(
+            costs,
+            "claude-sonnet-4-6",
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=1_000_000,  # +$2.70 saved
+        )
+        _apply_usage(
+            costs,
+            "claude-sonnet-4-6",
+            input_tokens=0,
+            output_tokens=0,
+            cache_creation_tokens=1_000_000,  # -$0.75 premium
+        )
+        assert costs["cache_savings"] == pytest.approx(2.70 - 0.75)
+
+    def test_legacy_call_signature_still_works(self):
+        """Callers passing only input/output (no cache args) still update correctly."""
+        costs = self._fresh()
+        _apply_usage(costs, "claude-sonnet-4-6", input_tokens=1000, output_tokens=500)
+        bucket = costs["by_model"]["sonnet"]
+        assert bucket["input_tokens"] == 1000
+        assert bucket["output_tokens"] == 500
+        assert bucket["cache_creation_tokens"] == 0
+        assert bucket["cache_read_tokens"] == 0
+        assert costs["cache_savings"] == 0.0

--- a/backend/tests/test_user_spending_periods.py
+++ b/backend/tests/test_user_spending_periods.py
@@ -1,0 +1,70 @@
+"""
+Tests for lazy user spending-period resets.
+"""
+from app.services.data_services.user_service import UserService
+
+
+def _service_with_store(store):
+    """Build a UserService instance without opening a real Supabase client."""
+    svc = UserService.__new__(UserService)
+
+    def get_user_settings_raw(_user_id):
+        return dict(store)
+
+    def save_user_settings(_user_id, settings):
+        store.clear()
+        store.update(settings)
+        return True
+
+    svc.get_user_settings_raw = get_user_settings_raw
+    svc.save_user_settings = save_user_settings
+    return svc
+
+
+def test_maybe_reset_expired_spending_period_persists_zeroed_period(monkeypatch):
+    store = {
+        "cost_limit": 25.0,
+        "reset_frequency": "weekly",
+        "period_spend": 25.03,
+        "period_start": "2026-05-03T03:30:00Z",
+    }
+    svc = _service_with_store(store)
+
+    monkeypatch.setattr(
+        "app.utils.spending_schedule.is_period_expired",
+        lambda _period_start, _frequency: True,
+    )
+    monkeypatch.setattr(
+        "app.utils.spending_schedule.aligned_period_start_iso",
+        lambda _frequency: "2026-05-10T03:30:00Z",
+    )
+
+    settings = svc.maybe_reset_expired_spending_period("user-1")
+
+    assert settings["period_spend"] == 0.0
+    assert settings["period_start"] == "2026-05-10T03:30:00Z"
+    assert store["period_spend"] == 0.0
+
+
+def test_increment_period_spend_resets_before_adding_new_cost(monkeypatch):
+    store = {
+        "cost_limit": 25.0,
+        "reset_frequency": "weekly",
+        "period_spend": 25.03,
+        "period_start": "2026-05-03T03:30:00Z",
+    }
+    svc = _service_with_store(store)
+
+    monkeypatch.setattr(
+        "app.utils.spending_schedule.is_period_expired",
+        lambda _period_start, _frequency: True,
+    )
+    monkeypatch.setattr(
+        "app.utils.spending_schedule.aligned_period_start_iso",
+        lambda _frequency: "2026-05-10T03:30:00Z",
+    )
+
+    svc.increment_period_spend("user-1", 0.5)
+
+    assert store["period_spend"] == 0.5
+    assert store["period_start"] == "2026-05-10T03:30:00Z"

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -143,22 +143,29 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   );
 
   // Drag-and-drop handlers on the wrapping pill container.
+  // Why: preventDefault must run unconditionally on dragenter/dragover or
+  // the browser refuses the drop entirely. We can't gate on
+  // `dataTransfer.types` including 'Files' here because some browsers
+  // (and most Linux file managers) only expose that flag on drop, not
+  // during dragover — checking it caused drag-drop to silently no-op.
+  // acceptFiles() filters by MIME, so non-image drops are still rejected
+  // cleanly with a toast.
+  const hasFiles = (e: React.DragEvent) =>
+    Array.from(e.dataTransfer.types || []).includes('Files');
+
   const handleDragEnter = useCallback((e: React.DragEvent) => {
-    if (!Array.from(e.dataTransfer.types || []).includes('Files')) return;
     e.preventDefault();
-    setDragDepth((d) => d + 1);
+    if (hasFiles(e)) setDragDepth((d) => d + 1);
   }, []);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
-    if (!Array.from(e.dataTransfer.types || []).includes('Files')) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'copy';
   }, []);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
-    if (!Array.from(e.dataTransfer.types || []).includes('Files')) return;
     e.preventDefault();
-    setDragDepth((d) => Math.max(0, d - 1));
+    if (hasFiles(e)) setDragDepth((d) => Math.max(0, d - 1));
   }, []);
 
   const handleDrop = useCallback(


### PR DESCRIPTION
Sync develop into main.

Includes:
- #237 cost tracking: bill prompt-cache tokens at correct multipliers (closes #186)
- #238 chat: enable prompt caching on the chat hot path (closes #185)
- #235 fix: reset expired user spending periods on access

🤖 Generated with [Claude Code](https://claude.com/claude-code)