### PR TITLE
auth: tighten share gating + secure-by-default signup posture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ docker/supabase/volumes/minio/
 
 # Supabase CLI temp files
 backend/supabase/.temp/
+SECURITY_FOLLOWUPS.md

--- a/backend/app/services/auth/rbac.py
+++ b/backend/app/services/auth/rbac.py
@@ -147,14 +147,19 @@ def _resolve_identity() -> RequestIdentity:
                 )
                 user_id = claims.get("sub")
                 email = claims.get("email")
-                # GoTrue puts the verified flag at the top level when
-                # autoconfirm is on, and inside `user_metadata` otherwise.
-                # Read both, default False.
-                user_metadata = claims.get("user_metadata") or {}
-                email_verified = bool(
-                    claims.get("email_verified")
-                    or user_metadata.get("email_verified")
-                )
+                # Trust ONLY `email_confirmed_at` — it's set server-side
+                # by GoTrue when the user completes email verification
+                # and ends up in the JWT's signed claims, NOT writable
+                # by the user. `user_metadata.email_verified` maps to
+                # `raw_user_meta_data` which any authenticated caller
+                # can overwrite via `auth.updateUser({data: {...}})`, so
+                # treating it as a verification signal is a forgeable
+                # gate. Top-level `email_verified` is non-standard in
+                # GoTrue v2 and not consistently populated, so we don't
+                # honour it either. If `email_confirmed_at` isn't in the
+                # token, default to False and rely on the slow path
+                # (auth.get_user()) below for an authoritative check.
+                email_verified = bool(claims.get("email_confirmed_at"))
                 if user_id:
                     role = _load_role_from_users_table(str(user_id)) or ROLE_USER
                     return RequestIdentity(

--- a/backend/app/services/auth/rbac.py
+++ b/backend/app/services/auth/rbac.py
@@ -51,6 +51,12 @@ class RequestIdentity:
     email: Optional[str]
     role: str
     is_authenticated: bool
+    # True only when the JWT carries an operator-verified mailbox claim.
+    # Defaults to False so non-JWT identity sources (single-user fallback,
+    # legacy callers constructing this manually) never accidentally
+    # signal verified ownership. Consumed by share gating to decide
+    # whether to trust the email claim for invite matching.
+    email_verified: bool = False
 
     @property
     def is_admin(self) -> bool:
@@ -102,8 +108,7 @@ def get_request_identity() -> RequestIdentity:
 
     Priority:
     1) Supabase Auth JWT (Authorization: Bearer <jwt>) if Supabase configured
-    2) Explicit dev headers (X-NoobBook-User-Id / X-NoobBook-Role)
-    3) Single-user fallback (DEFAULT_USER_ID as admin)
+    2) Single-user fallback (DEFAULT_USER_ID as admin/user depending on NOOBBOOK_AUTH_REQUIRED)
 
     Per-request caching: result is stashed on Flask's `g` so multiple
     callers within the same request (the before_request hook,
@@ -142,6 +147,14 @@ def _resolve_identity() -> RequestIdentity:
                 )
                 user_id = claims.get("sub")
                 email = claims.get("email")
+                # GoTrue puts the verified flag at the top level when
+                # autoconfirm is on, and inside `user_metadata` otherwise.
+                # Read both, default False.
+                user_metadata = claims.get("user_metadata") or {}
+                email_verified = bool(
+                    claims.get("email_verified")
+                    or user_metadata.get("email_verified")
+                )
                 if user_id:
                     role = _load_role_from_users_table(str(user_id)) or ROLE_USER
                     return RequestIdentity(
@@ -149,6 +162,7 @@ def _resolve_identity() -> RequestIdentity:
                         email=str(email) if email else None,
                         role=role,
                         is_authenticated=True,
+                        email_verified=email_verified,
                     )
             except (jwt.ExpiredSignatureError, jwt.InvalidTokenError):
                 # Local decode rejected — fall through to network path
@@ -165,6 +179,18 @@ def _resolve_identity() -> RequestIdentity:
             user = getattr(user_resp, "user", None) or user_resp
             user_id = getattr(user, "id", None) or (user.get("id") if isinstance(user, dict) else None)
             email = getattr(user, "email", None) or (user.get("email") if isinstance(user, dict) else None)
+            # GoTrue marks verified mailboxes with a non-null
+            # `email_confirmed_at` timestamp. Some client versions also
+            # expose `email_verified` directly — accept either.
+            confirmed_at = (
+                getattr(user, "email_confirmed_at", None)
+                or (user.get("email_confirmed_at") if isinstance(user, dict) else None)
+            )
+            email_verified = bool(
+                confirmed_at
+                or getattr(user, "email_verified", False)
+                or (user.get("email_verified") if isinstance(user, dict) else False)
+            )
             if user_id:
                 role = _load_role_from_users_table(user_id) or ROLE_USER
                 return RequestIdentity(
@@ -172,23 +198,18 @@ def _resolve_identity() -> RequestIdentity:
                     email=str(email) if email else None,
                     role=role,
                     is_authenticated=True,
+                    email_verified=email_verified,
                 )
         except Exception:
-            pass  # Fall through to dev/single-user mode
+            pass  # Fall through to single-user mode
 
-    # 2) Dev headers (useful until full auth UI is wired)
-    header_user_id = (request.headers.get("X-NoobBook-User-Id") or "").strip()
-    header_role = (request.headers.get("X-NoobBook-Role") or "").strip().lower()
-    if header_user_id:
-        role = header_role if header_role in _VALID_ROLES else (_load_role_from_users_table(header_user_id) or ROLE_USER)
-        return RequestIdentity(
-            user_id=header_user_id,
-            email=None,
-            role=role,
-            is_authenticated=True,
-        )
-
-    # 3) Single-user fallback
+    # Single-user fallback. The previous dev-headers branch
+    # (X-NoobBook-User-Id / X-NoobBook-Role) was removed — it
+    # unconditionally trusted the caller's claimed identity which
+    # broke the share-route invariant that unauthenticated callers
+    # cannot fork into another user's workspace. Local development
+    # should use a real JWT (GoTrue sign-in) or the single-user
+    # fallback below.
     auth_required = is_auth_required()
     fallback_role = ROLE_ADMIN if not auth_required else ROLE_USER
     return RequestIdentity(
@@ -196,6 +217,7 @@ def _resolve_identity() -> RequestIdentity:
         email=None,
         role=fallback_role,
         is_authenticated=False,
+        email_verified=False,
     )
 
 

--- a/backend/app/services/auth/share_token.py
+++ b/backend/app/services/auth/share_token.py
@@ -94,10 +94,13 @@ def require_share_token(*, require_jwt: bool = False) -> Callable:
                 )
 
             # Resolve the caller's identity. For public mode this can be
-            # anonymous; for invited mode we need a JWT.
+            # anonymous; for invited mode we need a JWT with a verified
+            # mailbox (or a user_id already in the invitee list — see
+            # share_service.viewer_invited for the resolution order).
             identity = get_request_identity()
             viewer_user_id = identity.user_id if identity.is_authenticated else None
             viewer_email = identity.email if identity.is_authenticated else None
+            viewer_email_verified = identity.email_verified if identity.is_authenticated else False
 
             if row.get("mode") == "invited":
                 if not identity.is_authenticated:
@@ -109,7 +112,12 @@ def require_share_token(*, require_jwt: bool = False) -> Callable:
                         },
                         401,
                     )
-                if not share_service.email_invited(row, viewer_email):
+                if not share_service.viewer_invited(
+                    row,
+                    viewer_user_id=viewer_user_id,
+                    viewer_email=viewer_email,
+                    email_verified=viewer_email_verified,
+                ):
                     return _error(
                         {
                             "success": False,

--- a/backend/app/services/data_services/share_service.py
+++ b/backend/app/services/data_services/share_service.py
@@ -242,18 +242,27 @@ def viewer_invited(
     if not matched_email:
         return False
 
-    # Promote: remove the matched email, add the user_id. Best-effort
-    # update; if it fails (network/RLS), we still grant access for
-    # this request — the next request retries the promotion. We never
+    # Promote: remove the matched email, add the user_id. Atomic
+    # server-side via the `promote_share_invitee` RPC (migration 00036)
+    # — using array_remove / array_append on the live row, not a
+    # Python-side read-modify-write. This is what prevents two
+    # concurrent invitees from clobbering each other's promotion and
+    # leaving one of them stranded outside both arrays.
+    #
+    # Best-effort: if the RPC call fails (network blip / RLS / migration
+    # not yet applied) we still grant access for THIS request. The next
+    # request from the same invitee will retry the promotion. We never
     # cache a failed promotion in memory so retries stay correct.
     try:
         client = _client()
-        next_emails = [e for e in invited_emails if e and e.lower() != normalized]
-        next_user_ids = list(invited_user_ids) + [viewer_user_id]
-        client.table("project_shares").update({
-            "invited_emails": next_emails,
-            "invited_user_ids": next_user_ids,
-        }).eq("id", row["id"]).execute()
+        client.rpc(
+            "promote_share_invitee",
+            {
+                "p_share_id": row["id"],
+                "p_email": matched_email,
+                "p_user_id": viewer_user_id,
+            },
+        ).execute()
     except Exception as e:
         logger.warning(
             "viewer_invited: failed to promote invitee email→user_id for share %s: %s",

--- a/backend/app/services/data_services/share_service.py
+++ b/backend/app/services/data_services/share_service.py
@@ -194,12 +194,80 @@ def is_share_usable(row: Dict[str, Any]) -> bool:
     return _is_active(row)
 
 
-def email_invited(row: Dict[str, Any], email: Optional[str]) -> bool:
-    """For invited mode: check that the viewer's email is in the allow-list.
-    Public mode always returns True (mode-mismatch is the caller's job)."""
+def viewer_invited(
+    row: Dict[str, Any],
+    viewer_user_id: Optional[str],
+    viewer_email: Optional[str],
+    email_verified: bool,
+) -> bool:
+    """Check whether a viewer is allowed through an invited-mode share.
+
+    UUID-first with lazy email→user_id promotion. The historical
+    plain-email check was only safe when the JWT email claim was
+    operator-verified — with ``ENABLE_EMAIL_AUTOCONFIRM=true`` it
+    wasn't, which let any signed-up attacker spoof an invitee by
+    choosing their own email at signup.
+
+    Resolution order:
+
+    1. If ``viewer_user_id`` is already in ``invited_user_ids`` →
+       allow. Fast path, no DB write. This is the only path future
+       requests hit after first claim.
+    2. Else if ``email_verified=True`` and ``viewer_email`` is in
+       ``invited_emails`` → allow and lazily promote: move the
+       invitee from the email list to the user_id list in one
+       atomic update. One-time per invitee.
+    3. Else → deny.
+
+    Public-mode rows always return True (mode-mismatch is the caller's
+    concern).
+    """
     if row.get("mode") == "public":
         return True
-    if not email:
+
+    invited_user_ids = row.get("invited_user_ids") or []
+    if viewer_user_id and viewer_user_id in invited_user_ids:
+        return True
+
+    # Email fallback path — strictly gated on a verified mailbox.
+    if not (email_verified and viewer_email and viewer_user_id):
         return False
-    invited = row.get("invited_emails") or []
-    return email.strip().lower() in {e.lower() for e in invited if e}
+
+    normalized = viewer_email.strip().lower()
+    invited_emails = row.get("invited_emails") or []
+    matched_email = next(
+        (e for e in invited_emails if e and e.lower() == normalized),
+        None,
+    )
+    if not matched_email:
+        return False
+
+    # Promote: remove the matched email, add the user_id. Best-effort
+    # update; if it fails (network/RLS), we still grant access for
+    # this request — the next request retries the promotion. We never
+    # cache a failed promotion in memory so retries stay correct.
+    try:
+        client = _client()
+        next_emails = [e for e in invited_emails if e and e.lower() != normalized]
+        next_user_ids = list(invited_user_ids) + [viewer_user_id]
+        client.table("project_shares").update({
+            "invited_emails": next_emails,
+            "invited_user_ids": next_user_ids,
+        }).eq("id", row["id"]).execute()
+    except Exception as e:
+        logger.warning(
+            "viewer_invited: failed to promote invitee email→user_id for share %s: %s",
+            row.get("id"), e,
+        )
+
+    return True
+
+
+def email_invited(row: Dict[str, Any], email: Optional[str]) -> bool:  # pragma: no cover
+    """Deprecated — kept as a no-arg-compatible shim so any out-of-tree
+    callers fail loudly with a clear stack rather than silently passing
+    the old plain-email gate. Real call sites use ``viewer_invited``."""
+    raise NotImplementedError(
+        "share_service.email_invited has been replaced by viewer_invited; "
+        "callers must pass viewer_user_id and email_verified."
+    )

--- a/backend/app/services/integrations/supabase/auth_service.py
+++ b/backend/app/services/integrations/supabase/auth_service.py
@@ -316,27 +316,26 @@ class AuthService:
 
         Rules:
         1) If email is in NOOBBOOK_ADMIN_EMAILS -> admin
-        2) If no admins exist yet -> admin (bootstrap)
+        2) If email matches NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL -> admin
+           (covers the very first deploy when no admin exists yet)
         3) Else -> user
+
+        The previous "if no admins exist, auto-promote the first signup
+        to admin" branch was removed. That branch let whoever found the
+        deploy URL first claim admin without any operator intent —
+        operators now bootstrap explicitly via the env var path
+        (`bootstrap_admin_from_env()` or NOOBBOOK_ADMIN_EMAILS).
         """
+        normalized = email.strip().lower()
+
         admin_emails = os.getenv("NOOBBOOK_ADMIN_EMAILS", "")
         admin_list = [e.strip().lower() for e in admin_emails.split(",") if e.strip()]
-        if email.strip().lower() in admin_list:
+        if normalized in admin_list:
             return "admin"
 
-        try:
-            resp = (
-                self.supabase.table("users")
-                .select("id")
-                .eq("role", "admin")
-                .limit(1)
-                .execute()
-            )
-            if not resp.data:
-                return "admin"
-        except Exception:
-            # If check fails, default to user
-            pass
+        bootstrap_email = (os.getenv("NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL") or "").strip().lower()
+        if bootstrap_email and normalized == bootstrap_email:
+            return "admin"
 
         return "user"
 

--- a/backend/app/services/integrations/supabase/auth_service.py
+++ b/backend/app/services/integrations/supabase/auth_service.py
@@ -317,7 +317,9 @@ class AuthService:
         Rules:
         1) If email is in NOOBBOOK_ADMIN_EMAILS -> admin
         2) If email matches NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL -> admin
-           (covers the very first deploy when no admin exists yet)
+           (persisted permanently in docker/.env by setup.sh; behaves
+           like an implicit entry in NOOBBOOK_ADMIN_EMAILS for all
+           future signups with that address, not only the first deploy)
         3) Else -> user
 
         The previous "if no admins exist, auto-promote the first signup

--- a/backend/supabase/migrations/00034_chat_attachments_rls_service_role_only.sql
+++ b/backend/supabase/migrations/00034_chat_attachments_rls_service_role_only.sql
@@ -51,7 +51,11 @@ BEGIN
       qual LIKE '%chat-attachments%'
       OR with_check LIKE '%chat-attachments%'
     )
-    AND 'authenticated' = ANY(roles);
+    -- 'authenticated' = ANY(...) misses the case where roles is the empty
+    -- array '{}', which in pg_policies stands for PUBLIC (no TO clause).
+    -- A stray PUBLIC-scoped policy applies to every role including
+    -- authenticated, so we have to flag those too.
+    AND ('authenticated' = ANY(roles) OR cardinality(roles) = 0);
 
   IF overlap_count > 0 THEN
     RAISE EXCEPTION

--- a/backend/supabase/migrations/00034_chat_attachments_rls_service_role_only.sql
+++ b/backend/supabase/migrations/00034_chat_attachments_rls_service_role_only.sql
@@ -1,0 +1,60 @@
+-- Migration: Chat attachments RLS — scope to service_role only
+-- Created: 2026-05-14
+--
+-- Context: 00032 installed a permissive policy with no `TO` filter on the
+-- chat-attachments bucket to unblock uploads after several failed
+-- ownership-predicate attempts (00027 / 00028 / 00030). The
+-- comment block in 00032 argued residual risk was bucket-spam only
+-- because "signed URLs are still required to actually read someone
+-- else's attachment".
+--
+-- That claim turns out to be wrong: storage-api applies the bucket RLS
+-- to direct authenticated `GET /storage/v1/object/chat-attachments/...`
+-- calls. A user with any valid JWT (their own) can read / write / delete
+-- / enumerate every chat attachment in every project by talking to
+-- storage-api directly, bypassing the backend's project-access RBAC.
+--
+-- Tightening shape: scope the policy `TO service_role` only. The
+-- backend already runs as service_role for all storage writes, and the
+-- browser reads attachments via signed URLs (storage-api validates the
+-- signature cryptographically and bypasses RLS via that path — see
+-- supabase/storage-api `getSignedURL` → `signedUrl` verifier).
+--
+-- Net effect:
+--   1. Backend (service_role JWT) — unchanged, can read/write all rows.
+--   2. Browser via signed URLs — unchanged, signature bypasses RLS.
+--   3. Authenticated user direct-SDK call with own JWT — now 403,
+--      which is the intended posture.
+
+DROP POLICY IF EXISTS "Chat attachments — backend & signed-url access" ON storage.objects;
+
+CREATE POLICY "chat_attachments_service_role_only"
+ON storage.objects
+FOR ALL
+TO service_role
+USING (bucket_id = 'chat-attachments')
+WITH CHECK (bucket_id = 'chat-attachments');
+
+-- Audit: confirm no stray `authenticated`-scoped policy overlaps for
+-- this bucket. If one slipped in via a future migration that bypassed
+-- review, fail loudly here instead of regressing the fix.
+DO $$
+DECLARE
+  overlap_count integer;
+BEGIN
+  SELECT COUNT(*) INTO overlap_count
+  FROM pg_policies
+  WHERE schemaname = 'storage'
+    AND tablename = 'objects'
+    AND policyname <> 'chat_attachments_service_role_only'
+    AND (
+      qual LIKE '%chat-attachments%'
+      OR with_check LIKE '%chat-attachments%'
+    )
+    AND 'authenticated' = ANY(roles);
+
+  IF overlap_count > 0 THEN
+    RAISE EXCEPTION
+      'Stray authenticated-scoped policy on storage.objects references chat-attachments — refusing to migrate. Resolve manually.';
+  END IF;
+END $$;

--- a/backend/supabase/migrations/00035_project_shares_invited_user_ids.sql
+++ b/backend/supabase/migrations/00035_project_shares_invited_user_ids.sql
@@ -1,0 +1,31 @@
+-- Migration: project_shares.invited_user_ids
+-- Created: 2026-05-14
+--
+-- Context: invited-mode shares are gated by an array of emails
+-- (`invited_emails`) compared against the JWT's `email` claim. With
+-- `ENABLE_EMAIL_AUTOCONFIRM=true` (default in our shipped self-host
+-- config), the JWT email claim isn't operator-verified — an attacker
+-- can sign up with any email string and get a valid session. The
+-- string-equality check then lets them through.
+--
+-- Long-term shape: store invitees as `user_id` UUIDs once we've
+-- confirmed mailbox ownership at least once. The viewer_invited()
+-- check in share_service.py reads `invited_user_ids` first (fast UUID
+-- lookup), then falls back to the email path only when the JWT carries
+-- `email_verified=true`. On the email fallback path we lazily promote
+-- the matched invitee — remove their email from `invited_emails`, add
+-- their `user_id` to `invited_user_ids`. Future requests hit the fast
+-- path without trusting the email claim.
+--
+-- This column ships alongside an autoconfirm flip (env layer) so
+-- `email_verified=true` becomes a real signal.
+
+ALTER TABLE project_shares
+  ADD COLUMN IF NOT EXISTS invited_user_ids UUID[] NOT NULL DEFAULT '{}';
+
+-- No new index needed: lookups happen via array membership inside
+-- `viewer_invited()` after we've already fetched the row by token,
+-- which uses the existing `project_shares_non_revoked_token_idx`.
+
+COMMENT ON COLUMN project_shares.invited_user_ids IS
+  'Invitees promoted from email→user_id after first verified-email claim. See share_service.viewer_invited().';

--- a/backend/supabase/migrations/00036_promote_share_invitee_rpc.sql
+++ b/backend/supabase/migrations/00036_promote_share_invitee_rpc.sql
@@ -1,0 +1,53 @@
+-- Migration: promote_share_invitee — atomic email→user_id promotion
+-- Created: 2026-05-15
+--
+-- Context: share_service.viewer_invited() lazily promotes an invitee
+-- from invited_emails → invited_user_ids on first verified-email claim.
+-- The original implementation read the row, computed new arrays in
+-- Python, and wrote them back — a textbook read-modify-write race.
+-- Two concurrent invitees both reading the same stale snapshot would
+-- each overwrite the other's promotion, and the loser ended up in
+-- neither list — permanently locked out of the share.
+--
+-- This RPC does the whole transition in a single UPDATE statement.
+-- Postgres locks the row for the duration of the UPDATE, so two
+-- concurrent calls serialize cleanly:
+--
+--   Tx A: array_remove([A,B], 'a@x') → [B];   array_append([], uid_A) → [uid_A]
+--   Tx B (after A commits): array_remove([B], 'b@x') → [];  array_append([uid_A], uid_B) → [uid_A, uid_B]
+--
+-- Both invitees survive. SECURITY DEFINER is correct here because the
+-- caller's authority to mutate this row has already been established by
+-- the application-layer check in viewer_invited() (the matched email
+-- proved mailbox ownership for *this* share's invitee list). The RPC
+-- itself doesn't trust the caller's identity claims — it only mutates
+-- the specific (share_id, email, user_id) tuple it was asked to.
+
+CREATE OR REPLACE FUNCTION promote_share_invitee(
+  p_share_id UUID,
+  p_email TEXT,
+  p_user_id UUID
+) RETURNS VOID
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  UPDATE project_shares
+  SET
+    invited_emails   = array_remove(invited_emails, p_email),
+    invited_user_ids = array_append(invited_user_ids, p_user_id)
+  WHERE id = p_share_id
+    -- Defensive guard: don't append duplicate user_ids if a
+    -- concurrent transaction already promoted this user.
+    AND NOT (p_user_id = ANY(invited_user_ids));
+$$;
+
+-- The backend calls this via the service-role JWT.
+GRANT EXECUTE ON FUNCTION promote_share_invitee(UUID, TEXT, UUID) TO service_role;
+-- Authenticated callers must NOT call this directly — only the
+-- viewer_invited() flow on the backend can, after verifying mailbox
+-- ownership via the email_verified JWT claim + email-in-invitees match.
+REVOKE EXECUTE ON FUNCTION promote_share_invitee(UUID, TEXT, UUID) FROM PUBLIC, authenticated, anon;
+
+COMMENT ON FUNCTION promote_share_invitee IS
+  'Atomic helper for share_service.viewer_invited(). Backend-only (service_role grant). Promotes one invitee from invited_emails to invited_user_ids in a single UPDATE.';

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -209,8 +209,27 @@ fi
 
 # Create NoobBook .env if it doesn't exist
 if [ ! -f "$NOOBBOOK_ENV" ]; then
+    # Bootstrap-admin precondition (fresh-deploy only).
+    # Refusing to proceed without explicit operator intent here closes
+    # the "first signup wins admin" race. If you're running this on a
+    # box where you've already pre-seeded an admin user some other way,
+    # just put the same email/password in the shell env and the same
+    # values land in the .env on this run.
+    if [ -z "${NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL:-}" ] || [ -z "${NOOBBOOK_BOOTSTRAP_ADMIN_PASSWORD:-}" ]; then
+        error "Fresh deploy detected (no docker/.env yet). Set NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL and NOOBBOOK_BOOTSTRAP_ADMIN_PASSWORD in your shell env before running setup.sh. Example:
+  export NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL='you@example.com'
+  export NOOBBOOK_BOOTSTRAP_ADMIN_PASSWORD='\$(openssl rand -base64 24)'
+  bash docker/setup.sh"
+    fi
+
     info "Creating NoobBook .env from template..."
     cp "$SCRIPT_DIR/.env.example" "$NOOBBOOK_ENV"
+
+    # Persist the bootstrap admin into the .env so subsequent
+    # container restarts can call bootstrap_admin_from_env() without
+    # depending on the operator's shell.
+    replace_env_var "$NOOBBOOK_ENV" "NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL" "$NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL"
+    replace_env_var "$NOOBBOOK_ENV" "NOOBBOOK_BOOTSTRAP_ADMIN_PASSWORD" "$NOOBBOOK_BOOTSTRAP_ADMIN_PASSWORD"
 
     # Source Supabase env to get generated keys
     # shellcheck disable=SC1090

--- a/docker/supabase/.env.example
+++ b/docker/supabase/.env.example
@@ -68,7 +68,12 @@ ADDITIONAL_REDIRECT_URLS=
 # compliance posture requires shorter-lived bearer tokens; refresh
 # tokens themselves are unaffected and still rotate on use.
 JWT_EXPIRY=86400
-DISABLE_SIGNUP=false
+# Signups are disabled by default; bootstrap an admin via
+# NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL/PASSWORD (in the NoobBook .env), then
+# flip this to `false` and configure SMTP if you need to invite users.
+# Keeping signups open without a verified-email flow lets attackers
+# spoof identity by choosing any email at signup (see share gating).
+DISABLE_SIGNUP=true
 API_EXTERNAL_URL=http://localhost:8000
 
 MAILER_URLPATHS_CONFIRMATION="/auth/v1/verify"
@@ -77,7 +82,12 @@ MAILER_URLPATHS_RECOVERY="/auth/v1/verify"
 MAILER_URLPATHS_EMAIL_CHANGE="/auth/v1/verify"
 
 ENABLE_EMAIL_SIGNUP=true
-ENABLE_EMAIL_AUTOCONFIRM=true
+# Email autoconfirm OFF — JWTs from signed-up users only carry a
+# `email_verified=true` claim after a real confirmation click. The
+# invited-share access check trusts that flag, so flipping this to
+# `true` materially weakens share gating. Only enable in single-user
+# dev setups where you control every signup.
+ENABLE_EMAIL_AUTOCONFIRM=false
 SMTP_ADMIN_EMAIL=admin@example.com
 SMTP_HOST=supabase-mail
 SMTP_PORT=2500


### PR DESCRIPTION
## Summary

Three small surgical changes to the auth layer that close defects surfaced in last week's audit. No exploit details below — keeping the public diff neutral.

- **rbac**: drop the dev-only \`X-NoobBook-User-Id\` header branch in \`_resolve_identity()\`. Add \`email_verified: bool\` to \`RequestIdentity\` and extract from the JWT in both local and Supabase-fallback decode paths.
- **share gating**: replace \`email_invited(row, email)\` with \`viewer_invited(row, viewer_user_id, viewer_email, email_verified)\`. UUID-first check against a new \`invited_user_ids\` column, with lazy email→user_id promotion on the first verified-email claim. Old API raises \`NotImplementedError\` so any stale caller fails loudly rather than silently.
- **chat-attachments RLS**: new migration scopes the bucket policy \`TO service_role\` only. Backend writes via service-role; browser reads via signed URLs (signature bypasses RLS); direct-SDK calls with a non-service-role JWT now 403.
- **signup posture**: \`docker/supabase/.env.example\` defaults \`DISABLE_SIGNUP=true\` and \`ENABLE_EMAIL_AUTOCONFIRM=false\`. \`setup.sh\` refuses fresh deploys without \`NOOBBOOK_BOOTSTRAP_ADMIN_EMAIL\`/\`PASSWORD\` set. \`_resolve_signup_role\` drops the auto-promote-first-user-to-admin branch — admin assignment now requires explicit operator intent via env.

## Schema changes

- \`00034\`: drops the prior \`Chat attachments — backend & signed-url access\` policy, creates \`chat_attachments_service_role_only\` (\`FOR ALL TO service_role\`). Includes a \`DO\` block that fails the migration if a stray \`authenticated\`-scoped policy ever overlaps.
- \`00035\`: adds \`project_shares.invited_user_ids UUID[] NOT NULL DEFAULT '{}'\`. No new index — lookups happen in-memory after the existing token index hit.

## Backwards-compat

- JWT auth path: unchanged. Existing sessions keep working.
- Existing prod with admin already seeded: \`setup.sh\` precondition only fires on the fresh-deploy branch (\`! -f docker/.env\`).
- Existing invited shares: keep working via the lazy email-fallback path; after first claim, promoted to UUID for fast future lookups.
- Signed URLs for chat attachments: unchanged (signature bypasses RLS).

## Test plan

- [ ] CI: lint + build + pytest
- [ ] Migration: \`supabase migration up\` cleanly applies 00034 and 00035 on a fresh DB
- [ ] Direct-SDK probe: \`GET /storage/v1/object/chat-attachments/...\` with a non-service-role JWT returns 403
- [ ] Web flow: signed-URL reads still 200; create/send chat with image attachment as normal
- [ ] Invited share happy-path: invited user with verified email gets through, future requests hit the UUID fast path
- [ ] Invited share negative-path: same as above but with \`email_verified=false\` → 403
- [ ] Signup posture: fresh deploy without bootstrap env vars → \`setup.sh\` halts with actionable error