### PR TITLE
rls: gate connection-credential tables + revoke public freshdesk RPC grant

### DIFF
--- a/backend/supabase/migrations/00037_database_mcp_connections_rls.sql
+++ b/backend/supabase/migrations/00037_database_mcp_connections_rls.sql
@@ -46,10 +46,18 @@
 -- RLS on the inner query). Used only by the join-table policies; the
 -- parent-table policies can keep their plain EXISTS clauses because the
 -- inner reference now resolves without re-entering the parent's policy.
+--
+-- These helpers intentionally take NO user_id parameter and resolve
+-- the caller's identity via `auth.uid()` inside. Reason: the function
+-- is reachable as a PostgREST RPC endpoint (auth role needs EXECUTE
+-- for policy expressions to call it). If we accepted `p_user_id` as a
+-- parameter, any authenticated caller could iterate the (connection_id,
+-- user_id) space against the RPC and map out cross-tenant ownership.
+-- Anchoring to `auth.uid()` means the function only ever answers
+-- "do I own connection X?" — information the caller already has.
 
 CREATE OR REPLACE FUNCTION user_owns_database_connection(
-  p_connection_id UUID,
-  p_user_id UUID
+  p_connection_id UUID
 ) RETURNS BOOLEAN
 LANGUAGE sql
 STABLE
@@ -58,17 +66,16 @@ SET search_path = public, pg_catalog
 AS $$
   SELECT EXISTS (
     SELECT 1 FROM database_connections
-    WHERE id = p_connection_id AND owner_user_id = p_user_id
+    WHERE id = p_connection_id AND owner_user_id = auth.uid()
   );
 $$;
 
-REVOKE EXECUTE ON FUNCTION user_owns_database_connection(UUID, UUID) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION user_owns_database_connection(UUID, UUID)
+REVOKE EXECUTE ON FUNCTION user_owns_database_connection(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION user_owns_database_connection(UUID)
   TO authenticated, service_role;
 
 CREATE OR REPLACE FUNCTION user_owns_mcp_connection(
-  p_connection_id UUID,
-  p_user_id UUID
+  p_connection_id UUID
 ) RETURNS BOOLEAN
 LANGUAGE sql
 STABLE
@@ -77,12 +84,12 @@ SET search_path = public, pg_catalog
 AS $$
   SELECT EXISTS (
     SELECT 1 FROM mcp_connections
-    WHERE id = p_connection_id AND owner_user_id = p_user_id
+    WHERE id = p_connection_id AND owner_user_id = auth.uid()
   );
 $$;
 
-REVOKE EXECUTE ON FUNCTION user_owns_mcp_connection(UUID, UUID) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION user_owns_mcp_connection(UUID, UUID)
+REVOKE EXECUTE ON FUNCTION user_owns_mcp_connection(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION user_owns_mcp_connection(UUID)
   TO authenticated, service_role;
 
 -- =============================================================================
@@ -154,7 +161,7 @@ ON database_connection_users FOR SELECT
 TO authenticated
 USING (
   user_id = auth.uid()
-  OR user_owns_database_connection(connection_id, auth.uid())
+  OR user_owns_database_connection(connection_id)
 );
 
 -- Writes: only the parent connection's owner can grant / revoke members.
@@ -162,13 +169,13 @@ DROP POLICY IF EXISTS database_connection_users_insert ON database_connection_us
 CREATE POLICY database_connection_users_insert
 ON database_connection_users FOR INSERT
 TO authenticated
-WITH CHECK (user_owns_database_connection(connection_id, auth.uid()));
+WITH CHECK (user_owns_database_connection(connection_id));
 
 DROP POLICY IF EXISTS database_connection_users_delete ON database_connection_users;
 CREATE POLICY database_connection_users_delete
 ON database_connection_users FOR DELETE
 TO authenticated
-USING (user_owns_database_connection(connection_id, auth.uid()));
+USING (user_owns_database_connection(connection_id));
 
 -- =============================================================================
 -- 4. mcp_connections RLS — same shape as database_connections
@@ -221,17 +228,17 @@ ON mcp_connection_users FOR SELECT
 TO authenticated
 USING (
   user_id = auth.uid()
-  OR user_owns_mcp_connection(connection_id, auth.uid())
+  OR user_owns_mcp_connection(connection_id)
 );
 
 DROP POLICY IF EXISTS mcp_connection_users_insert ON mcp_connection_users;
 CREATE POLICY mcp_connection_users_insert
 ON mcp_connection_users FOR INSERT
 TO authenticated
-WITH CHECK (user_owns_mcp_connection(connection_id, auth.uid()));
+WITH CHECK (user_owns_mcp_connection(connection_id));
 
 DROP POLICY IF EXISTS mcp_connection_users_delete ON mcp_connection_users;
 CREATE POLICY mcp_connection_users_delete
 ON mcp_connection_users FOR DELETE
 TO authenticated
-USING (user_owns_mcp_connection(connection_id, auth.uid()));
+USING (user_owns_mcp_connection(connection_id));

--- a/backend/supabase/migrations/00037_database_mcp_connections_rls.sql
+++ b/backend/supabase/migrations/00037_database_mcp_connections_rls.sql
@@ -1,0 +1,212 @@
+-- Migration: tighten access to connection-credential tables + freshdesk RPC
+-- Created: 2026-05-15
+--
+-- Context: `database_connections.connection_uri` stores plaintext Postgres
+-- URIs (incl. passwords) and `mcp_connections.auth_config` stores bearer
+-- tokens / API keys. Both tables shipped without RLS, and Supabase's
+-- default `GRANT ALL ON ALL TABLES IN SCHEMA public TO authenticated`
+-- meant any signed-up user could read every tenant's secrets via the
+-- public PostgREST `/rest/v1/<table>` endpoint.
+--
+-- The same audit also surfaced `exec_freshdesk_query`: the function is
+-- granted EXECUTE to `authenticated`, accepts caller-supplied SQL, and
+-- its only safety check (`position('freshdesk_tickets' in ...) > 0`) is
+-- bypassable by using `freshdesk_tickets` as an alias on a different
+-- table — e.g. `SELECT ... FROM database_connections AS freshdesk_tickets`.
+-- The backend always invokes this RPC with service-role, so revoking
+-- the `authenticated` grant doesn't change product behaviour.
+--
+-- Backend posture: all reads/writes to these tables go through service-
+-- role (`SUPABASE_SERVICE_KEY` per supabase_client.py:64). service-role
+-- bypasses RLS, so the policies below only gate direct PostgREST calls
+-- using a non-admin JWT. No frontend code talks to these tables
+-- directly — the UI calls backend endpoints which mediate via
+-- service-role.
+--
+-- Out of scope here (deferred to separate PRs per the audit):
+--   * Encrypt connection_uri / auth_config at rest (pgcrypto / Vault).
+--   * Replace the free-form `exec_freshdesk_query` RPC with a
+--     parameterised whitelist of query shapes.
+
+-- =============================================================================
+-- 1. exec_freshdesk_query — revoke the dangerous authenticated grant
+-- =============================================================================
+
+REVOKE EXECUTE ON FUNCTION public.exec_freshdesk_query(text)
+  FROM authenticated, authenticator, PUBLIC;
+-- service_role grant from 00033 stays, which is what the backend uses
+-- (services/tool_executors/freshdesk_executor.py:263).
+
+-- =============================================================================
+-- 2. database_connections RLS
+-- =============================================================================
+
+ALTER TABLE database_connections ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: owner, OR connection marked visible_to_all, OR caller has been
+-- granted access via the `*_users` join table. Mirrors the access logic
+-- already implemented in services/auth/permissions.py.
+DROP POLICY IF EXISTS database_connections_select ON database_connections;
+CREATE POLICY database_connections_select
+ON database_connections FOR SELECT
+TO authenticated
+USING (
+  auth.uid() = owner_user_id
+  OR visible_to_all = true
+  OR EXISTS (
+    SELECT 1 FROM database_connection_users dcu
+    WHERE dcu.connection_id = database_connections.id
+      AND dcu.user_id = auth.uid()
+  )
+);
+
+-- Writes (INSERT / UPDATE / DELETE): owner only. The backend gates
+-- ownership transfer + invitee changes at the application layer; this
+-- policy is the database-level fence behind that.
+DROP POLICY IF EXISTS database_connections_insert ON database_connections;
+CREATE POLICY database_connections_insert
+ON database_connections FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = owner_user_id);
+
+DROP POLICY IF EXISTS database_connections_update ON database_connections;
+CREATE POLICY database_connections_update
+ON database_connections FOR UPDATE
+TO authenticated
+USING (auth.uid() = owner_user_id)
+WITH CHECK (auth.uid() = owner_user_id);
+
+DROP POLICY IF EXISTS database_connections_delete ON database_connections;
+CREATE POLICY database_connections_delete
+ON database_connections FOR DELETE
+TO authenticated
+USING (auth.uid() = owner_user_id);
+
+-- =============================================================================
+-- 3. database_connection_users RLS (join table)
+-- =============================================================================
+
+ALTER TABLE database_connection_users ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: owner of the parent connection, or the user listed in the row.
+-- (Members need to see their own grants so the UI can render
+-- "connections shared with me".)
+DROP POLICY IF EXISTS database_connection_users_select ON database_connection_users;
+CREATE POLICY database_connection_users_select
+ON database_connection_users FOR SELECT
+TO authenticated
+USING (
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM database_connections dc
+    WHERE dc.id = database_connection_users.connection_id
+      AND dc.owner_user_id = auth.uid()
+  )
+);
+
+-- Writes: only the parent connection's owner can grant / revoke members.
+DROP POLICY IF EXISTS database_connection_users_insert ON database_connection_users;
+CREATE POLICY database_connection_users_insert
+ON database_connection_users FOR INSERT
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM database_connections dc
+    WHERE dc.id = database_connection_users.connection_id
+      AND dc.owner_user_id = auth.uid()
+  )
+);
+
+DROP POLICY IF EXISTS database_connection_users_delete ON database_connection_users;
+CREATE POLICY database_connection_users_delete
+ON database_connection_users FOR DELETE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM database_connections dc
+    WHERE dc.id = database_connection_users.connection_id
+      AND dc.owner_user_id = auth.uid()
+  )
+);
+
+-- =============================================================================
+-- 4. mcp_connections RLS — same shape as database_connections
+-- =============================================================================
+
+ALTER TABLE mcp_connections ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS mcp_connections_select ON mcp_connections;
+CREATE POLICY mcp_connections_select
+ON mcp_connections FOR SELECT
+TO authenticated
+USING (
+  auth.uid() = owner_user_id
+  OR visible_to_all = true
+  OR EXISTS (
+    SELECT 1 FROM mcp_connection_users mcu
+    WHERE mcu.connection_id = mcp_connections.id
+      AND mcu.user_id = auth.uid()
+  )
+);
+
+DROP POLICY IF EXISTS mcp_connections_insert ON mcp_connections;
+CREATE POLICY mcp_connections_insert
+ON mcp_connections FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = owner_user_id);
+
+DROP POLICY IF EXISTS mcp_connections_update ON mcp_connections;
+CREATE POLICY mcp_connections_update
+ON mcp_connections FOR UPDATE
+TO authenticated
+USING (auth.uid() = owner_user_id)
+WITH CHECK (auth.uid() = owner_user_id);
+
+DROP POLICY IF EXISTS mcp_connections_delete ON mcp_connections;
+CREATE POLICY mcp_connections_delete
+ON mcp_connections FOR DELETE
+TO authenticated
+USING (auth.uid() = owner_user_id);
+
+-- =============================================================================
+-- 5. mcp_connection_users RLS (join table)
+-- =============================================================================
+
+ALTER TABLE mcp_connection_users ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS mcp_connection_users_select ON mcp_connection_users;
+CREATE POLICY mcp_connection_users_select
+ON mcp_connection_users FOR SELECT
+TO authenticated
+USING (
+  user_id = auth.uid()
+  OR EXISTS (
+    SELECT 1 FROM mcp_connections mc
+    WHERE mc.id = mcp_connection_users.connection_id
+      AND mc.owner_user_id = auth.uid()
+  )
+);
+
+DROP POLICY IF EXISTS mcp_connection_users_insert ON mcp_connection_users;
+CREATE POLICY mcp_connection_users_insert
+ON mcp_connection_users FOR INSERT
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM mcp_connections mc
+    WHERE mc.id = mcp_connection_users.connection_id
+      AND mc.owner_user_id = auth.uid()
+  )
+);
+
+DROP POLICY IF EXISTS mcp_connection_users_delete ON mcp_connection_users;
+CREATE POLICY mcp_connection_users_delete
+ON mcp_connection_users FOR DELETE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM mcp_connections mc
+    WHERE mc.id = mcp_connection_users.connection_id
+      AND mc.owner_user_id = auth.uid()
+  )
+);

--- a/backend/supabase/migrations/00037_database_mcp_connections_rls.sql
+++ b/backend/supabase/migrations/00037_database_mcp_connections_rls.sql
@@ -29,6 +29,63 @@
 --     parameterised whitelist of query shapes.
 
 -- =============================================================================
+-- 0. SECURITY DEFINER helpers — break the RLS cycle
+-- =============================================================================
+--
+-- The connection-credential policies below have to reference each other:
+-- `*_connections_select` needs to allow members in via `*_connection_users`,
+-- and `*_connection_users_select` needs to allow the owner of the parent
+-- connection to see member rows. If both sides use `EXISTS` directly,
+-- PostgreSQL's policy expansion enters an infinite cycle and raises
+-- `ERROR: infinite recursion detected in policy for relation ...` on
+-- every authenticated query — turning the policy into a no-op that
+-- errors instead of filters.
+--
+-- The fix is one SECURITY DEFINER helper per parent table that checks
+-- ownership while running as the function owner (and therefore bypasses
+-- RLS on the inner query). Used only by the join-table policies; the
+-- parent-table policies can keep their plain EXISTS clauses because the
+-- inner reference now resolves without re-entering the parent's policy.
+
+CREATE OR REPLACE FUNCTION user_owns_database_connection(
+  p_connection_id UUID,
+  p_user_id UUID
+) RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM database_connections
+    WHERE id = p_connection_id AND owner_user_id = p_user_id
+  );
+$$;
+
+REVOKE EXECUTE ON FUNCTION user_owns_database_connection(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION user_owns_database_connection(UUID, UUID)
+  TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION user_owns_mcp_connection(
+  p_connection_id UUID,
+  p_user_id UUID
+) RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM mcp_connections
+    WHERE id = p_connection_id AND owner_user_id = p_user_id
+  );
+$$;
+
+REVOKE EXECUTE ON FUNCTION user_owns_mcp_connection(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION user_owns_mcp_connection(UUID, UUID)
+  TO authenticated, service_role;
+
+-- =============================================================================
 -- 1. exec_freshdesk_query — revoke the dangerous authenticated grant
 -- =============================================================================
 
@@ -97,11 +154,7 @@ ON database_connection_users FOR SELECT
 TO authenticated
 USING (
   user_id = auth.uid()
-  OR EXISTS (
-    SELECT 1 FROM database_connections dc
-    WHERE dc.id = database_connection_users.connection_id
-      AND dc.owner_user_id = auth.uid()
-  )
+  OR user_owns_database_connection(connection_id, auth.uid())
 );
 
 -- Writes: only the parent connection's owner can grant / revoke members.
@@ -109,25 +162,13 @@ DROP POLICY IF EXISTS database_connection_users_insert ON database_connection_us
 CREATE POLICY database_connection_users_insert
 ON database_connection_users FOR INSERT
 TO authenticated
-WITH CHECK (
-  EXISTS (
-    SELECT 1 FROM database_connections dc
-    WHERE dc.id = database_connection_users.connection_id
-      AND dc.owner_user_id = auth.uid()
-  )
-);
+WITH CHECK (user_owns_database_connection(connection_id, auth.uid()));
 
 DROP POLICY IF EXISTS database_connection_users_delete ON database_connection_users;
 CREATE POLICY database_connection_users_delete
 ON database_connection_users FOR DELETE
 TO authenticated
-USING (
-  EXISTS (
-    SELECT 1 FROM database_connections dc
-    WHERE dc.id = database_connection_users.connection_id
-      AND dc.owner_user_id = auth.uid()
-  )
-);
+USING (user_owns_database_connection(connection_id, auth.uid()));
 
 -- =============================================================================
 -- 4. mcp_connections RLS — same shape as database_connections
@@ -180,33 +221,17 @@ ON mcp_connection_users FOR SELECT
 TO authenticated
 USING (
   user_id = auth.uid()
-  OR EXISTS (
-    SELECT 1 FROM mcp_connections mc
-    WHERE mc.id = mcp_connection_users.connection_id
-      AND mc.owner_user_id = auth.uid()
-  )
+  OR user_owns_mcp_connection(connection_id, auth.uid())
 );
 
 DROP POLICY IF EXISTS mcp_connection_users_insert ON mcp_connection_users;
 CREATE POLICY mcp_connection_users_insert
 ON mcp_connection_users FOR INSERT
 TO authenticated
-WITH CHECK (
-  EXISTS (
-    SELECT 1 FROM mcp_connections mc
-    WHERE mc.id = mcp_connection_users.connection_id
-      AND mc.owner_user_id = auth.uid()
-  )
-);
+WITH CHECK (user_owns_mcp_connection(connection_id, auth.uid()));
 
 DROP POLICY IF EXISTS mcp_connection_users_delete ON mcp_connection_users;
 CREATE POLICY mcp_connection_users_delete
 ON mcp_connection_users FOR DELETE
 TO authenticated
-USING (
-  EXISTS (
-    SELECT 1 FROM mcp_connections mc
-    WHERE mc.id = mcp_connection_users.connection_id
-      AND mc.owner_user_id = auth.uid()
-  )
-);
+USING (user_owns_mcp_connection(connection_id, auth.uid()));


### PR DESCRIPTION
## Summary

One new migration, two layers of fix. Both close cross-tenant read primitives on tables that store secrets.

- **`exec_freshdesk_query`**: REVOKE the `authenticated` / `authenticator` / `PUBLIC` grants. service-role grant stays — backend invokes this exclusively via service-role per `services/integrations/supabase/supabase_client.py:64`, so behaviour is unchanged.
- **`database_connections`, `mcp_connections`, `database_connection_users`, `mcp_connection_users`**: enable RLS with policies that mirror the application-layer access logic in `services/auth/permissions.py` — owner / `visible_to_all` / invited-member can read; owner-only for writes; only the parent connection's owner can manage member grants.

## Why now

These tables store \`connection_uri\` (plaintext Postgres URIs incl. passwords) and \`auth_config\` JSONB (bearer tokens / API keys). Supabase's default \`GRANT ALL ON ALL TABLES IN SCHEMA public TO authenticated\` was sufficient to read them via the public REST API — combined with the freshdesk RPC's bypassable safety check, that was a full cross-tenant exfil primitive.

## Backwards-compat

- Backend uses service-role (\`SUPABASE_SERVICE_KEY\`) — bypasses RLS, all existing flows unchanged.
- Frontend doesn't query these tables directly (verified via grep) — UI hits backend endpoints which mediate.
- Policies preserve every access pattern that was previously enforced at the application layer.

## Out of scope (deferred)

- Encrypt \`connection_uri\` / \`auth_config\` at rest (pgcrypto / Vault).
- Replace the free-form \`exec_freshdesk_query\` RPC with a parameterised whitelist of query shapes.

Both are defence-in-depth recommendations from the same audit; they'll ship in separate PRs.

## Test plan

- [ ] CI: pytest passes
- [ ] Migration applies cleanly via \`migrate-prep\` container on first redeploy
- [ ] Authenticated direct call: \`POST /rest/v1/rpc/exec_freshdesk_query\` with a non-admin JWT returns 403 (was 200)
- [ ] Authenticated direct read: \`GET /rest/v1/database_connections\` with a non-admin JWT returns only rows the caller owns / has been granted / are visible_to_all
- [ ] Backend flow: existing database / MCP connection UI continues to work end-to-end (read, create, share, delete)