### PR TITLE
feat: xlsx upload + resizable chat input + message timestamps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ All API keys are stored in `backend/.env` (not database) and managed via the Set
 **Google Drive**:
 - `GET /google/status` - Check if configured and connected
 - `GET /google/auth` - Get OAuth authorization URL
-- `GET /google/callback` - Handle OAuth callback (redirects to frontend)
+- `GET /google/callback` - Handle OAuth callback (renders a self-closing popup that postMessages the opener)
 - `POST /google/disconnect` - Remove stored tokens
 - `GET /google/files` - List files (supports `folder_id`, `page_size`, `page_token`)
 - `POST /projects/{id}/sources/google-import` - Import file to sources
@@ -339,9 +339,11 @@ All API keys are stored in `backend/.env` (not database) and managed via the Set
 
 Import files from Google Drive. OAuth 2.0 flow with `drive.readonly` scope. Tokens stored per-user in Supabase `users.google_tokens` column, auto-refresh on expiry. Google Workspace exports: Docs→DOCX, Sheets→CSV, Slides→PPTX.
 
-**Setup**: Create OAuth credentials in Google Cloud Console, add redirect URI `http://localhost/api/v1/google/callback` (Docker) or `http://localhost:5001/api/v1/google/callback` (local dev).
+**Setup**: Create OAuth credentials in Google Cloud Console. The callback URL is derived from your deployment's host + API prefix — `http://localhost:5001/api/v1/google/callback` for local dev, `http://localhost/api/v1/google/callback` for Docker, `https://<your-domain>/api/v1/google/callback` for prod. Override with `GOOGLE_REDIRECT_URI` env var when the registered URI must differ from what the backend computes.
 
 **Multi-user Support**: Each user has their own Google Drive connection. The OAuth state parameter carries user_id for proper token association.
+
+**Connect UX**: `useGoogleConnect()` opens the consent popup, then listens for a postMessage from the callback page (fast path) and falls back to polling `/google/status` (slow path). The callback page renders `oauth.py:_render_callback_page()` HTML that calls `window.opener.postMessage(...)` then `window.close()`.
 
 ## Voice Input (ElevenLabs)
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -99,6 +99,14 @@ def create_app(config_name='development'):
         if path.startswith(f"{api_prefix}/share/"):
             return None
 
+        # Google's OAuth redirect lands here as a top-level browser GET with
+        # no Authorization header (Google initiates the request, the browser
+        # just follows the redirect). The user is identified by the `state`
+        # query parameter set when we minted the auth URL. The middleware
+        # would otherwise 401 every successful sign-in.
+        if path == f"{api_prefix}/google/callback":
+            return None
+
         identity = get_request_identity()
         if not identity.is_authenticated:
             return {"success": False, "error": "Authentication required"}, 401

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -62,6 +62,13 @@ def authenticate_request():
     if request.path.startswith('/api/v1/share/'):
         return None
 
+    # Google's OAuth redirect lands here as a top-level browser GET with
+    # no Authorization header (Google initiates it, the browser just
+    # follows). The user is identified by the `state` query parameter
+    # set when we minted the auth URL.
+    if request.path == '/api/v1/google/callback':
+        return None
+
     user_id = validate_token()
 
     if not user_id:

--- a/backend/app/api/google/oauth.py
+++ b/backend/app/api/google/oauth.py
@@ -25,11 +25,78 @@ Routes:
 - GET  /google/callback   - Handle OAuth callback (redirects)
 - POST /google/disconnect - Remove stored tokens
 """
+import html
+import json
 from typing import Optional
-from flask import jsonify, request, redirect, current_app
+from flask import jsonify, request, current_app, make_response
 from app.api.google import google_bp
 from app.services.integrations.google import google_auth_service
 from app.services.auth.rbac import get_request_identity
+
+
+def _render_callback_page(status: str, message: str = ''):
+    """
+    Render the OAuth completion page.
+
+    The callback is loaded inside a popup opened by the frontend's
+    `useGoogleConnect` hook. The page posts the result back to the
+    opener and self-closes; the opener's existing status poll is the
+    fallback if the browser blocks postMessage or window.close().
+
+    Origins for postMessage come from `CORS_ALLOWED_ORIGINS` so the
+    completion event is delivered to whichever frontend host the operator
+    has configured (works for local dev, Docker, and prod transparently).
+    Falls back to `*` when no origins are configured — acceptable because
+    the payload carries no secret material, just a status flag the opener
+    re-validates via `/google/status`.
+    """
+    message_safe = html.escape(message)
+    title = 'Google Drive connected' if status == 'success' else 'Google Drive sign-in failed'
+    fallback_copy = 'You can close this window.' if status == 'success' else 'Please try again from the app.'
+    origins = [o for o in (current_app.config.get('CORS_ALLOWED_ORIGINS') or []) if o and o.strip()] or ['*']
+    payload = {'type': 'noobbook:google-auth', 'status': status, 'message': message}
+
+    # JSON-escape, then neutralize sequences that could break out of the
+    # inline <script> tag. Without this, a `message` from Google's `error`
+    # query string containing `</script>` would close the script element
+    # mid-stream and execute attacker-controlled HTML. Belt-and-braces:
+    # the `message` is also html-escaped above for the visible <p> tag.
+    def _js_literal(obj):
+        return (
+            json.dumps(obj)
+            .replace('</', '<\\/')
+            .replace(' ', '\\u2028')
+            .replace(' ', '\\u2029')
+        )
+
+    body = f"""<!doctype html>
+<html><head><meta charset="utf-8"><title>Google Drive</title>
+<style>body{{font-family:system-ui,-apple-system,sans-serif;background:#f5f1eb;color:#1c1917;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;text-align:center;padding:24px}}.card{{max-width:380px}}.muted{{color:#78716c;font-size:14px;margin-top:8px}}</style>
+</head><body><div class="card">
+<h2>{html.escape(title)}</h2>
+<p class="muted">{message_safe or html.escape(fallback_copy)}</p>
+</div>
+<script>
+(function () {{
+  var payload = {_js_literal(payload)};
+  var origins = {_js_literal(origins)};
+  try {{
+    if (window.opener && !window.opener.closed) {{
+      origins.forEach(function (o) {{
+        try {{ window.opener.postMessage(payload, o); }} catch (e) {{}}
+      }});
+    }}
+  }} catch (e) {{}}
+  // Give the opener a tick to receive the message before closing.
+  setTimeout(function () {{ try {{ window.close(); }} catch (e) {{}} }}, 200);
+}})();
+</script>
+</body></html>"""
+
+    response = make_response(body, 200 if status == 'success' else 400)
+    response.headers['Content-Type'] = 'text/html; charset=utf-8'
+    response.headers['Cache-Control'] = 'no-store'
+    return response
 
 
 def _get_current_user_id() -> Optional[str]:
@@ -158,33 +225,33 @@ def google_callback():
     """
     try:
         # Check for error (user denied access)
-        error = request.args.get('error')
-        if error:
-            current_app.logger.warning(f"Google OAuth denied: {error}")
-            return redirect(f'http://localhost:5173?google_auth=error&message={error}')
+        oauth_error = request.args.get('error')
+        if oauth_error:
+            current_app.logger.warning("Google OAuth denied: %s", oauth_error)
+            return _render_callback_page('error', oauth_error)
 
         # Get authorization code
         code = request.args.get('code')
         if not code:
-            return redirect('http://localhost:5173?google_auth=error&message=No+authorization+code')
+            return _render_callback_page('error', 'No authorization code')
 
         # Get user_id from state parameter (for multi-user support)
         # State was set in get_auth_url() to identify which user initiated OAuth
-        user_id = request.args.get('state')
+        user_id = request.args.get('state') or None
 
         # Exchange code for tokens, passing user_id for storage
-        success, message = google_auth_service.handle_callback(code, user_id=user_id if user_id else None)
+        success, message = google_auth_service.handle_callback(code, user_id=user_id)
 
         if success:
-            current_app.logger.info(f"Google OAuth successful: {message}")
-            return redirect('http://localhost:5173?google_auth=success')
-        else:
-            current_app.logger.error(f"Google OAuth failed: {message}")
-            return redirect(f'http://localhost:5173?google_auth=error&message={message}')
+            current_app.logger.info("Google OAuth successful: %s", message)
+            return _render_callback_page('success', message)
+
+        current_app.logger.error("Google OAuth failed: %s", message)
+        return _render_callback_page('error', message)
 
     except Exception as e:
-        current_app.logger.error(f"Error in Google callback: {e}")
-        return redirect(f'http://localhost:5173?google_auth=error&message={str(e)}')
+        current_app.logger.error("Error in Google callback: %s", e)
+        return _render_callback_page('error', str(e))
 
 
 @google_bp.route('/google/disconnect', methods=['POST'])

--- a/backend/app/services/integrations/google/google_auth_service.py
+++ b/backend/app/services/integrations/google/google_auth_service.py
@@ -20,7 +20,11 @@ Required Setup:
     1. Create project at https://console.cloud.google.com
     2. Enable Google Drive API
     3. Create OAuth 2.0 credentials (Web application)
-    4. Add http://localhost:5001/api/v1/google/callback as redirect URI
+    4. Add the callback URL as a redirect URI. The URL is derived from your
+       deployment's host + `<API_PREFIX>/google/callback` (e.g.
+       `http://localhost:5001/api/v1/google/callback` for local dev or
+       `https://your-domain.com/api/v1/google/callback` for prod). Override
+       explicitly with the `GOOGLE_REDIRECT_URI` env var if needed.
     5. Copy Client ID and Client Secret to Admin Settings
 
 Migration Note (2026-01):
@@ -34,6 +38,7 @@ import os
 from datetime import datetime
 from typing import Dict, Any, Optional, Tuple
 
+from flask import current_app, has_request_context, request
 from google.oauth2.credentials import Credentials
 
 logger = logging.getLogger(__name__)
@@ -61,13 +66,41 @@ class GoogleAuthService:
         'https://www.googleapis.com/auth/drive.readonly',
     ]
 
-    # Redirect URI for OAuth callback
-    # Educational Note: Must match exactly what's configured in Google Console
-    REDIRECT_URI = 'http://localhost:5001/api/v1/google/callback'
+    # Default redirect URI used when no request context is available and
+    # GOOGLE_REDIRECT_URI is not set (e.g. CLI invocations during tests).
+    # In production the real value is resolved per-request from the active
+    # host or the env override — see `_get_redirect_uri()`.
+    DEFAULT_REDIRECT_URI = 'http://localhost:5001/api/v1/google/callback'
 
     def __init__(self):
         """Initialize the Google Auth service."""
         self._supabase = None
+
+    def _get_redirect_uri(self) -> str:
+        """
+        Resolve the OAuth callback URI for the current deployment.
+
+        Resolution order:
+        1. `GOOGLE_REDIRECT_URI` env var (explicit operator override — must
+           match exactly what's registered in Google Cloud Console).
+        2. Derived from the active request's host + API prefix. Honors
+           X-Forwarded-* headers via ProxyFix, so it works behind Coolify /
+           Traefik / Kong without manual config.
+        3. Localhost fallback for off-request contexts (tests, CLI).
+
+        Google requires the redirect URI sent in `/auth` to match the one
+        sent in the token exchange exactly, which is why both `get_auth_url`
+        and `handle_callback` route through this single helper.
+        """
+        override = os.getenv('GOOGLE_REDIRECT_URI', '').strip()
+        if override:
+            return override
+
+        if has_request_context():
+            api_prefix = current_app.config.get('API_PREFIX', '/api/v1').rstrip('/')
+            return f"{request.host_url.rstrip('/')}{api_prefix}/google/callback"
+
+        return self.DEFAULT_REDIRECT_URI
 
     @property
     def supabase(self):
@@ -99,7 +132,7 @@ class GoogleAuthService:
                 'client_secret': client_secret,
                 'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
                 'token_uri': 'https://oauth2.googleapis.com/token',
-                'redirect_uris': [self.REDIRECT_URI],
+                'redirect_uris': [self._get_redirect_uri()],
             }
         }
 
@@ -184,7 +217,7 @@ class GoogleAuthService:
         flow = Flow.from_client_config(
             client_config,
             scopes=self.SCOPES,
-            redirect_uri=self.REDIRECT_URI
+            redirect_uri=self._get_redirect_uri()
         )
 
         # Generate auth URL
@@ -228,7 +261,7 @@ class GoogleAuthService:
             flow = Flow.from_client_config(
                 client_config,
                 scopes=self.SCOPES,
-                redirect_uri=self.REDIRECT_URI
+                redirect_uri=self._get_redirect_uri()
             )
 
             # Exchange authorization code for tokens

--- a/backend/app/services/source_services/source_processing/source_processing_service.py
+++ b/backend/app/services/source_services/source_processing/source_processing_service.py
@@ -56,6 +56,7 @@ class SourceProcessingService:
         ".xml": "text",
         ".docx": "docx",
         ".csv": "csv",  # CSV files (including Google Sheets exports)
+        ".xlsx": "xlsx",  # Excel workbooks — converted to CSV then routed through csv pipeline
         ".jpeg": "image",
         ".jpg": "image",
         ".png": "image",
@@ -159,6 +160,10 @@ class SourceProcessingService:
             elif processor_type == "csv":
                 from app.services.source_services.source_processing.csv_processor import process_csv
                 return process_csv(project_id, source_id, source, raw_file_path, source_service)
+
+            elif processor_type == "xlsx":
+                from app.services.source_services.source_processing.xlsx_processor import process_xlsx
+                return process_xlsx(project_id, source_id, source, raw_file_path, source_service)
 
             elif processor_type == "image":
                 from app.services.source_services.source_processing.image_processor import process_image

--- a/backend/app/services/source_services/source_processing/xlsx_processor.py
+++ b/backend/app/services/source_services/source_processing/xlsx_processor.py
@@ -1,0 +1,90 @@
+"""
+XLSX Processor — convert Excel workbooks into CSV and reuse the CSV pipeline.
+
+Why route through csv_processor: the chat-side analyzer (csv_analyzer_agent)
+dispatches on `embedding_info["file_extension"] == ".csv"` and the existing
+csv_service prompts are already tuned for tabular data. Re-implementing all
+of that for xlsx would be churn for no gain.
+
+Multi-sheet handling: each sheet is dumped as its own CSV section with a
+clear `=== SHEET: <name> ===` header so the analyzer can tell sheets
+apart. Sheets are concatenated in workbook order. For a single-sheet
+workbook the header is omitted so it looks identical to a plain CSV.
+
+Empty sheets are skipped. Cells are coerced to strings via pandas'
+default csv export — dates and numbers round-trip cleanly enough for
+the analyzer's purposes.
+"""
+import logging
+from io import StringIO
+from pathlib import Path
+from typing import Dict, Any
+
+import pandas as pd
+
+from app.services.source_services.source_processing.csv_processor import process_csv
+
+logger = logging.getLogger(__name__)
+
+
+def _xlsx_to_csv_text(xlsx_path: Path) -> str:
+    """Read every sheet in the workbook and return a single CSV string."""
+    # sheet_name=None returns {sheet_name: DataFrame} preserving workbook order.
+    sheets: Dict[str, pd.DataFrame] = pd.read_excel(xlsx_path, sheet_name=None)
+    non_empty = [(name, df) for name, df in sheets.items() if not df.empty]
+
+    if not non_empty:
+        return ''
+
+    buf = StringIO()
+    if len(non_empty) == 1:
+        non_empty[0][1].to_csv(buf, index=False)
+        return buf.getvalue()
+
+    for idx, (name, df) in enumerate(non_empty):
+        if idx > 0:
+            buf.write('\n')
+        buf.write(f"=== SHEET: {name} ===\n")
+        df.to_csv(buf, index=False)
+    return buf.getvalue()
+
+
+def process_xlsx(
+    project_id: str,
+    source_id: str,
+    source: Dict[str, Any],
+    raw_file_path: Path,
+    source_service,
+) -> Dict[str, Any]:
+    source_name = source.get("name", "unknown")
+    logger.info("Processing XLSX source: %s", source_name)
+
+    try:
+        csv_text = _xlsx_to_csv_text(raw_file_path)
+    except Exception as exc:
+        logger.error("Failed to read XLSX %s: %s", raw_file_path, exc)
+        source_service.update_source(
+            project_id,
+            source_id,
+            status="error",
+            processing_info={"error": f"Failed to read XLSX: {exc}"},
+        )
+        return {"success": False, "error": f"Failed to read XLSX: {exc}"}
+
+    if not csv_text.strip():
+        source_service.update_source(
+            project_id,
+            source_id,
+            status="error",
+            processing_info={"error": "Workbook is empty (no sheets with data)"},
+        )
+        return {"success": False, "error": "Workbook is empty"}
+
+    # Write the converted CSV next to the raw xlsx so csv_processor reads
+    # from disk via its usual path. Keeping it inside the same per-source
+    # temp dir means the outer cleanup in source_processing_service still
+    # removes it on completion.
+    csv_path = raw_file_path.with_suffix('.csv')
+    csv_path.write_text(csv_text, encoding='utf-8')
+
+    return process_csv(project_id, source_id, source, csv_path, source_service)

--- a/backend/app/utils/file_utils.py
+++ b/backend/app/utils/file_utils.py
@@ -38,6 +38,7 @@ ALLOWED_EXTENSIONS: Dict[str, str] = {
     '.webp': 'image',
     # Data
     '.csv': 'data',
+    '.xlsx': 'data',
     # Links (stored as JSON with URL metadata)
     '.link': 'link',
 }
@@ -63,6 +64,7 @@ MIME_TYPES: Dict[str, str] = {
     '.gif': 'image/gif',
     '.webp': 'image/webp',
     '.csv': 'text/csv',
+    '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     '.link': 'application/json',
 }
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -51,6 +51,7 @@ mypy_extensions==1.1.0
 numpy==2.3.5
 oauthlib==3.3.1
 openai==2.8.1
+openpyxl==3.1.5
 orjson==3.11.4
 packaging==24.2
 pandas==2.3.3

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -14,6 +14,13 @@ ELEVENLABS_API_KEY=
 TAVILY_API_KEY=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+# Optional. Override the OAuth callback URL the backend hands to Google.
+# Defaults to `<scheme>://<host><API_PREFIX>/google/callback` derived from
+# the active request (honors X-Forwarded-* headers behind a proxy), so most
+# deployments don't need this. Set it only when your registered Google
+# Cloud Console redirect URI must differ from what the backend computes
+# (e.g. custom proxy paths). It must match Google Console exactly.
+GOOGLE_REDIRECT_URI=
 
 # --- Optional AI/Media Generation Keys ---
 # These can also be added later via Settings → API Keys in the UI.

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -300,7 +300,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             onChange={(e) => onMessageChange(e.target.value)}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
-            className={`flex-1 py-1.5 min-h-[32px] max-h-[100px] resize-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent ${
+            // `resize-y` exposes the native bottom-right drag handle so
+            // users can pull the box taller when they're drafting longer
+            // messages. min/max bound it so the input can't shrink to a
+            // single line or swallow the entire chat surface.
+            className={`flex-1 py-1.5 min-h-[32px] max-h-[400px] resize-y border-0 focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent ${
               partialTranscript ? 'text-muted-foreground' : ''
             }`}
             disabled={sending || isRecording}

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -31,6 +31,53 @@ import { cn } from '@/lib/utils';
 
 const log = createLogger('chat-messages');
 
+/**
+ * Format a message timestamp for display next to the bubble.
+ *
+ * Today  → "3:45 PM"
+ * This year, different day → "May 11, 3:45 PM"
+ * Different year          → "May 11, 2025, 3:45 PM"
+ *
+ * Invalid / missing timestamps return an empty string so the caller can
+ * skip rendering without an extra guard.
+ */
+const formatMessageTime = (raw?: string): string => {
+  if (!raw) return '';
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return '';
+
+  const now = new Date();
+  const timePart = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  const sameDay = d.toDateString() === now.toDateString();
+  if (sameDay) return timePart;
+
+  const sameYear = d.getFullYear() === now.getFullYear();
+  const datePart = d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    ...(sameYear ? {} : { year: 'numeric' }),
+  });
+  return `${datePart}, ${timePart}`;
+};
+
+const MessageTimestamp: React.FC<{ raw?: string; align: 'left' | 'right' }> = ({ raw, align }) => {
+  const formatted = formatMessageTime(raw);
+  if (!formatted) return null;
+  return (
+    <p
+      className={cn(
+        'mt-1 text-[11px] text-muted-foreground/80 select-none',
+        align === 'right' ? 'text-right' : 'text-left'
+      )}
+      // Surface full ISO on hover so users can copy exact time if needed —
+      // the visible form is intentionally short to keep the chat tidy.
+      title={raw}
+    >
+      {formatted}
+    </p>
+  );
+};
+
 interface ChatMessagesProps {
   messages: Message[];
   sending: boolean;
@@ -700,6 +747,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
                 studioAssetRewriter={studioAssetRewriter}
               />
             )}
+            <MessageTimestamp raw={msg.timestamp} align={msg.role === 'user' ? 'right' : 'left'} />
             {msg.error && (
               <p className="text-xs text-destructive text-center mt-1">
                 This message had an error

--- a/frontend/src/components/settings/sections/IntegrationsSection.tsx
+++ b/frontend/src/components/settings/sections/IntegrationsSection.tsx
@@ -39,6 +39,7 @@ import type { DatabaseType, McpAuthType, McpTransport } from '@/lib/api/settings
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
 import { useIntegrations } from '@/contexts/IntegrationsContext';
+import { useGoogleConnect } from '@/hooks/useGoogleConnect';
 
 const log = createLogger('integrations-section');
 
@@ -65,9 +66,11 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
     removeMcpConnection,
     patchMcpConnection,
   } = useIntegrations();
+  const { connect: connectGoogle, isConnecting: googleConnecting } = useGoogleConnect();
   const [dbCreating, setDbCreating] = useState(false);
   const [dbValidating, setDbValidating] = useState(false);
-  const [googleMutating, setGoogleMutating] = useState(false);
+  const [googleDisconnecting, setGoogleDisconnecting] = useState(false);
+  const googleMutating = googleConnecting || googleDisconnecting;
   const [showDbUri, setShowDbUri] = useState(false);
   const [dbValidation, setDbValidation] = useState<{ valid?: boolean; message?: string }>({});
   const [dbForm, setDbForm] = useState<{
@@ -114,53 +117,10 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
   const [deleteMcpId, setDeleteMcpId] = useState<string | null>(null);
   const [disconnectGoogleOpen, setDisconnectGoogleOpen] = useState(false);
 
-  const { success, error, info } = useToast();
-
-  const handleGoogleConnect = async () => {
-    setGoogleMutating(true);
-    try {
-      const authUrl = await googleDriveAPI.getAuthUrl();
-      if (!authUrl) {
-        error('Failed to get Google auth URL. Check your credentials.');
-        setGoogleMutating(false);
-        return;
-      }
-
-      window.open(authUrl, '_blank', 'width=500,height=600');
-      info('Complete authentication in the new window');
-      // Keep the button disabled while polling runs so a second click cannot
-      // spawn a parallel interval. Button re-enables on success, timeout, or
-      // any poll error.
-      const pollInterval = setInterval(async () => {
-        try {
-          const status = await googleDriveAPI.getStatus();
-          if (status.connected) {
-            clearInterval(pollInterval);
-            clearTimeout(timeoutId);
-            setGoogleStatus(status);
-            setGoogleMutating(false);
-            success(`Connected as ${status.email}`);
-          }
-        } catch (pollErr) {
-          log.error({ err: pollErr }, 'google poll failed');
-          clearInterval(pollInterval);
-          clearTimeout(timeoutId);
-          setGoogleMutating(false);
-        }
-      }, 2000);
-      const timeoutId = setTimeout(() => {
-        clearInterval(pollInterval);
-        setGoogleMutating(false);
-      }, 120000);
-    } catch (err) {
-      log.error({ err }, 'failed to connect Google');
-      error('Failed to connect Google Drive');
-      setGoogleMutating(false);
-    }
-  };
+  const { success, error } = useToast();
 
   const handleGoogleDisconnect = async () => {
-    setGoogleMutating(true);
+    setGoogleDisconnecting(true);
     try {
       const disconnected = await googleDriveAPI.disconnect();
       if (disconnected) {
@@ -173,7 +133,7 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
       log.error({ err }, 'failed to disconnect Google');
       error('Failed to disconnect Google Drive');
     } finally {
-      setGoogleMutating(false);
+      setGoogleDisconnecting(false);
     }
   };
 
@@ -430,7 +390,7 @@ export const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({ isAdmi
               <Button
                 variant="default"
                 size="sm"
-                onClick={handleGoogleConnect}
+                onClick={connectGoogle}
                 disabled={googleLoading || googleMutating || !googleStatus.configured}
               >
                 {googleLoading || googleMutating ? (

--- a/frontend/src/components/sources/GoogleDriveTab.tsx
+++ b/frontend/src/components/sources/GoogleDriveTab.tsx
@@ -23,7 +23,6 @@ import {
   GoogleDriveLogo,
   ArrowLeft,
   CircleNotch,
-  Gear,
   MagnifyingGlass,
 } from '@phosphor-icons/react';
 import { googleDriveAPI, type GoogleFile } from '@/lib/api/settings';
@@ -31,6 +30,7 @@ import { useToast } from '../ui/use-toast';
 import { DriveItem } from './drive';
 import { createLogger } from '@/lib/logger';
 import { useIntegrations } from '@/contexts/IntegrationsContext';
+import { useGoogleConnect } from '@/hooks/useGoogleConnect';
 
 const log = createLogger('google-drive-tab');
 
@@ -70,6 +70,7 @@ export const GoogleDriveTab: React.FC<GoogleDriveTabProps> = ({
     ensureGoogleStatus,
     setGoogleStatus,
   } = useIntegrations();
+  const { connect: connectGoogle, isConnecting } = useGoogleConnect();
 
   const loadStatus = useCallback(async () => {
     setLoading(true);
@@ -196,36 +197,44 @@ export const GoogleDriveTab: React.FC<GoogleDriveTabProps> = ({
     loadFiles(false);
   };
 
-  // Not configured state
+  // Not configured state — only an admin can fix this (it requires the
+  // GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET env credentials to be set via
+  // Admin Settings → API Keys), so we don't render a CTA here.
   if (!loading && !status.configured) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <GoogleDriveLogo size={48} weight="duotone" className="text-muted-foreground mb-4" />
         <h3 className="font-medium mb-2">Google Drive Not Configured</h3>
-        <p className="text-sm text-muted-foreground mb-4 max-w-sm">
-          Add your Google Client ID and Client Secret in Admin Settings to enable Google Drive
-          integration.
+        <p className="text-sm text-muted-foreground max-w-sm">
+          An administrator needs to add Google OAuth credentials in Admin Settings → API Keys
+          before this integration can be used.
         </p>
-        <Button variant="soft" size="sm">
-          <Gear size={16} className="mr-2" />
-          Open Settings
-        </Button>
       </div>
     );
   }
 
-  // Not connected state
+  // Not connected state — fire the OAuth popup inline so the user doesn't
+  // have to detour through Admin Settings just to authorise their account.
   if (!loading && !status.connected) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <GoogleDriveLogo size={48} weight="duotone" className="text-primary mb-4" />
         <h3 className="font-medium mb-2">Connect Google Drive</h3>
         <p className="text-sm text-muted-foreground mb-4 max-w-sm">
-          Connect your Google account in Admin Settings to import files from Google Drive.
+          Sign in with your Google account to browse and import files from Drive.
         </p>
-        <Button variant="soft" size="sm">
-          <Gear size={16} className="mr-2" />
-          Open Settings
+        <Button onClick={connectGoogle} disabled={isConnecting} size="sm">
+          {isConnecting ? (
+            <>
+              <CircleNotch size={16} className="mr-2 animate-spin" />
+              Waiting for sign-in...
+            </>
+          ) : (
+            <>
+              <GoogleDriveLogo size={16} className="mr-2" />
+              Connect Google Drive
+            </>
+          )}
         </Button>
       </div>
     );

--- a/frontend/src/components/sources/SourceItem.tsx
+++ b/frontend/src/components/sources/SourceItem.tsx
@@ -16,6 +16,7 @@ import {
   FileHtml,
   FilePng,
   FileJpg,
+  FileXls,
   MarkdownLogo,
   File,
   MusicNote,
@@ -93,6 +94,7 @@ const getSourceIcon = (source: Source): { icon: typeof File; weight?: 'bold' } =
     case '.pptx': return { icon: FilePpt, weight: 'bold' };
     case '.txt': return { icon: FileText, weight: 'bold' };
     case '.csv': return { icon: FileCsv, weight: 'bold' };
+    case '.xlsx': return { icon: FileXls, weight: 'bold' };
     case '.database': return { icon: Table, weight: 'bold' };
     case '.mcp': return { icon: Plug, weight: 'bold' };
     case '.md': return { icon: MarkdownLogo, weight: 'bold' };

--- a/frontend/src/hooks/useGoogleConnect.ts
+++ b/frontend/src/hooks/useGoogleConnect.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { googleDriveAPI } from '@/lib/api/settings';
+import { API_HOST } from '@/lib/api/client';
 import { useIntegrations } from '@/contexts/IntegrationsContext';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
@@ -9,6 +10,26 @@ const log = createLogger('use-google-connect');
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 120_000;
 const POST_MESSAGE_TYPE = 'noobbook:google-auth';
+
+/**
+ * Origins we accept postMessage events from. The callback page is served
+ * by the backend at `<API_HOST>/api/v1/google/callback`, so its
+ * `event.origin` is the backend's origin. In prod/Docker the frontend
+ * and backend share an origin (API_HOST is empty / same-origin); in
+ * local dev the backend is at :5001 while the frontend is at :5173, so
+ * we explicitly allow the API host too.
+ */
+const buildAllowedOrigins = (): Set<string> => {
+  const origins = new Set<string>([window.location.origin]);
+  if (API_HOST) {
+    try {
+      origins.add(new URL(API_HOST, window.location.origin).origin);
+    } catch {
+      // API_HOST is malformed — ignore; same-origin still works.
+    }
+  }
+  return origins;
+};
 
 interface GoogleAuthMessage {
   type: typeof POST_MESSAGE_TYPE;
@@ -39,6 +60,13 @@ export function useGoogleConnect() {
   // We register the postMessage listener once per connect attempt so a
   // stale listener from a previous attempt can't fire against new state.
   const messageHandlerRef = useRef<((event: MessageEvent) => void) | null>(null);
+  // Guards against concurrent finalize calls — e.g. when two overlapping
+  // status polls both observe `connected=true` before the first one's
+  // cleanup() takes effect. Without this the user would see two
+  // "Connected as …" toasts back-to-back.
+  const finalizingRef = useRef(false);
+
+  const allowedOrigins = useMemo(() => buildAllowedOrigins(), []);
 
   const cleanup = useCallback(() => {
     if (pollRef.current) {
@@ -58,6 +86,8 @@ export function useGoogleConnect() {
   useEffect(() => () => cleanup(), [cleanup]);
 
   const finalizeSuccess = useCallback(async () => {
+    if (finalizingRef.current) return;
+    finalizingRef.current = true;
     cleanup();
     try {
       // Re-fetch from the backend rather than trusting the popup's payload —
@@ -83,6 +113,7 @@ export function useGoogleConnect() {
 
   const connect = useCallback(async () => {
     setIsConnecting(true);
+    finalizingRef.current = false;
     try {
       const authUrl = await googleDriveAPI.getAuthUrl();
       if (!authUrl) {
@@ -97,7 +128,12 @@ export function useGoogleConnect() {
       cleanup();
 
       // Fast path: the callback page posts back to us before self-closing.
+      // Any same-window page that holds a reference to us could spoof this
+      // event, so we gate on `event.origin` matching the backend that we
+      // know served the callback HTML. The allowlist is derived from
+      // API_HOST + same-origin, computed once per hook instance.
       const handler = (event: MessageEvent) => {
+        if (!allowedOrigins.has(event.origin)) return;
         const data = event.data as Partial<GoogleAuthMessage> | undefined;
         if (!data || data.type !== POST_MESSAGE_TYPE) return;
         if (data.status === 'success') {
@@ -135,7 +171,7 @@ export function useGoogleConnect() {
       error('Failed to connect Google Drive');
       setIsConnecting(false);
     }
-  }, [cleanup, error, finalizeSuccess, info]);
+  }, [allowedOrigins, cleanup, error, finalizeSuccess, info]);
 
   return { connect, isConnecting };
 }

--- a/frontend/src/hooks/useGoogleConnect.ts
+++ b/frontend/src/hooks/useGoogleConnect.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { googleDriveAPI } from '@/lib/api/settings';
+import { useIntegrations } from '@/contexts/IntegrationsContext';
+import { useToast } from '@/components/ui/use-toast';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('use-google-connect');
+
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 120_000;
+const POST_MESSAGE_TYPE = 'noobbook:google-auth';
+
+interface GoogleAuthMessage {
+  type: typeof POST_MESSAGE_TYPE;
+  status: 'success' | 'error';
+  message?: string;
+}
+
+/**
+ * Shared Google Drive OAuth connect flow.
+ *
+ * Opens the consent popup, then completes via the faster of two signals:
+ * - A `postMessage` from the callback page (instant, fires before the
+ *   popup self-closes).
+ * - A periodic `/google/status` poll (fallback when the popup is blocked,
+ *   the message is lost, or the user pastes the callback URL by hand).
+ *
+ * Either path writes the new status into IntegrationsContext so every
+ * consumer (Sources → Drive tab, Admin Settings → Integrations) re-renders
+ * automatically.
+ */
+export function useGoogleConnect() {
+  const [isConnecting, setIsConnecting] = useState(false);
+  const { setGoogleStatus } = useIntegrations();
+  const { success, error, info } = useToast();
+
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // We register the postMessage listener once per connect attempt so a
+  // stale listener from a previous attempt can't fire against new state.
+  const messageHandlerRef = useRef<((event: MessageEvent) => void) | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (messageHandlerRef.current) {
+      window.removeEventListener('message', messageHandlerRef.current);
+      messageHandlerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => cleanup(), [cleanup]);
+
+  const finalizeSuccess = useCallback(async () => {
+    cleanup();
+    try {
+      // Re-fetch from the backend rather than trusting the popup's payload —
+      // we want the canonical `email` for the toast and to be sure the
+      // refresh token actually persisted before we flip the UI.
+      const status = await googleDriveAPI.getStatus();
+      setGoogleStatus(status);
+      setIsConnecting(false);
+      if (status.connected) {
+        success(`Connected as ${status.email}`);
+      } else {
+        // Defensive: popup said success but the backend disagrees. Rare —
+        // usually a refresh-token persistence error — surface it instead
+        // of silently leaving the user thinking they're connected.
+        error('Sign-in completed but no tokens were stored. Please retry.');
+      }
+    } catch (err) {
+      log.error({ err }, 'failed to fetch status after google auth');
+      setIsConnecting(false);
+      error('Connected with Google, but failed to refresh status. Please reload.');
+    }
+  }, [cleanup, error, setGoogleStatus, success]);
+
+  const connect = useCallback(async () => {
+    setIsConnecting(true);
+    try {
+      const authUrl = await googleDriveAPI.getAuthUrl();
+      if (!authUrl) {
+        error('Failed to get Google auth URL. Check your credentials.');
+        setIsConnecting(false);
+        return;
+      }
+
+      window.open(authUrl, '_blank', 'width=500,height=600');
+      info('Complete authentication in the new window');
+
+      cleanup();
+
+      // Fast path: the callback page posts back to us before self-closing.
+      const handler = (event: MessageEvent) => {
+        const data = event.data as Partial<GoogleAuthMessage> | undefined;
+        if (!data || data.type !== POST_MESSAGE_TYPE) return;
+        if (data.status === 'success') {
+          finalizeSuccess();
+        } else {
+          cleanup();
+          setIsConnecting(false);
+          error(data.message ? `Google sign-in failed: ${data.message}` : 'Google sign-in failed');
+        }
+      };
+      window.addEventListener('message', handler);
+      messageHandlerRef.current = handler;
+
+      // Fallback: poll status in case the postMessage was dropped (popup
+      // blocker, cross-origin quirk, manual paste of the callback URL).
+      pollRef.current = setInterval(async () => {
+        try {
+          const status = await googleDriveAPI.getStatus();
+          if (status.connected) {
+            finalizeSuccess();
+          }
+        } catch (pollErr) {
+          log.error({ err: pollErr }, 'google poll failed');
+          cleanup();
+          setIsConnecting(false);
+        }
+      }, POLL_INTERVAL_MS);
+
+      timeoutRef.current = setTimeout(() => {
+        cleanup();
+        setIsConnecting(false);
+      }, POLL_TIMEOUT_MS);
+    } catch (err) {
+      log.error({ err }, 'failed to connect Google');
+      error('Failed to connect Google Drive');
+      setIsConnecting(false);
+    }
+  }, [cleanup, error, finalizeSuccess, info]);
+
+  return { connect, isConnecting };
+}

--- a/frontend/src/lib/api/sources.ts
+++ b/frontend/src/lib/api/sources.ts
@@ -72,7 +72,7 @@ export const ALLOWED_EXTENSIONS = {
   document: ['.pdf', '.txt', '.docx', '.pptx', '.md', '.json', '.html', '.xml'],
   image: ['.jpeg', '.jpg', '.png', '.gif', '.webp'],
   audio: ['.mp3', '.wav', '.m4a', '.aac', '.flac'],
-  data: ['.csv'],
+  data: ['.csv', '.xlsx'],
 };
 
 /**


### PR DESCRIPTION
Three small features from the roadmap.

Closes #250 (xlsx upload), #251 (resizable chat textbox), #252 (per-message timestamp).

## Summary

- **XLSX upload** — `.xlsx` files are now accepted alongside `.csv`. A new `xlsx_processor` reads every sheet via pandas/openpyxl, joins them into a single CSV string (one `=== SHEET: <name> ===` header per sheet, single-sheet workbooks come out as plain CSV), then hands off to the existing CSV pipeline. Empty sheets are skipped. The chat-side analyzer treats it identically to CSV so no chat changes were needed.
- **Resizable chat input** — `resize-y` on the textarea exposes the native bottom-right drag handle. Max height bumped from 100px to 400px so users can pull the box much taller when drafting longer prompts; min stays at 32px.
- **Message timestamps** — small muted timestamp under every chat bubble. Today → `3:45 PM`, earlier in the year → `May 11, 3:45 PM`, prior years → `May 11, 2025, 3:45 PM`. Hovering shows the full ISO timestamp. Backend already returned `timestamp` per message — no API changes.

## Test plan

- [ ] Upload an `.xlsx` workbook with one sheet → renders as a CSV source, csv-analyzer queries work
- [ ] Upload a multi-sheet `.xlsx` → each sheet appears as its own block in the processed content
- [ ] In the chat input, drag the bottom-right corner up/down — height changes within 32–400px
- [ ] Open any chat → timestamps appear under every message, right-aligned for user, left-aligned for assistant
- [ ] Hover a timestamp → full ISO shows in tooltip