### PR TITLE
feat(cache): auto-cache messages array (top-level cache_control) — 14 studio agents + main chat

### DIFF
--- a/backend/app/services/ai_agents/blog_agent_service.py
+++ b/backend/app/services/ai_agents/blog_agent_service.py
@@ -138,7 +138,8 @@ class BlogAgentService:
                 temperature=config["temperature"],
                 tools=tools["all_tools"] if isinstance(tools, dict) else tools,
                 tool_choice={"type": "any"},
-                project_id=project_id
+                project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/business_report_agent_service.py
+++ b/backend/app/services/ai_agents/business_report_agent_service.py
@@ -115,7 +115,8 @@ class BusinessReportAgentService:
                 temperature=config["temperature"],
                 tools=tools["all_tools"] if isinstance(tools, dict) else tools,
                 tool_choice={"type": "any"},
-                project_id=project_id
+                project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/component_agent_service.py
+++ b/backend/app/services/ai_agents/component_agent_service.py
@@ -317,6 +317,7 @@ class ComponentAgentService:
                 tools=tools["all_tools"] if isinstance(tools, dict) else tools,
                 tool_choice={"type": "any"},
                 project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/csv_analyzer_agent.py
+++ b/backend/app/services/ai_agents/csv_analyzer_agent.py
@@ -119,6 +119,7 @@ class CSVAnalyzerAgent:
                 tags=["query"],
                 chat_id=chat_id,
                 user_id=user_id,
+                enable_prompt_cache=True,
             )
 
             total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/database_analyzer_agent.py
+++ b/backend/app/services/ai_agents/database_analyzer_agent.py
@@ -140,6 +140,7 @@ class DatabaseAnalyzerAgent:
                     tags=["query"],
                     chat_id=chat_id,
                     user_id=user_id,
+                    enable_prompt_cache=True,
                 )
 
                 total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/deep_research_agent.py
+++ b/backend/app/services/ai_agents/deep_research_agent.py
@@ -124,7 +124,8 @@ class DeepResearchAgent:
                 temperature=config["temperature"],
                 tools=all_tools,
                 tool_choice={"type": "any"},
-                project_id=project_id
+                project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             # Track token usage

--- a/backend/app/services/ai_agents/email_agent_service.py
+++ b/backend/app/services/ai_agents/email_agent_service.py
@@ -257,7 +257,8 @@ class EmailAgentService:
                 temperature=config["temperature"],
                 tools=tools["all_tools"] if isinstance(tools, dict) else tools,
                 tool_choice={"type": "any"},
-                project_id=project_id
+                project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/freshdesk_analyzer_agent.py
+++ b/backend/app/services/ai_agents/freshdesk_analyzer_agent.py
@@ -162,6 +162,7 @@ class FreshdeskAnalyzerAgent:
                     tags=["query"],
                     chat_id=chat_id,
                     user_id=user_id,
+                    enable_prompt_cache=True,
                 )
 
                 # Track usage

--- a/backend/app/services/ai_agents/marketing_strategy_agent_service.py
+++ b/backend/app/services/ai_agents/marketing_strategy_agent_service.py
@@ -124,7 +124,8 @@ class MarketingStrategyAgentService:
                 temperature=config["temperature"],
                 tools=tools["all_tools"] if isinstance(tools, dict) else tools,
                 tool_choice={"type": "any"},
-                project_id=project_id
+                project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/prd_agent_service.py
+++ b/backend/app/services/ai_agents/prd_agent_service.py
@@ -126,7 +126,8 @@ class PRDAgentService:
                 temperature=config["temperature"],
                 tools=tools["all_tools"] if isinstance(tools, dict) else tools,
                 tool_choice={"type": "any"},
-                project_id=project_id
+                project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/presentation_agent_service.py
+++ b/backend/app/services/ai_agents/presentation_agent_service.py
@@ -126,7 +126,8 @@ class PresentationAgentService:
                 temperature=config["temperature"],
                 tools=tools["all_tools"] if isinstance(tools, dict) else tools,
                 tool_choice={"type": "any"},
-                project_id=project_id
+                project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/web_agent_service.py
+++ b/backend/app/services/ai_agents/web_agent_service.py
@@ -123,7 +123,8 @@ class WebAgentService:
                 tools=all_tools,
                 tool_choice={"type": "any"},
                 extra_headers=extra_headers,
-                project_id=project_id
+                project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             # Track token usage

--- a/backend/app/services/ai_agents/website_agent_service.py
+++ b/backend/app/services/ai_agents/website_agent_service.py
@@ -119,7 +119,8 @@ class WebsiteAgentService:
                 temperature=config["temperature"],
                 tools=tools["all_tools"] if isinstance(tools, dict) else tools,
                 tool_choice={"type": "any"},
-                project_id=project_id
+                project_id=project_id,
+                enable_prompt_cache=True,
             )
 
             total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/ai_agents/wireframe_agent_service.py
+++ b/backend/app/services/ai_agents/wireframe_agent_service.py
@@ -170,6 +170,7 @@ class WireframeAgentService:
                     tools=tools["all_tools"] if isinstance(tools, dict) else tools,
                     tool_choice={"type": "any"},
                     project_id=project_id,
+                    enable_prompt_cache=True,
                 )
 
                 total_input_tokens += response["usage"]["input_tokens"]

--- a/backend/app/services/integrations/claude/claude_service.py
+++ b/backend/app/services/integrations/claude/claude_service.py
@@ -466,6 +466,18 @@ class ClaudeService:
         if tool_choice:
             api_params["tool_choice"] = tool_choice
 
+        # Automatic prompt caching for the messages array. Setting
+        # `cache_control` at the top level tells Anthropic to place a cache
+        # breakpoint on the last cacheable block of `messages` and slide
+        # that breakpoint forward as the conversation/loop grows — so each
+        # turn after the first reads the prior turns from cache instead of
+        # paying full input price. Stacks with the explicit breakpoints on
+        # `system` and the last tool above; budget goes 2-of-4 → 3-of-4.
+        # 5-min TTL (default ephemeral) is enough for chat sessions and
+        # in-flight agentic loops; 1h would double write cost for no win.
+        if enable_prompt_cache:
+            api_params["cache_control"] = {"type": "ephemeral"}
+
         # Add extra headers for beta features (e.g., web_fetch)
         if extra_headers:
             api_params["extra_headers"] = extra_headers

--- a/backend/tests/test_claude_prompt_cache.py
+++ b/backend/tests/test_claude_prompt_cache.py
@@ -103,6 +103,13 @@ class TestBuildApiParamsCaching:
         params = self._build(enable_prompt_cache=False)
         assert params["system"] == "you are NoobBook"
         assert "cache_control" not in params["tools"][-1]
+        assert "cache_control" not in params
+
+    def test_caching_on_sets_top_level_cache_control(self):
+        """Top-level cache_control opts into Anthropic's automatic messages-array
+        breakpoint that slides forward as the conversation grows."""
+        params = self._build(enable_prompt_cache=True)
+        assert params["cache_control"] == {"type": "ephemeral"}
 
     def test_caching_on_wraps_system(self):
         params = self._build(enable_prompt_cache=True)

--- a/backend/tests/test_claude_prompt_cache.py
+++ b/backend/tests/test_claude_prompt_cache.py
@@ -127,8 +127,14 @@ class TestBuildApiParamsCaching:
         # No tools key when tools is falsy, but system should still cache.
         assert "tools" not in params
         assert params["system"][0]["cache_control"] == {"type": "ephemeral"}
+        # Top-level messages-array breakpoint must still be set — it's
+        # independent of whether tools are present.
+        assert params["cache_control"] == {"type": "ephemeral"}
 
     def test_caching_on_with_no_system_does_not_crash(self):
         params = self._build(enable_prompt_cache=True, system_prompt=None)
         assert "system" not in params
         assert params["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+        # Top-level messages-array breakpoint must still be set — it's
+        # independent of whether a system prompt is present.
+        assert params["cache_control"] == {"type": "ephemeral"}


### PR DESCRIPTION
## Summary

- Wire Anthropic's **automatic prompt caching** into `_build_api_params` — a single top-level `cache_control: {\"type\": \"ephemeral\"}` causes the API to place a cache breakpoint on the latest cacheable block of `messages` and *slide it forward* each turn. Existing system + last-tool breakpoints stay; budget goes 2-of-4 → 3-of-4.
- Flip `enable_prompt_cache=True` on the **in-loop** `send_message` / `stream_message` call in all 14 studio agentic services. They iterate up to 40 times and re-send a fully growing messages array each turn — until now they paid full input price on every iteration.
- `main_chat_service` already passes the flag; it transparently picks up the messages-array breakpoint with zero code change.

## What's *not* in this PR

- Single-shot services in `ai_services/` (pdf, pptx, image, summary, chat_naming, memory, csv, video_prompt, wireframe) — no loop, no cache hit to chase.
- `csv_analyzer_agent.py:233` synthesis fallback — different prefix (`tools=None`), same reason `main_chat:736` stays off.
- Cost-tracking pipeline — already records `cache_creation_input_tokens` / `cache_read_input_tokens` into `projects.costs` and `chats.costs` JSONB.

## Verification done

- Isolated logic test of `_build_api_params`:
  - `enable_prompt_cache=True` → top-level `cache_control` set, system + last-tool breakpoints intact (3 of 4 slots).
  - `enable_prompt_cache=False` → request shape byte-identical to before.
  - Opus 4.7 `temperature` stripping still works alongside the new cache field.
- All 16 edited files parse OK.
- Added 2 test cases in `test_claude_prompt_cache.py` covering both states.

## Test plan

- [ ] After Coolify redeploys, send 3 turns in an existing chat with sources. Check `GET /api/v1/projects/{id}/chats/{chat_id}/costs` — `cache_read_tokens` per model should grow turn over turn (today: system + tools only; after: prior messages too).
- [ ] Generate a component (Opus 4.7, ≥3 iters): `GET /api/v1/projects/{id}/costs` before/after — `cache_creation_tokens` and `cache_read_tokens` both non-zero, `cache_savings` net-positive.
- [ ] Run a CSV analyzer (Sonnet, multi-iter): same check.
- [ ] Run web_agent (Haiku — 2048-token min; early iters silently skip cache, late iters cache). Should still complete normally.
- [ ] Smoke regression: a single-shot extraction (PDF upload) should be unaffected (no flag passed).

## Anthropic docs caveats — handled

- 5-min TTL via default `ephemeral` (1h would 2× write cost for no benefit here).
- Min thresholds (1024 Sonnet/Opus, 2048 Haiku) — sub-threshold blocks served-but-not-cached, silent safe fallback.
- Top-level breakpoint consumes 1 of 4 slots — 3 used, 1 free.
- Byte-identical prefix: `_rewrite_image_blocks_for_claude` re-encodes attachments each turn but reads identical bytes from storage and uses deterministic base64 — prefix stays stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)