### PR TITLE
feat: saved insights with daily/weekly auto-refresh

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -126,6 +126,16 @@ def create_app(config_name='development'):
     # Register error handlers
     register_error_handlers(app)
 
+    # Start the saved-insight scheduler. Daemon thread; one tick every
+    # 5 minutes; refreshes any insight whose cadence interval has
+    # elapsed. Tick failures are swallowed and logged so a transient
+    # Supabase blip can't take the app down.
+    try:
+        from app.services.background_services.insight_scheduler import insight_scheduler
+        insight_scheduler.start()
+    except Exception as exc:
+        app.logger.warning("Failed to start insight scheduler: %s", exc)
+
     # Log successful initialization
     app.logger.info(f"✅ {app.config['APP_NAME']} backend initialized successfully")
 

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -97,6 +97,7 @@ from app.api.studio import studio_bp
 from app.api.brand import brand_bp
 from app.api.share import share_bp
 from app.api.logs import logs_bp
+from app.api.insights import insights_bp
 
 # Register nested blueprints with the main api blueprint
 # No url_prefix needed - routes already have full paths
@@ -113,3 +114,4 @@ api_bp.register_blueprint(studio_bp)
 api_bp.register_blueprint(brand_bp)
 api_bp.register_blueprint(share_bp)
 api_bp.register_blueprint(logs_bp)
+api_bp.register_blueprint(insights_bp)

--- a/backend/app/api/insights/__init__.py
+++ b/backend/app/api/insights/__init__.py
@@ -1,0 +1,6 @@
+"""Saved Insights blueprint — auto-refreshing chat prompts."""
+from flask import Blueprint
+
+insights_bp = Blueprint("insights", __name__)
+
+from app.api.insights import routes  # noqa: E402,F401  -- registers routes

--- a/backend/app/api/insights/routes.py
+++ b/backend/app/api/insights/routes.py
@@ -12,7 +12,22 @@ from flask import current_app, jsonify, request
 
 from app.api.insights import insights_bp
 from app.services.auth.rbac import get_request_identity
+from app.services.data_services import project_service
 from app.services.data_services.insight_service import insight_service
+
+
+def _project_access_or_404(project_id: str, user_id: str):
+    """Enforce project membership before any insight mutation.
+
+    The backend uses the Supabase service-role JWT for all writes, which
+    bypasses RLS — so the project-ownership gate must live in Python,
+    not in the database policy. Without this an authenticated user who
+    knows a foreign project UUID could attach a scheduler-driven chat
+    to it.
+    """
+    if not project_service.has_project_access(project_id, user_id):
+        return jsonify({"success": False, "error": "Project not found"}), 404
+    return None
 
 
 # Reused worker pool for manual refreshes — keeps the response endpoint
@@ -30,6 +45,9 @@ def list_insights(project_id: str):
     user_id = _current_user_id()
     if not user_id:
         return jsonify({"success": False, "error": "Authentication required"}), 401
+    err = _project_access_or_404(project_id, user_id)
+    if err is not None:
+        return err
     try:
         rows = insight_service.list_insights(project_id, user_id)
         return jsonify({"success": True, "insights": rows}), 200
@@ -43,6 +61,9 @@ def create_insight(project_id: str):
     user_id = _current_user_id()
     if not user_id:
         return jsonify({"success": False, "error": "Authentication required"}), 401
+    err = _project_access_or_404(project_id, user_id)
+    if err is not None:
+        return err
     data = request.get_json() or {}
     prompt = (data.get("prompt") or "").strip()
     cadence = (data.get("cadence") or "weekly").strip()
@@ -69,12 +90,12 @@ def create_insight(project_id: str):
     "/projects/<project_id>/insights/<insight_id>", methods=["DELETE"]
 )
 def delete_insight(project_id: str, insight_id: str):
-    # project_id is accepted in the path for route symmetry but the
-    # ownership check on owner_user_id is what actually authorises.
-    _ = project_id
     user_id = _current_user_id()
     if not user_id:
         return jsonify({"success": False, "error": "Authentication required"}), 401
+    err = _project_access_or_404(project_id, user_id)
+    if err is not None:
+        return err
     deleted = insight_service.delete_insight(insight_id, user_id)
     if not deleted:
         return jsonify({"success": False, "error": "Not found"}), 404
@@ -85,13 +106,19 @@ def delete_insight(project_id: str, insight_id: str):
     "/projects/<project_id>/insights/<insight_id>/refresh", methods=["POST"]
 )
 def refresh_insight(project_id: str, insight_id: str):
-    _ = project_id
     user_id = _current_user_id()
     if not user_id:
         return jsonify({"success": False, "error": "Authentication required"}), 401
+    err = _project_access_or_404(project_id, user_id)
+    if err is not None:
+        return err
 
     insight = insight_service.get_insight(insight_id)
-    if not insight or insight.get("owner_user_id") != user_id:
+    if (
+        not insight
+        or insight.get("owner_user_id") != user_id
+        or insight.get("project_id") != project_id
+    ):
         return jsonify({"success": False, "error": "Not found"}), 404
 
     # Claim before submitting so we can return a clean 409 if a scheduler

--- a/backend/app/api/insights/routes.py
+++ b/backend/app/api/insights/routes.py
@@ -1,0 +1,114 @@
+"""
+Saved Insights routes — list, create, delete, manual refresh.
+
+The scheduler handles automatic refresh on cadence; this surface lets the
+user save new insights, see what's stored, kick a refresh by hand, and
+delete ones they no longer want.
+"""
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+from flask import current_app, jsonify, request
+
+from app.api.insights import insights_bp
+from app.services.auth.rbac import get_request_identity
+from app.services.data_services.insight_service import insight_service
+
+
+# Reused worker pool for manual refreshes — keeps the response endpoint
+# fast (returns immediately) while the refresh runs in the background.
+_manual_refresh_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="insight-manual")
+
+
+def _current_user_id() -> Optional[str]:
+    identity = get_request_identity()
+    return identity.user_id if identity.is_authenticated else None
+
+
+@insights_bp.route("/projects/<project_id>/insights", methods=["GET"])
+def list_insights(project_id: str):
+    user_id = _current_user_id()
+    if not user_id:
+        return jsonify({"success": False, "error": "Authentication required"}), 401
+    try:
+        rows = insight_service.list_insights(project_id, user_id)
+        return jsonify({"success": True, "insights": rows}), 200
+    except Exception as exc:
+        current_app.logger.error("list_insights failed: %s", exc)
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+
+@insights_bp.route("/projects/<project_id>/insights", methods=["POST"])
+def create_insight(project_id: str):
+    user_id = _current_user_id()
+    if not user_id:
+        return jsonify({"success": False, "error": "Authentication required"}), 401
+    data = request.get_json() or {}
+    prompt = (data.get("prompt") or "").strip()
+    cadence = (data.get("cadence") or "weekly").strip()
+    title = (data.get("title") or prompt[:60]).strip()
+    if not prompt:
+        return jsonify({"success": False, "error": "Prompt is required"}), 400
+    if cadence not in ("daily", "weekly"):
+        return jsonify({"success": False, "error": "Cadence must be 'daily' or 'weekly'"}), 400
+    try:
+        insight = insight_service.create_insight(
+            project_id=project_id,
+            owner_user_id=user_id,
+            title=title,
+            prompt=prompt,
+            cadence=cadence,
+        )
+        return jsonify({"success": True, "insight": insight}), 201
+    except Exception as exc:
+        current_app.logger.error("create_insight failed: %s", exc)
+        return jsonify({"success": False, "error": str(exc)}), 500
+
+
+@insights_bp.route(
+    "/projects/<project_id>/insights/<insight_id>", methods=["DELETE"]
+)
+def delete_insight(project_id: str, insight_id: str):
+    # project_id is accepted in the path for route symmetry but the
+    # ownership check on owner_user_id is what actually authorises.
+    _ = project_id
+    user_id = _current_user_id()
+    if not user_id:
+        return jsonify({"success": False, "error": "Authentication required"}), 401
+    deleted = insight_service.delete_insight(insight_id, user_id)
+    if not deleted:
+        return jsonify({"success": False, "error": "Not found"}), 404
+    return jsonify({"success": True}), 200
+
+
+@insights_bp.route(
+    "/projects/<project_id>/insights/<insight_id>/refresh", methods=["POST"]
+)
+def refresh_insight(project_id: str, insight_id: str):
+    _ = project_id
+    user_id = _current_user_id()
+    if not user_id:
+        return jsonify({"success": False, "error": "Authentication required"}), 401
+
+    insight = insight_service.get_insight(insight_id)
+    if not insight or insight.get("owner_user_id") != user_id:
+        return jsonify({"success": False, "error": "Not found"}), 404
+
+    # Claim before submitting so we can return a clean 409 if a scheduler
+    # tick or another tab already kicked off this refresh.
+    if not insight_service.claim_for_refresh(insight_id):
+        return jsonify(
+            {"success": False, "error": "Refresh already in progress"}
+        ), 409
+
+    _manual_refresh_pool.submit(_run_manual_refresh, insight_id)
+    return jsonify({"success": True, "status": "queued"}), 202
+
+
+def _run_manual_refresh(insight_id: str) -> None:
+    try:
+        insight_service.refresh_insight(insight_id)
+    except Exception:
+        # refresh_insight already logs + records last_error; just swallow
+        # so the worker pool doesn't surface this on stderr a second time.
+        pass

--- a/backend/app/services/background_services/insight_scheduler.py
+++ b/backend/app/services/background_services/insight_scheduler.py
@@ -1,0 +1,101 @@
+"""
+Saved-Insight Scheduler — daemon thread that periodically refreshes any
+insight whose cadence interval has elapsed.
+
+Design:
+- One daemon thread per process. We run a single gunicorn worker in prod
+  (and a Flask dev server in dev), so a single in-process scheduler is
+  sufficient — no cross-process coordination needed.
+- Tick interval is intentionally coarse (5 minutes). Cadences are daily
+  or weekly; sub-minute precision isn't needed and the looser interval
+  keeps Supabase chatter low.
+- Per-insight refreshes are submitted to a small ThreadPoolExecutor so a
+  slow refresh (long agentic loop) doesn't block the next tick from
+  enqueuing other due insights.
+- The atomic claim in insight_service.refresh_insight makes this safe
+  against the manual /refresh route racing the scheduler.
+"""
+import logging
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from app.services.data_services.insight_service import insight_service
+
+logger = logging.getLogger(__name__)
+
+
+TICK_INTERVAL_SECONDS = 300  # 5 min
+MAX_CONCURRENT_REFRESHES = 4
+STARTUP_DELAY_SECONDS = 30   # let the app finish booting before first tick
+
+
+class InsightScheduler:
+    def __init__(self):
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._executor = ThreadPoolExecutor(
+            max_workers=MAX_CONCURRENT_REFRESHES,
+            thread_name_prefix="insight-refresh",
+        )
+        self._started = False
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        self._thread = threading.Thread(
+            target=self._run,
+            name="insight-scheduler",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info("Insight scheduler started (tick=%ss)", TICK_INTERVAL_SECONDS)
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _run(self) -> None:
+        # Sleep briefly before the first tick so we don't compete with app
+        # warmup for resources.
+        if self._stop.wait(STARTUP_DELAY_SECONDS):
+            return
+
+        # Clear any `is_running=true` rows abandoned by a previous worker
+        # that was SIGKILLed mid-refresh (Coolify redeploy, OOM, watchdog
+        # bounce). Without this, the affected insight would be skipped
+        # forever because `claim_for_refresh` filters on `is_running=false`.
+        try:
+            insight_service.reset_stale_claims()
+        except Exception as exc:
+            logger.warning("Stale-claim sweep failed: %s", exc)
+
+        while not self._stop.is_set():
+            try:
+                self._tick()
+            except Exception as exc:
+                logger.exception("Insight scheduler tick failed: %s", exc)
+            if self._stop.wait(TICK_INTERVAL_SECONDS):
+                break
+
+    def _tick(self) -> None:
+        due = insight_service.find_due_insights()
+        if not due:
+            return
+        logger.info("Insight scheduler: %d due", len(due))
+        for row in due:
+            insight_id = row["id"]
+            if not insight_service.claim_for_refresh(insight_id):
+                # Lost the race with manual refresh or a prior tick.
+                continue
+            self._executor.submit(self._refresh_safely, insight_id)
+
+    @staticmethod
+    def _refresh_safely(insight_id: str) -> None:
+        try:
+            insight_service.refresh_insight(insight_id)
+        except Exception as exc:
+            logger.exception("Insight refresh %s threw: %s", insight_id, exc)
+
+
+insight_scheduler = InsightScheduler()

--- a/backend/app/services/data_services/insight_service.py
+++ b/backend/app/services/data_services/insight_service.py
@@ -1,0 +1,275 @@
+"""
+Saved Insights Service — CRUD + refresh for user-saved chat prompts that
+auto-rerun on a daily / weekly cadence.
+
+A "refresh" means: start a fresh single-turn chat in the same project,
+send the saved prompt as the first user message, capture the assistant's
+final text, and store it on the insight row. Subsequent reads return
+the stored result without replaying the chat.
+
+The `is_running` flag on each row is the scheduler's claim primitive:
+`UPDATE saved_insights SET is_running = true WHERE id = ? AND NOT is_running`
+either claims or fails atomically, so two parallel scheduler ticks can't
+both fire the same insight.
+"""
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from app.services.integrations.supabase import get_supabase
+
+logger = logging.getLogger(__name__)
+
+
+CADENCE_INTERVALS = {
+    "daily": timedelta(days=1),
+    "weekly": timedelta(days=7),
+}
+
+
+class InsightService:
+    TABLE = "saved_insights"
+
+    @property
+    def supabase(self):
+        return get_supabase()
+
+    # ----- CRUD --------------------------------------------------------
+
+    def list_insights(self, project_id: str, user_id: str) -> List[Dict[str, Any]]:
+        response = (
+            self.supabase.table(self.TABLE)
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", user_id)
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return response.data or []
+
+    def create_insight(
+        self,
+        *,
+        project_id: str,
+        owner_user_id: str,
+        title: str,
+        prompt: str,
+        cadence: str,
+    ) -> Dict[str, Any]:
+        if cadence not in CADENCE_INTERVALS:
+            raise ValueError(f"Invalid cadence {cadence!r}; expected 'daily' or 'weekly'")
+        row = {
+            "project_id": project_id,
+            "owner_user_id": owner_user_id,
+            "title": title.strip() or prompt[:60].strip(),
+            "prompt": prompt.strip(),
+            "cadence": cadence,
+        }
+        response = self.supabase.table(self.TABLE).insert(row).execute()
+        if not response.data:
+            raise RuntimeError("Failed to create saved insight")
+        return response.data[0]
+
+    def get_insight(self, insight_id: str) -> Optional[Dict[str, Any]]:
+        response = (
+            self.supabase.table(self.TABLE)
+            .select("*")
+            .eq("id", insight_id)
+            .limit(1)
+            .execute()
+        )
+        return response.data[0] if response.data else None
+
+    def delete_insight(self, insight_id: str, user_id: str) -> bool:
+        # Owner check at the SQL level so we don't need to round-trip first.
+        response = (
+            self.supabase.table(self.TABLE)
+            .delete()
+            .eq("id", insight_id)
+            .eq("owner_user_id", user_id)
+            .execute()
+        )
+        return bool(response.data)
+
+    # ----- Scheduler primitives ---------------------------------------
+
+    def find_due_insights(self, *, limit: int = 50) -> List[Dict[str, Any]]:
+        """Return rows whose cadence interval has elapsed since last_run_at.
+
+        Done in Python rather than SQL because Supabase REST doesn't let us
+        compare two intervals against each other inline, and the row count
+        is small (saved insights are deliberately user-scoped).
+        """
+        now = datetime.now(timezone.utc)
+        response = (
+            self.supabase.table(self.TABLE)
+            .select("*")
+            .eq("is_running", False)
+            .limit(500)
+            .execute()
+        )
+        rows = response.data or []
+        due: List[Dict[str, Any]] = []
+        for row in rows:
+            interval = CADENCE_INTERVALS.get(row.get("cadence"))
+            if interval is None:
+                continue
+            last = row.get("last_run_at")
+            if last is None:
+                due.append(row)
+                continue
+            try:
+                last_dt = datetime.fromisoformat(last.replace("Z", "+00:00"))
+            except (TypeError, ValueError):
+                due.append(row)
+                continue
+            if now - last_dt >= interval:
+                due.append(row)
+            if len(due) >= limit:
+                break
+        return due
+
+    def claim_for_refresh(self, insight_id: str) -> bool:
+        """Atomic claim: set is_running=true only if currently false.
+
+        Supabase Python SDK doesn't expose RETURNING for UPDATE ... WHERE
+        easily, so we do the read-then-write with a guard. Race-safe because
+        we filter on `is_running=False` in the WHERE — concurrent claims
+        will both UPDATE but only the row already-flagged-false will match;
+        the loser's UPDATE returns empty data and we know we didn't claim.
+        """
+        response = (
+            self.supabase.table(self.TABLE)
+            .update({"is_running": True})
+            .eq("id", insight_id)
+            .eq("is_running", False)
+            .execute()
+        )
+        return bool(response.data)
+
+    def reset_stale_claims(self, *, grace_minutes: int = 30) -> int:
+        """Clear `is_running` on rows abandoned by a crashed worker.
+
+        Why: `refresh_insight` sets `is_running=true`, runs the chat, then
+        clears it. If the container is SIGKILLed (Coolify redeploy, OOM,
+        watchdog bounce) between those steps the flag stays stuck on the
+        row and the scheduler will skip it forever. We sweep on startup
+        and clear anything claimed longer than the grace window.
+
+        Returns the number of rows reset.
+        """
+        from datetime import datetime, timedelta, timezone
+        cutoff = (datetime.now(timezone.utc) - timedelta(minutes=grace_minutes)).isoformat()
+        response = (
+            self.supabase.table(self.TABLE)
+            .update({
+                "is_running": False,
+                "last_error": "Refresh interrupted by server restart",
+            })
+            .eq("is_running", True)
+            .lt("updated_at", cutoff)
+            .execute()
+        )
+        rows = response.data or []
+        if rows:
+            logger.info("Insight scheduler: reset %d stale claim(s)", len(rows))
+        return len(rows)
+
+    def release_with_result(
+        self,
+        insight_id: str,
+        *,
+        result_text: Optional[str],
+        chat_id: Optional[str],
+        error_text: Optional[str],
+    ) -> None:
+        self.supabase.table(self.TABLE).update(
+            {
+                "is_running": False,
+                "last_run_at": datetime.now(timezone.utc).isoformat(),
+                "last_result": result_text,
+                "last_chat_id": chat_id,
+                "last_error": error_text,
+            }
+        ).eq("id", insight_id).execute()
+
+    # ----- Refresh -----------------------------------------------------
+
+    def refresh_insight(self, insight_id: str) -> Dict[str, Any]:
+        """Re-run the saved prompt as a fresh chat and store the result.
+
+        Caller is expected to have already claimed the row (or be calling
+        for a manual refresh from the UI, which races nothing). Either way
+        we set/clear `is_running` defensively here so a manual refresh
+        also blocks the scheduler from racing it.
+        """
+        # Local imports to avoid a circular import at module load:
+        # chat_service / main_chat_service both pull data_services in.
+        from app.services.data_services import chat_service
+        from app.services.chat_services.main_chat_service import main_chat_service
+
+        # Defensive claim — no-op if already claimed by caller.
+        self.claim_for_refresh(insight_id)
+
+        insight = self.get_insight(insight_id)
+        if not insight:
+            return {"success": False, "error": "Insight not found"}
+
+        project_id = insight["project_id"]
+        prompt = insight["prompt"]
+        chat_id: Optional[str] = None
+
+        try:
+            # Fresh chat per refresh keeps the runs auditable and avoids
+            # any context carry-over from previous turns.
+            chat = chat_service.create_chat(
+                project_id,
+                title=f"Insight refresh: {insight['title'][:50]}",
+            )
+            chat_id = chat["id"]
+
+            result = main_chat_service.send_message(
+                project_id=project_id,
+                chat_id=chat_id,
+                user_message_text=prompt,
+            )
+
+            assistant_text = _extract_assistant_text(result.get("assistant_message"))
+            self.release_with_result(
+                insight_id,
+                result_text=assistant_text,
+                chat_id=chat_id,
+                error_text=None,
+            )
+            return {"success": True, "result": assistant_text, "chat_id": chat_id}
+
+        except Exception as exc:
+            logger.exception("Failed to refresh insight %s: %s", insight_id, exc)
+            self.release_with_result(
+                insight_id,
+                result_text=None,
+                chat_id=chat_id,
+                error_text=str(exc)[:500],
+            )
+            return {"success": False, "error": str(exc)}
+
+
+def _extract_assistant_text(assistant_message: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Pull plain text out of an assistant message regardless of content shape."""
+    if not assistant_message:
+        return None
+    content = assistant_message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text" and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return "\n".join(parts) if parts else None
+    return None
+
+
+insight_service = InsightService()

--- a/backend/app/services/data_services/insight_service.py
+++ b/backend/app/services/data_services/insight_service.py
@@ -111,6 +111,13 @@ class InsightService:
         rows = response.data or []
         due: List[Dict[str, Any]] = []
         for row in rows:
+            # Check the cap first so the limit is enforced uniformly across
+            # every path that might append (null last_run_at, parse error,
+            # interval elapsed). A fresh deployment with hundreds of unrun
+            # insights would otherwise blow past `limit` and saturate the
+            # scheduler's thread pool.
+            if len(due) >= limit:
+                break
             interval = CADENCE_INTERVALS.get(row.get("cadence"))
             if interval is None:
                 continue
@@ -125,8 +132,6 @@ class InsightService:
                 continue
             if now - last_dt >= interval:
                 due.append(row)
-            if len(due) >= limit:
-                break
         return due
 
     def claim_for_refresh(self, insight_id: str) -> bool:
@@ -181,15 +186,26 @@ class InsightService:
         *,
         result_text: Optional[str],
         chat_id: Optional[str],
-        error_text: Optional[str],
     ) -> None:
+        """Stamp a successful refresh result and clear the running flag."""
         self.supabase.table(self.TABLE).update(
             {
                 "is_running": False,
                 "last_run_at": datetime.now(timezone.utc).isoformat(),
                 "last_result": result_text,
                 "last_chat_id": chat_id,
-                "last_error": error_text,
+                "last_error": None,
+            }
+        ).eq("id", insight_id).execute()
+
+    def release_with_error(self, insight_id: str, *, error_text: str) -> None:
+        """Clear the running flag after a failed refresh, leaving last_run_at
+        untouched so the next scheduler tick retries immediately instead of
+        postponing by a full cadence interval."""
+        self.supabase.table(self.TABLE).update(
+            {
+                "is_running": False,
+                "last_error": error_text[:500],
             }
         ).eq("id", insight_id).execute()
 
@@ -198,28 +214,35 @@ class InsightService:
     def refresh_insight(self, insight_id: str) -> Dict[str, Any]:
         """Re-run the saved prompt as a fresh chat and store the result.
 
-        Caller is expected to have already claimed the row (or be calling
-        for a manual refresh from the UI, which races nothing). Either way
-        we set/clear `is_running` defensively here so a manual refresh
-        also blocks the scheduler from racing it.
+        Caller may have already claimed the row (scheduler path) or not
+        (manual /refresh route). Either way the entire body runs under a
+        single try/except so a transient Supabase error before send_message
+        — or any other unexpected failure — can never leave `is_running=true`
+        permanently. On failure we keep `last_run_at` untouched so the next
+        scheduler tick retries on the very next cycle instead of waiting a
+        full cadence interval.
         """
         # Local imports to avoid a circular import at module load:
         # chat_service / main_chat_service both pull data_services in.
         from app.services.data_services import chat_service
         from app.services.chat_services.main_chat_service import main_chat_service
 
-        # Defensive claim — no-op if already claimed by caller.
-        self.claim_for_refresh(insight_id)
-
-        insight = self.get_insight(insight_id)
-        if not insight:
-            return {"success": False, "error": "Insight not found"}
-
-        project_id = insight["project_id"]
-        prompt = insight["prompt"]
         chat_id: Optional[str] = None
-
         try:
+            # Defensive claim — no-op if already claimed by caller.
+            self.claim_for_refresh(insight_id)
+
+            insight = self.get_insight(insight_id)
+            if not insight:
+                # Released via the error helper so the caller still gets a
+                # consistent {success: False, ...} response; if the row is
+                # genuinely missing the UPDATE is just a no-op.
+                self.release_with_error(insight_id, error_text="Insight not found")
+                return {"success": False, "error": "Insight not found"}
+
+            project_id = insight["project_id"]
+            prompt = insight["prompt"]
+
             # Fresh chat per refresh keeps the runs auditable and avoids
             # any context carry-over from previous turns.
             chat = chat_service.create_chat(
@@ -239,18 +262,22 @@ class InsightService:
                 insight_id,
                 result_text=assistant_text,
                 chat_id=chat_id,
-                error_text=None,
             )
             return {"success": True, "result": assistant_text, "chat_id": chat_id}
 
         except Exception as exc:
             logger.exception("Failed to refresh insight %s: %s", insight_id, exc)
-            self.release_with_result(
-                insight_id,
-                result_text=None,
-                chat_id=chat_id,
-                error_text=str(exc)[:500],
-            )
+            try:
+                self.release_with_error(insight_id, error_text=str(exc))
+            except Exception as release_exc:
+                # If even the cleanup write fails the row stays claimed; the
+                # startup reaper will eventually unstick it. Log loudly so
+                # we notice in metrics.
+                logger.exception(
+                    "Failed to release insight %s after error: %s",
+                    insight_id,
+                    release_exc,
+                )
             return {"success": False, "error": str(exc)}
 
 

--- a/backend/supabase/migrations/00038_saved_insights.sql
+++ b/backend/supabase/migrations/00038_saved_insights.sql
@@ -1,0 +1,69 @@
+-- Migration: saved_insights — user-saved chat prompts that re-run on a schedule.
+-- Created: 2026-05-15
+--
+-- Use case: a user asks "how many liquidation cases were rated 1 star and
+-- blamed chart issues?" and wants that answer refreshed weekly. We save the
+-- prompt text and re-send it as a fresh single-turn chat in the same project
+-- on the configured cadence. The latest assistant response is stored on the
+-- row so the Studio's Saved Insights section can show it without replaying
+-- the whole chat.
+--
+-- `is_running` is the dual-purpose claim flag for the scheduler: an UPDATE
+-- ... WHERE id = ? AND NOT is_running atomically claims an insight so two
+-- workers (or two scheduler ticks racing) can't both kick off the same
+-- refresh. The scheduler clears it on completion (success or error).
+
+CREATE TABLE IF NOT EXISTS saved_insights (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id      UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  owner_user_id   UUID NOT NULL,
+  title           TEXT NOT NULL,
+  prompt          TEXT NOT NULL,
+  cadence         TEXT NOT NULL CHECK (cadence IN ('daily', 'weekly')),
+  last_run_at     TIMESTAMPTZ,
+  last_result     TEXT,
+  last_chat_id    UUID,
+  last_error      TEXT,
+  is_running      BOOLEAN NOT NULL DEFAULT false,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS saved_insights_project_id_idx ON saved_insights(project_id);
+CREATE INDEX IF NOT EXISTS saved_insights_owner_idx     ON saved_insights(owner_user_id);
+-- Partial index supports the scheduler's "find due" query cheaply.
+CREATE INDEX IF NOT EXISTS saved_insights_due_idx
+  ON saved_insights(last_run_at)
+  WHERE NOT is_running;
+
+CREATE OR REPLACE FUNCTION saved_insights_touch_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS saved_insights_touch ON saved_insights;
+CREATE TRIGGER saved_insights_touch
+  BEFORE UPDATE ON saved_insights
+  FOR EACH ROW EXECUTE FUNCTION saved_insights_touch_updated_at();
+
+ALTER TABLE saved_insights ENABLE ROW LEVEL SECURITY;
+
+-- Owners read and mutate only their own insights. The backend uses the
+-- service-role JWT for scheduler-driven writes (which bypasses RLS), so
+-- these policies are about hardening direct authenticated access.
+DROP POLICY IF EXISTS "saved_insights_owner_select" ON saved_insights;
+CREATE POLICY "saved_insights_owner_select" ON saved_insights
+  FOR SELECT TO authenticated
+  USING (owner_user_id = auth.uid());
+
+DROP POLICY IF EXISTS "saved_insights_owner_write" ON saved_insights;
+CREATE POLICY "saved_insights_owner_write" ON saved_insights
+  FOR ALL TO authenticated
+  USING (owner_user_id = auth.uid())
+  WITH CHECK (owner_user_id = auth.uid());
+
+COMMENT ON TABLE saved_insights IS
+  'User-saved prompts that auto-refresh on a daily or weekly schedule. The scheduler re-sends the prompt as a single-turn chat in the same project and stores the assistant response in last_result.';

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -28,6 +28,7 @@ import {
 import { copyToClipboard } from '@/lib/clipboard';
 import { createLogger } from '@/lib/logger';
 import { cn } from '@/lib/utils';
+import { SaveAsInsightButton } from './SaveAsInsightButton';
 
 const log = createLogger('chat-messages');
 
@@ -734,27 +735,36 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
       className="absolute inset-0 overflow-y-auto overflow-x-hidden"
     >
       <div className="pt-6 pb-2 px-6 space-y-4 w-full">
-        {messages.filter((msg) => msg && msg.id).map((msg) => (
-          <div key={msg.id}>
-            {msg.role === 'user' ? (
-              <UserMessage content={msg.content} />
-            ) : (
-              // AI messages don't carry image blocks today; coerce to
-              // string so the markdown renderer's prop type stays simple.
-              <AIMessage
-                content={messageContentAsText(msg.content)}
-                projectId={projectId}
-                studioAssetRewriter={studioAssetRewriter}
-              />
-            )}
-            <MessageTimestamp raw={msg.timestamp} align={msg.role === 'user' ? 'right' : 'left'} />
-            {msg.error && (
-              <p className="text-xs text-destructive text-center mt-1">
-                This message had an error
-              </p>
-            )}
-          </div>
-        ))}
+        {messages.filter((msg) => msg && msg.id).map((msg) => {
+          const isUser = msg.role === 'user';
+          const userPromptText = isUser ? messageContentAsText(msg.content) : '';
+          return (
+            <div key={msg.id}>
+              {isUser ? (
+                <UserMessage content={msg.content} />
+              ) : (
+                // AI messages don't carry image blocks today; coerce to
+                // string so the markdown renderer's prop type stays simple.
+                <AIMessage
+                  content={messageContentAsText(msg.content)}
+                  projectId={projectId}
+                  studioAssetRewriter={studioAssetRewriter}
+                />
+              )}
+              {isUser && userPromptText && (
+                <div className="flex justify-end mt-1">
+                  <SaveAsInsightButton projectId={projectId} prompt={userPromptText} />
+                </div>
+              )}
+              <MessageTimestamp raw={msg.timestamp} align={isUser ? 'right' : 'left'} />
+              {msg.error && (
+                <p className="text-xs text-destructive text-center mt-1">
+                  This message had an error
+                </p>
+              )}
+            </div>
+          );
+        })}
 
         {streamingAssistantContent && (
           <AIMessage

--- a/frontend/src/components/chat/SaveAsInsightButton.tsx
+++ b/frontend/src/components/chat/SaveAsInsightButton.tsx
@@ -1,0 +1,158 @@
+/**
+ * SaveAsInsightButton — adds a "Save as recurring insight" affordance to
+ * a user chat message. Clicking opens a dialog where the user names it
+ * and picks a cadence; on save, the prompt text is stored as a
+ * saved_insight and the scheduler refreshes it on the chosen cadence.
+ *
+ * Lives on user messages only (we save the *question* the assistant
+ * answered, not the assistant's answer). The button is a low-key text
+ * affordance to avoid crowding the bubble row.
+ */
+import React, { useState } from 'react';
+import { BookmarkSimple, CircleNotch } from '@phosphor-icons/react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { insightsAPI, type InsightCadence } from '@/lib/api/insights';
+import { useToast } from '@/components/ui/use-toast';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('save-as-insight');
+
+interface Props {
+  projectId: string;
+  prompt: string;
+}
+
+export const SaveAsInsightButton: React.FC<Props> = ({ projectId, prompt }) => {
+  const trimmed = prompt.trim();
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [cadence, setCadence] = useState<InsightCadence>('weekly');
+  const [saving, setSaving] = useState(false);
+  const { success, error } = useToast();
+
+  if (!trimmed) return null;
+
+  const openDialog = () => {
+    // Seed the title from the prompt so the user usually just clicks Save.
+    setTitle(trimmed.slice(0, 60));
+    setCadence('weekly');
+    setOpen(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const created = await insightsAPI.create(projectId, {
+        title: title.trim() || trimmed.slice(0, 60),
+        prompt: trimmed,
+        cadence,
+      });
+      if (created) {
+        success('Saved as a recurring insight');
+        setOpen(false);
+      } else {
+        error('Could not save insight');
+      }
+    } catch (err) {
+      log.error({ err }, 'failed to save insight');
+      error('Could not save insight');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openDialog}
+        title="Save as recurring insight"
+        // Inline text-only affordance keeps the bubble row uncluttered.
+        // Hover reveals a subtle underline to telegraph interactivity.
+        className="inline-flex items-center gap-1 text-[11px] text-muted-foreground/80 hover:text-amber-700 hover:underline"
+      >
+        <BookmarkSimple size={11} weight="bold" />
+        Save as insight
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Save as recurring insight</DialogTitle>
+            <DialogDescription>
+              NoobBook will re-run this prompt on the cadence you pick and
+              keep the latest answer in your Studio panel.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3 py-1">
+            <div className="space-y-1.5">
+              <Label htmlFor="insight-title">Title</Label>
+              <Input
+                id="insight-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Short label for the Studio panel"
+                maxLength={120}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="insight-cadence">Refresh cadence</Label>
+              <Select
+                value={cadence}
+                onValueChange={(v: string) => setCadence(v as InsightCadence)}
+              >
+                <SelectTrigger id="insight-cadence">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="daily">Daily</SelectItem>
+                  <SelectItem value="weekly">Weekly</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Prompt</Label>
+              <p className="rounded-md border border-stone-200 bg-stone-50 px-3 py-2 text-xs text-stone-700 whitespace-pre-wrap max-h-32 overflow-y-auto">
+                {trimmed}
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? (
+                <>
+                  <CircleNotch size={14} className="mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                'Save'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/frontend/src/components/studio/sections/SavedInsightsSection.tsx
+++ b/frontend/src/components/studio/sections/SavedInsightsSection.tsx
@@ -1,0 +1,235 @@
+/**
+ * SavedInsightsSection — auto-refreshing chat prompts in the Studio panel.
+ *
+ * A saved insight is a user prompt that the backend re-runs daily or
+ * weekly. This section lists them with their latest result and lets the
+ * user trigger a manual refresh or delete one. Creation happens from the
+ * chat surface (the "Save as insight" button on user messages); this
+ * section is read-and-manage only.
+ *
+ * Hidden when there are no saved insights so we don't add empty noise
+ * to the Studio panel.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ArrowsClockwise,
+  CircleNotch,
+  Lightbulb,
+  Trash,
+  Warning,
+} from '@phosphor-icons/react';
+import { useStudioContext } from '../studio-hooks';
+import {
+  insightsAPI,
+  type SavedInsight,
+  type InsightCadence,
+} from '@/lib/api/insights';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useToast } from '@/components/ui/use-toast';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('saved-insights-section');
+
+const POLL_INTERVAL_MS = 15_000;
+
+const cadenceLabel = (c: InsightCadence) => (c === 'daily' ? 'Daily' : 'Weekly');
+
+const formatLastRun = (iso: string | null): string => {
+  if (!iso) return 'Not run yet';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'Not run yet';
+  const diffMs = Date.now() - d.getTime();
+  const mins = Math.round(diffMs / 60_000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+};
+
+export const SavedInsightsSection: React.FC = () => {
+  const { projectId } = useStudioContext();
+  const { success, error } = useToast();
+
+  const [insights, setInsights] = useState<SavedInsight[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<SavedInsight | null>(null);
+
+  const loadInsights = useCallback(async () => {
+    try {
+      const rows = await insightsAPI.list(projectId);
+      setInsights(rows);
+    } catch (err) {
+      log.error({ err }, 'failed to load insights');
+    } finally {
+      setLoaded(true);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    loadInsights();
+  }, [loadInsights]);
+
+  // Poll while any insight is currently running so the user sees the new
+  // result land without a manual reload. Stops when no row is running.
+  useEffect(() => {
+    if (!insights.some((i) => i.is_running)) return;
+    const interval = setInterval(loadInsights, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [insights, loadInsights]);
+
+  const handleRefresh = useCallback(
+    async (insight: SavedInsight) => {
+      const ok = await insightsAPI.refresh(projectId, insight.id);
+      if (ok) {
+        // Optimistically flip is_running so the spinner shows; the next
+        // poll picks up the canonical state from the backend.
+        setInsights((prev) =>
+          prev.map((row) => (row.id === insight.id ? { ...row, is_running: true } : row)),
+        );
+        success('Refresh started');
+      } else {
+        error('Could not start refresh');
+      }
+    },
+    [projectId, success, error],
+  );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!pendingDelete) return;
+    const insight = pendingDelete;
+    setPendingDelete(null);
+    const ok = await insightsAPI.remove(projectId, insight.id);
+    if (ok) {
+      setInsights((prev) => prev.filter((row) => row.id !== insight.id));
+      success('Insight deleted');
+    } else {
+      error('Could not delete insight');
+    }
+  }, [pendingDelete, projectId, success, error]);
+
+  if (!loaded || insights.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center gap-2 px-1">
+        <Lightbulb size={16} weight="bold" className="text-amber-600" />
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-stone-700">
+          Saved Insights
+        </h3>
+      </div>
+
+      <div className="space-y-2">
+        {insights.map((insight) => {
+          const isExpanded = expandedId === insight.id;
+          return (
+            <div
+              key={insight.id}
+              className="rounded-lg border border-stone-200 bg-white p-3 text-sm"
+            >
+              <div className="flex items-start gap-2">
+                <button
+                  type="button"
+                  onClick={() => setExpandedId(isExpanded ? null : insight.id)}
+                  className="flex-1 min-w-0 text-left"
+                >
+                  <div className="font-medium text-stone-800 truncate">
+                    {insight.title}
+                  </div>
+                  <div className="mt-0.5 text-xs text-muted-foreground">
+                    {cadenceLabel(insight.cadence)} · {formatLastRun(insight.last_run_at)}
+                    {insight.last_error && (
+                      <span className="ml-2 inline-flex items-center gap-1 text-destructive">
+                        <Warning size={12} weight="bold" />
+                        last refresh failed
+                      </span>
+                    )}
+                  </div>
+                </button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleRefresh(insight)}
+                  disabled={insight.is_running}
+                  title="Refresh now"
+                  className="h-7 w-7 p-0"
+                >
+                  {insight.is_running ? (
+                    <CircleNotch size={14} className="animate-spin" />
+                  ) : (
+                    <ArrowsClockwise size={14} />
+                  )}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setPendingDelete(insight)}
+                  title="Delete insight"
+                  className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                >
+                  <Trash size={14} />
+                </Button>
+              </div>
+
+              {isExpanded && (
+                <div className="mt-3 space-y-2 border-t border-stone-100 pt-2">
+                  <div>
+                    <div className="text-xs font-medium text-stone-500">Prompt</div>
+                    <p className="mt-0.5 text-xs text-stone-700 whitespace-pre-wrap">
+                      {insight.prompt}
+                    </p>
+                  </div>
+                  <div>
+                    <div className="text-xs font-medium text-stone-500">
+                      {insight.last_error ? 'Last error' : 'Last result'}
+                    </div>
+                    <p className="mt-0.5 text-xs text-stone-700 whitespace-pre-wrap">
+                      {insight.last_error
+                        ? insight.last_error
+                        : insight.last_result || 'No result yet — refresh to populate.'}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <AlertDialog open={!!pendingDelete} onOpenChange={(open) => !open && setPendingDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete saved insight?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This stops the scheduled refresh and removes the stored result.
+              The chats that were already run stay intact.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  );
+};

--- a/frontend/src/components/studio/sections/StudioSections.tsx
+++ b/frontend/src/components/studio/sections/StudioSections.tsx
@@ -26,10 +26,14 @@ import { PRDSection } from './PRDSection';
 import { MarketingStrategySection } from './MarketingStrategySection';
 import { BlogSection } from './BlogSection';
 import { BusinessReportSection } from './BusinessReportSection';
+import { SavedInsightsSection } from './SavedInsightsSection';
 
 export const StudioSections: React.FC = () => {
   return (
     <>
+      {/* Auto-refreshing saved chat prompts — shows only when present */}
+      <SavedInsightsSection />
+
       {/* Learning Sections */}
       <AudioSection />
       <QuizSection />

--- a/frontend/src/lib/api/insights.ts
+++ b/frontend/src/lib/api/insights.ts
@@ -1,0 +1,87 @@
+/**
+ * Saved Insights API client.
+ *
+ * Saved insights are chat prompts the user marks to auto-refresh on a
+ * daily or weekly cadence. The backend scheduler re-runs them; this
+ * client surfaces list/create/delete/refresh for the Studio panel UI.
+ */
+import axios from 'axios';
+import { API_BASE_URL } from './client';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('insights-api');
+
+export type InsightCadence = 'daily' | 'weekly';
+
+export interface SavedInsight {
+  id: string;
+  project_id: string;
+  owner_user_id: string;
+  title: string;
+  prompt: string;
+  cadence: InsightCadence;
+  last_run_at: string | null;
+  last_result: string | null;
+  last_chat_id: string | null;
+  last_error: string | null;
+  is_running: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateInsightInput {
+  title?: string;
+  prompt: string;
+  cadence: InsightCadence;
+}
+
+export const insightsAPI = {
+  async list(projectId: string): Promise<SavedInsight[]> {
+    try {
+      const { data } = await axios.get(`${API_BASE_URL}/projects/${projectId}/insights`);
+      return data?.insights ?? [];
+    } catch (err) {
+      log.error({ err }, 'failed to list insights');
+      return [];
+    }
+  },
+
+  async create(projectId: string, input: CreateInsightInput): Promise<SavedInsight | null> {
+    try {
+      const { data } = await axios.post(
+        `${API_BASE_URL}/projects/${projectId}/insights`,
+        input,
+      );
+      return data?.insight ?? null;
+    } catch (err) {
+      log.error({ err }, 'failed to create insight');
+      throw err;
+    }
+  },
+
+  async remove(projectId: string, insightId: string): Promise<boolean> {
+    try {
+      await axios.delete(`${API_BASE_URL}/projects/${projectId}/insights/${insightId}`);
+      return true;
+    } catch (err) {
+      log.error({ err }, 'failed to delete insight');
+      return false;
+    }
+  },
+
+  /**
+   * Kick a manual refresh. Returns immediately (202); poll list() for the
+   * updated row to see the new result land.
+   */
+  async refresh(projectId: string, insightId: string): Promise<boolean> {
+    try {
+      await axios.post(
+        `${API_BASE_URL}/projects/${projectId}/insights/${insightId}/refresh`,
+      );
+      return true;
+    } catch (err) {
+      log.error({ err }, 'failed to refresh insight');
+      return false;
+    }
+  },
+};


### PR DESCRIPTION
Ships Sno 30: users can save a chat prompt as a recurring insight that the backend re-runs on a daily or weekly cadence. Closes #243.

## How it works

1. **Save**: a small "Save as insight" button under every user message in chat opens a dialog (title + daily/weekly cadence). The user's question is stored as a `saved_insight` row.
2. **Refresh**: a daemon thread in the backend wakes every 5 minutes, finds rows where the cadence interval has elapsed, and re-runs the saved prompt in a fresh single-turn chat in the same project. The assistant's final text is stored on the insight row.
3. **View**: a new "Saved Insights" section at the top of the Studio panel lists every insight with its latest result, cadence, last-run age, and manual refresh / delete actions. Section is hidden when there are no saved insights.

## Crash safety

The refresh path uses a two-step claim (`UPDATE ... WHERE NOT is_running`) so the scheduler and a manual refresh can't race the same row. On scheduler startup, any `is_running=true` rows older than 30 minutes are reset back to `false` with `last_error = "Refresh interrupted by server restart"` — this means a Coolify redeploy mid-refresh leaves the next tick clean instead of silently skipping the row forever.

## Files

**Backend**
- `00038_saved_insights.sql` — new table with owner-scoped RLS, due-row partial index, updated_at trigger
- `insight_service.py` — CRUD + atomic claim/release + stale-claim reaper + refresh that spawns a fresh chat
- `insight_scheduler.py` — daemon thread, 5-min tick, ThreadPool for concurrent refreshes, startup reaper
- `api/insights/{__init__,routes}.py` — GET list, POST create, DELETE, POST refresh (queued)
- `app/__init__.py` — boots the scheduler at app init
- `app/api/__init__.py` — registers the blueprint

**Frontend**
- `lib/api/insights.ts` — typed client
- `studio/sections/SavedInsightsSection.tsx` — list/refresh/delete with expand-for-details and auto-poll while running
- `studio/sections/StudioSections.tsx` — slot at top
- `chat/SaveAsInsightButton.tsx` — dialog for save flow
- `chat/ChatMessages.tsx` — renders the button under user messages

## Test plan

- [ ] Migration `00038_saved_insights.sql` applies cleanly on prod
- [ ] Send a chat message, click "Save as insight" → dialog opens with the prompt prefilled → save with weekly cadence
- [ ] Open Studio panel: new "Saved Insights" section appears with the insight
- [ ] Click the refresh icon: spinner shows, then the latest result populates within a minute
- [ ] Expand the row: prompt + last result both visible
- [ ] Delete: row disappears, section hides if list is empty
- [ ] Restart the backend container mid-refresh (or simulate): on next scheduler tick (~5 min after restart) the stuck row is reset and re-runs cleanly