### PR TITLE
fix: stage A — freshdesk silent upsert loss + CSV agent no-termination paths

### DIFF
--- a/backend/app/services/ai_agents/csv_analyzer_agent.py
+++ b/backend/app/services/ai_agents/csv_analyzer_agent.py
@@ -143,6 +143,16 @@ class CSVAnalyzerAgent:
                             "CSV analyzer ended on text response (iter %d, no termination tool)",
                             iteration,
                         )
+                        # Append the final assistant content to messages
+                        # BEFORE save_execution so the saved transcript
+                        # ends with the answer that was actually returned
+                        # to the user. The "defer-append" pattern at the
+                        # top of this block is to keep messages ending
+                        # with a user role when we `continue` — but this
+                        # is a terminal `return`, so appending here is
+                        # both safe and necessary.
+                        serialized_content = claude_parsing_utils.serialize_content_blocks(content_blocks)
+                        messages.append({"role": "assistant", "content": serialized_content})
                         final_result = self._build_result(
                             {
                                 "summary": text,

--- a/backend/app/services/ai_agents/csv_analyzer_agent.py
+++ b/backend/app/services/ai_agents/csv_analyzer_agent.py
@@ -131,8 +131,34 @@ class CSVAnalyzerAgent:
             # Appending first then doing `continue` would leave messages ending
             # with an assistant role, causing a prefill API error on the next iteration.
             if not tool_blocks:
+                # Claude ended the turn without calling return_analysis.
+                # Previously this just `continue`d, which guaranteed we
+                # burned every remaining iteration on the same dead path
+                # (and contributed to the 27 "Max iterations reached (20)"
+                # warnings in prod). Accept the text answer instead.
                 if claude_parsing_utils.is_end_turn(response):
-                    logger.warning("End turn without return_analysis tool")
+                    text = claude_parsing_utils.extract_text(response).strip()
+                    if text:
+                        logger.info(
+                            "CSV analyzer ended on text response (iter %d, no termination tool)",
+                            iteration,
+                        )
+                        final_result = self._build_result(
+                            {
+                                "summary": text,
+                                "image_paths": generated_plots,
+                            },
+                            iteration,
+                            total_input_tokens,
+                            total_output_tokens,
+                        )
+                        self._save_execution(
+                            project_id, execution_id, query, messages,
+                            final_result, started_at, source_id,
+                        )
+                        return final_result
+                    logger.warning("End turn with no text and no tool — bailing")
+                    break
                 continue
 
             serialized_content = claude_parsing_utils.serialize_content_blocks(content_blocks)
@@ -185,7 +211,46 @@ class CSVAnalyzerAgent:
                 tool_results_content = claude_parsing_utils.build_tool_result_content(tool_results_data)
                 messages.append({"role": "user", "content": tool_results_content})
 
-        logger.warning("Max iterations reached (%d)", self.MAX_ITERATIONS)
+        logger.warning("Max iterations reached (%d) — forcing tool-less synthesis", self.MAX_ITERATIONS)
+
+        # Same shape as the main-chat synthesis fallback (commit c60393a):
+        # the loop has expensive context — run_analysis tool results,
+        # generated plots, partial reasoning — that the user paid for.
+        # Force one more Claude call with tools=None so the model can
+        # only emit prose, and surface that as the answer. Falls through
+        # to the original error_result only if even this call fails.
+        try:
+            synthesis_response = claude_service.send_message(
+                messages=messages,
+                system_prompt=config.get("system_prompt", ""),
+                model=config.get("model"),
+                max_tokens=config.get("max_tokens"),
+                temperature=config.get("temperature"),
+                tools=None,
+                project_id=project_id,
+                tags=["query", "synthesis_fallback"],
+                chat_id=chat_id,
+                user_id=user_id,
+            )
+            synthesis_usage = synthesis_response.get("usage", {})
+            total_input_tokens += synthesis_usage.get("input_tokens", 0)
+            total_output_tokens += synthesis_usage.get("output_tokens", 0)
+            synthesis_text = claude_parsing_utils.extract_text(synthesis_response).strip()
+            if synthesis_text:
+                final_result = self._build_result(
+                    {"summary": synthesis_text, "image_paths": generated_plots},
+                    self.MAX_ITERATIONS,
+                    total_input_tokens,
+                    total_output_tokens,
+                )
+                self._save_execution(
+                    project_id, execution_id, query, messages,
+                    final_result, started_at, source_id,
+                )
+                return final_result
+        except Exception as exc:
+            logger.warning("CSV analyzer synthesis fallback failed: %s", exc)
+
         error_result = {
             "success": False,
             "error": f"Analysis did not complete within {self.MAX_ITERATIONS} iterations",

--- a/backend/app/services/ai_agents/csv_analyzer_agent.py
+++ b/backend/app/services/ai_agents/csv_analyzer_agent.py
@@ -247,6 +247,14 @@ class CSVAnalyzerAgent:
             total_output_tokens += synthesis_usage.get("output_tokens", 0)
             synthesis_text = claude_parsing_utils.extract_text(synthesis_response).strip()
             if synthesis_text:
+                # Append the synthesis assistant content to messages
+                # BEFORE _save_execution so the saved transcript ends
+                # with the answer the user actually saw — same shape as
+                # the end-turn-text branch above. The synthesis call ran
+                # with tools=None, so its content_blocks are pure text.
+                synthesis_blocks = synthesis_response.get("content_blocks", [])
+                synthesis_serialized = claude_parsing_utils.serialize_content_blocks(synthesis_blocks)
+                messages.append({"role": "assistant", "content": synthesis_serialized})
                 final_result = self._build_result(
                     {"summary": synthesis_text, "image_paths": generated_plots},
                     self.MAX_ITERATIONS,

--- a/backend/app/services/ai_services/csv_service.py
+++ b/backend/app/services/ai_services/csv_service.py
@@ -34,7 +34,10 @@ class CSVService:
     Claude analyzes the tool output and generates a concise summary.
     """
 
-    MAX_ITERATIONS = 5  # Simple analysis shouldn't need many iterations
+    # 10 (was 5) — 5 was too tight when Claude wants to call csv_analyzer
+    # more than once before summarising (e.g. profile then sample). The
+    # cost ceiling is small here since this runs on Haiku.
+    MAX_ITERATIONS = 10
     TERMINATION_TOOL = "return_csv_summary"
 
     def __init__(self):
@@ -121,9 +124,28 @@ class CSVService:
             tool_blocks = claude_parsing_utils.extract_tool_use_blocks(response)
 
             if not tool_blocks:
-                # No tool calls - check if end_turn
+                # Claude ended the turn without calling return_csv_summary.
+                # Previous behaviour was to `continue`, which just re-asked
+                # Claude with the same conversation — guaranteed to waste
+                # every remaining iteration on the same dead path
+                # (12 hits of "End turn without summary tool - unexpected"
+                # in prod). Treat the text Claude produced as the summary
+                # and exit cleanly.
                 if claude_parsing_utils.is_end_turn(response):
-                    logger.warning("End turn without summary tool - unexpected")
+                    text = claude_parsing_utils.extract_text(response).strip()
+                    if text:
+                        logger.info(
+                            "CSV analysis ended on text response (iter %d, no termination tool)",
+                            iteration,
+                        )
+                        return self._build_result(
+                            {"summary": text, "row_count": 0, "column_count": 0},
+                            iteration,
+                            total_input_tokens,
+                            total_output_tokens,
+                        )
+                    logger.warning("End turn with no text and no tool — bailing")
+                    break
                 continue
 
             # Process each tool call

--- a/backend/app/services/ai_services/csv_service.py
+++ b/backend/app/services/ai_services/csv_service.py
@@ -138,8 +138,13 @@ class CSVService:
                             "CSV analysis ended on text response (iter %d, no termination tool)",
                             iteration,
                         )
+                        # Claude produced only prose — it never called the
+                        # csv_analyzer tool, so we have no real row/column
+                        # counts to report. Use None (not 0) so a frontend
+                        # that displays row/column metadata can render
+                        # "—" rather than silently showing "0 rows".
                         return self._build_result(
-                            {"summary": text, "row_count": 0, "column_count": 0},
+                            {"summary": text, "row_count": None, "column_count": None},
                             iteration,
                             total_input_tokens,
                             total_output_tokens,

--- a/backend/app/services/integrations/freshdesk/freshdesk_sync_service.py
+++ b/backend/app/services/integrations/freshdesk/freshdesk_sync_service.py
@@ -419,14 +419,30 @@ class FreshdeskSyncService:
 
                 # PGRST303 → JWT expired on the cached service-role
                 # client. Rebuild and retry the same rows once.
-                if "PGRST303" in err_str and not jwt_recovery_done:
-                    jwt_recovery_done = True
-                    logger.warning(
-                        "Supabase service-role JWT expired (PGRST303); resetting client and retrying batch (%d rows)",
+                if "PGRST303" in err_str:
+                    if not jwt_recovery_done:
+                        jwt_recovery_done = True
+                        logger.warning(
+                            "Supabase service-role JWT expired (PGRST303); resetting client and retrying batch (%d rows)",
+                            len(rows),
+                        )
+                        SupabaseClient.reset()
+                        return _try(rows)
+                    # Recovery already attempted and PGRST303 came back.
+                    # Don't fall into the halving branch — every smaller
+                    # sub-batch will hit the same expired JWT, end up at
+                    # len(rows) == 1, and emit N "Upsert dropped" errors
+                    # without ever pointing at the real cause. Emit one
+                    # actionable CRITICAL and abandon the rest of the
+                    # batch so the operator has a clear signal.
+                    logger.critical(
+                        "Supabase service-role JWT still expired after client reset — "
+                        "the SUPABASE_SERVICE_KEY env value itself is stale. "
+                        "Rotate the key in the deployment and restart. "
+                        "Dropping %d ticket(s) in this batch.",
                         len(rows),
                     )
-                    SupabaseClient.reset()
-                    return _try(rows)
+                    return 0
 
                 # Single row that still failed → drop it, log with
                 # ticket_id so the operator can investigate the

--- a/backend/app/services/integrations/freshdesk/freshdesk_sync_service.py
+++ b/backend/app/services/integrations/freshdesk/freshdesk_sync_service.py
@@ -146,14 +146,16 @@ class FreshdeskSyncService:
                     logger.error("Transform error for ticket %s: %s", raw_ticket.get("id"), e)
 
                 if len(batch) >= 100:
-                    self._upsert_batch(batch)
-                    stats["tickets_upserted"] += len(batch)
+                    upserted = self._upsert_batch(batch)
+                    stats["tickets_upserted"] += upserted
+                    stats["errors"] += len(batch) - upserted
                     batch = []
 
             # Final batch
             if batch:
-                self._upsert_batch(batch)
-                stats["tickets_upserted"] += len(batch)
+                upserted = self._upsert_batch(batch)
+                stats["tickets_upserted"] += upserted
+                stats["errors"] += len(batch) - upserted
 
             logger.info(
                 "Freshdesk sync complete (source_id=%s): fetched=%d, upserted=%d, errors=%d",
@@ -361,18 +363,92 @@ class FreshdeskSyncService:
             "synced_at": datetime.now(timezone.utc).isoformat(),
         }
 
-    def _upsert_batch(self, tickets: List[Dict[str, Any]]) -> None:
-        """Batch upsert tickets for performance (100 at a time instead of 1-by-1).
-        Uses ticket_id as the unique key since tickets are stored globally."""
+    def _upsert_batch(self, tickets: List[Dict[str, Any]]) -> int:
+        """Batch upsert tickets, returning the count actually written.
+
+        Three robustness measures over the naive single-shot upsert:
+
+        1. ``returning="minimal"`` — PostgREST otherwise ships the full
+           upserted rowset back through Kong. With 100 freshdesk_tickets
+           rows (long ``description_text``, JSONB ``custom_fields``) the
+           response can exceed Kong's upstream buffer / timeout and come
+           back as ``code 502 / "JSON could not be generated"`` — which
+           we saw 2483× in prod. We already have the rows; nothing wants
+           the echoed body.
+
+        2. Halving retry on any non-JWT failure — recovers transient 502s
+           and the rare row that's pathologically large for the chunked
+           response. Walks down to per-row inserts before giving up.
+
+        3. PGRST303 recovery — the singleton supabase client caches the
+           service-role JWT it was built with. On self-hosted Supabase
+           the JWT can carry an ``exp`` claim; once it stales, every
+           call from every service fails with PGRST303 until container
+           restart. Reset the singleton (re-reads SUPABASE_SERVICE_KEY
+           from env) and retry the batch once. If it persists, we log
+           CRITICAL — the key itself needs rotation.
+
+        Returns the count of tickets actually upserted (caller compares
+        against the batch length to know how many were dropped).
+        """
         if not tickets:
-            return
-        try:
-            supabase = get_supabase()
-            supabase.table("freshdesk_tickets").upsert(
-                tickets, on_conflict="ticket_id"
-            ).execute()
-        except Exception as e:
-            logger.error("Batch upsert failed (%d tickets): %s", len(tickets), e)
+            return 0
+
+        # Imported lazily to avoid pulling in the module at import time.
+        from app.services.integrations.supabase.supabase_client import SupabaseClient
+
+        # PGRST303 recovery should fire at most once per top-level batch:
+        # the first time we see it, we reset the client and retry the
+        # whole batch from the top. Persisting after that means the env
+        # key itself is stale — no amount of retrying will help.
+        jwt_recovery_done = False
+
+        def _try(rows: List[Dict[str, Any]]) -> int:
+            nonlocal jwt_recovery_done
+            if not rows:
+                return 0
+            try:
+                get_supabase().table("freshdesk_tickets").upsert(
+                    rows,
+                    on_conflict="ticket_id",
+                    returning="minimal",
+                ).execute()
+                return len(rows)
+            except Exception as exc:
+                err_str = str(exc)
+
+                # PGRST303 → JWT expired on the cached service-role
+                # client. Rebuild and retry the same rows once.
+                if "PGRST303" in err_str and not jwt_recovery_done:
+                    jwt_recovery_done = True
+                    logger.warning(
+                        "Supabase service-role JWT expired (PGRST303); resetting client and retrying batch (%d rows)",
+                        len(rows),
+                    )
+                    SupabaseClient.reset()
+                    return _try(rows)
+
+                # Single row that still failed → drop it, log with
+                # ticket_id so the operator can investigate the
+                # specific record.
+                if len(rows) == 1:
+                    logger.error(
+                        "Upsert dropped freshdesk ticket %s: %s",
+                        rows[0].get("ticket_id"), exc,
+                    )
+                    return 0
+
+                # Halve and retry. Recovers transient upstream 502s and
+                # isolates any individual row that's too large for the
+                # response chunker.
+                mid = len(rows) // 2
+                logger.warning(
+                    "Batch upsert failed (%d rows), halving: %s",
+                    len(rows), exc,
+                )
+                return _try(rows[:mid]) + _try(rows[mid:])
+
+        return _try(tickets)
 
     @staticmethod
     def _compute_hours_between(


### PR DESCRIPTION
## Summary

Three production stability fixes traced from the latest backend logs. All three silently drop data or burn user-paid Claude tokens with no visible response.

---

### 1. Freshdesk `_upsert_batch` silently loses batches

**Log evidence — 2867 distinct failures across 3 log files, split into two families:**

| Hits | Error message |
|---:|---|
| 2483 | `Batch upsert failed (100 tickets): {'message': 'JSON could not be generated', 'code': 502, 'hint': 'Refer to full message for details', 'details': 'An invalid response was received from the upstream server'}` |
| 384 | `Batch upsert failed (100 tickets): {'message': 'JWT expired', 'code': 'PGRST303', 'hint': None, 'details': None}` |

**Concrete failure cluster** at `2026-05-12 20:19:50` (backend.log.1 lines 6240–6280) — one backfill sync had fetched ~17900 tickets across 180 pages, then **every** subsequent batch upsert blew up within the same second, mixing 502 and PGRST303:

```
20:19:48 [INFO] freshdesk_service: Freshdesk: page 178 (100 tickets, 17800 total, rate=3375/5000)
20:19:48 [WARNING] freshdesk_sync_service: Freshdesk progress update failed: {'message': 'JWT expired', 'code': 'PGRST303', ...}
20:19:50 [INFO] freshdesk_service: Freshdesk: page 180 (12 tickets, 17912 total, rate=3357/5000)
20:19:50 [ERROR] freshdesk_sync_service: Batch upsert failed (100 tickets): {'message': 'JSON could not be generated', 'code': 502, ...'An invalid response was received from the upstream server'...}
20:19:50 [ERROR] freshdesk_sync_service: Batch upsert failed (100 tickets): {'message': 'JWT expired', 'code': 'PGRST303', ...}
20:19:50 [ERROR] freshdesk_sync_service: Batch upsert failed (100 tickets): {'message': 'JSON could not be generated', 'code': 502, ...}
... (28 more identical lines in the same second)
```

Same root cause manifesting in two ways:

- **502 / "JSON could not be generated"** — PostgREST's default `returning=representation` echoes all 100 rows back through Kong. With long `description_text` and JSONB `custom_fields`, the response body exceeds Kong's upstream buffer / timeout. We already have the rows, nothing wants the echo.
- **PGRST303 / "JWT expired"** — the singleton `get_supabase()` client caches the service-role JWT it was built with at process start. On self-hosted Supabase, some setups carry an `exp` claim on the service key; once it stales, every call from every service fails until container restart. We see the same code spamming from `task_service.get_tasks_for_target` and `auth_service.Token refresh failed: Invalid Refresh Token: Already Used` (backend.log.1 lines 5688, 5708+) — same expired-JWT singleton.

`_upsert_batch` caught the exception, logged it, and swallowed it — meanwhile the caller in `sync_tickets` did:

```python
self._upsert_batch(batch)
stats["tickets_upserted"] += len(batch)   # ← incremented unconditionally
```

So the sync reported `upserted=N` while N rows were actually lost.

**Fixes (commit `a6452a0`)**:
1. Pass `returning="minimal"` — kills the 2483 family by not asking PostgREST to ship rows back.
2. **Halving retry** on any other failure: 100 → 50 → 25 → … → 1, isolates pathological rows, recovers transient 502s, logs the dropped `ticket_id` if a single-row insert still fails.
3. **PGRST303 recovery**: catch the code, `SupabaseClient.reset()` to re-read `SUPABASE_SERVICE_KEY` from env, retry the batch once. If persistence after that, log CRITICAL — env key itself is stale and needs rotation.
4. `_upsert_batch` now returns the actual upserted count; caller credits `stats["errors"]` for the diff instead of assuming `len(batch)` succeeded.

---

### 2. CSV ingestion service burns iterations on text-only `end_turn`

**Log evidence:**
- **12×** `[WARNING] csv_service: End turn without summary tool - unexpected`
- **6×** `[WARNING] csv_service: Max iterations reached (5)` (the same path eventually exhausting)

Sample lines (backend.log.1):
```
06:39:41 [WARNING] csv_service: End turn without summary tool - unexpected
06:39:42 [WARNING] csv_service: Max iterations reached (5)
```

**Code path** at `csv_service.py:123-127`:

```python
if not tool_blocks:
    if claude_parsing_utils.is_end_turn(response):
        logger.warning("End turn without summary tool - unexpected")
    continue   # ← guaranteed to waste every remaining iteration
```

When Claude end_turns with text instead of calling `return_csv_summary`, the bare `continue` re-asks Claude with the same conversation. Claude does the same thing again. 5 iterations, source has no summary.

**Fix (commit `b4dfa4f`)**:
- On `end_turn` without termination tool, `claude_parsing_utils.extract_text(response)` and use it as the summary. Most of the time Claude IS giving us the analysis — as prose.
- Bump `MAX_ITERATIONS` 5 → 10. Cheap on Haiku.

---

### 3. CSV analyzer agent (live chat) silently fails at MAX_ITERATIONS

**Log evidence — 27×** `[WARNING] csv_analyzer_agent: Max iterations reached (20)`

Sample lines:
```
04:52:04 [WARNING] csv_analyzer_agent: Max iterations reached (20)
04:55:47 [WARNING] csv_analyzer_agent: Max iterations reached (20)
04:56:35 [WARNING] csv_analyzer_agent: Max iterations reached (20)
```

`tool_choice={"type":"any"}` forces tool use, so the user ends up in a different failure mode than #2: Claude keeps calling `run_analysis` (pandas) 20× and never calls `return_analysis`. Each iteration is a full Claude call — 20 burnt calls, then `success=False` with `"Analysis did not complete within 20 iterations"` shown to the user.

**Fix (commit `d6c4ae9`)** mirrors the chat synthesis fallback shipped in `c60393a`:
- On max-iterations: force ONE more `claude_service.send_message` with `tools=None` so the model can only emit prose. Surface that text + any `generated_plots` collected along the way as the answer. Falls back to the original error only if the synthesis call also returns nothing.
- Same `end_turn`-without-tool fix as #2 (rare here under forced `tool_choice="any"`, kept for parity).

---

## Test plan

- [ ] Trigger a Freshdesk backfill against a large account (>10k tickets). Confirm no `Batch upsert failed` with the `returning=representation` 502 wording.
- [ ] Force a stale JWT (e.g. wait past expiry on a short-`JWT_EXPIRY` Supabase): confirm one `PGRST303 JWT expired; resetting client` warning, then subsequent batches succeed.
- [ ] Upload a CSV that takes more than one tool round to summarise. Confirm a summary is generated even if Claude doesn't call `return_csv_summary` cleanly.
- [ ] Ask the CSV analyzer agent a question complex enough to spike past 20 `run_analysis` calls. Confirm the user sees a synthesised answer, not the `"Analysis did not complete"` string.
- [ ] Existing chats / source-ingestion flows for non-CSV / non-Freshdesk paths still work (no shared call sites changed besides `stats` accounting on the freshdesk caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)