### PR TITLE
Release: develop → main (auth client isolation + insight bg user + timestamp spacing)

### DIFF
--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -921,13 +921,22 @@ class MainChatService:
         project_id: str,
         chat_id: str,
         user_message_text: UserMessagePayload,
+        *,
+        user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Process a user message and return saved messages plus sync metadata."""
+        """Process a user message and return saved messages plus sync metadata.
+
+        `user_id` is required when calling from background contexts (e.g.
+        the saved-insight scheduler) where `has_request_context()` is
+        False and the fallback to DEFAULT_USER_ID would otherwise produce
+        a bogus UUID that fails the brand_config FK constraint.
+        """
         return self._run_message_flow(
             project_id=project_id,
             chat_id=chat_id,
             user_message_text=user_message_text,
             stream_text=False,
+            user_id=user_id,
         )
 
     def stream_message(

--- a/backend/app/services/data_services/insight_service.py
+++ b/backend/app/services/data_services/insight_service.py
@@ -251,10 +251,17 @@ class InsightService:
             )
             chat_id = chat["id"]
 
+            # Background refresh runs outside any HTTP request context, so
+            # main_chat_service can't resolve the active user from the
+            # request and would otherwise fall back to DEFAULT_USER_ID —
+            # which fails the brand_config FK and breaks the chat flow.
+            # Pass the saved owner explicitly so brand context, memory,
+            # and cost tracking all attribute to the right user.
             result = main_chat_service.send_message(
                 project_id=project_id,
                 chat_id=chat_id,
                 user_message_text=prompt,
+                user_id=insight["owner_user_id"],
             )
 
             assistant_text = _extract_assistant_text(result.get("assistant_message"))

--- a/backend/app/services/integrations/supabase/auth_service.py
+++ b/backend/app/services/integrations/supabase/auth_service.py
@@ -24,8 +24,19 @@ class AuthService:
     """
 
     def __init__(self):
-        """Initialize the auth service with Supabase client."""
-        self.supabase: Client = get_supabase()
+        """Initialize the auth service with a DEDICATED Supabase client.
+
+        We must NOT share the data-path singleton here. supabase-py stores
+        the auth session on the client object, so calling
+        `sign_in_with_password()` flips its identity to the user's JWT and
+        every subsequent `.table()` / `.rpc()` call from that client sends
+        the user's bearer token instead of the service key. When the
+        singleton was shared, a sign-in silently downgraded backend role
+        from `service_role` to `authenticated`, breaking RPCs that PR #266
+        revoked from `authenticated` (notably `exec_freshdesk_query`).
+        """
+        from app.services.integrations.supabase.supabase_client import create_dedicated_client
+        self.supabase: Client = create_dedicated_client()
 
     def sign_up(self, email: str, password: str) -> Dict[str, Any]:
         """

--- a/backend/app/services/integrations/supabase/supabase_client.py
+++ b/backend/app/services/integrations/supabase/supabase_client.py
@@ -127,6 +127,34 @@ def get_supabase() -> Client:
     return SupabaseClient.get_client()
 
 
+def create_dedicated_client() -> Client:
+    """Create a fresh, non-shared Supabase Client.
+
+    Why: supabase-py stores the auth session ON the client object. Calling
+    `client.auth.sign_in_with_password(...)` flips that client's identity
+    to the just-signed-in user's JWT, and every subsequent `.table()` /
+    `.rpc()` call from THAT client now sends the user's JWT instead of
+    the service key. If `auth_service` shared the data singleton (it did
+    until 2026-05-16), a single sign-in would silently downgrade the
+    backend's role from `service_role` to `authenticated` — producing
+    permission errors on RLS-gated tables and RPCs that only service_role
+    is allowed to hit (e.g. `exec_freshdesk_query` after PR #266's
+    REVOKE).
+
+    Auth flows hold their own dedicated instance so this pollution stays
+    contained. Data calls keep using `get_supabase()` and the singleton's
+    identity stays as service_role.
+
+    Returns a NEW client every call; caller is expected to hold the
+    reference.
+    """
+    supabase_url = os.getenv("SUPABASE_URL")
+    supabase_key = os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_ANON_KEY")
+    if not supabase_url or not supabase_key:
+        raise ValueError("SUPABASE_URL and SUPABASE_SERVICE_KEY (or ANON_KEY) must be set")
+    return create_client(supabase_url, supabase_key)
+
+
 def is_supabase_enabled() -> bool:
     """
     Check if Supabase integration is enabled.

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -64,14 +64,17 @@ const formatMessageTime = (raw?: string): string => {
 const MessageTimestamp: React.FC<{ raw?: string; align: 'left' | 'right' }> = ({ raw, align }) => {
   const formatted = formatMessageTime(raw);
   if (!formatted) return null;
+  // Left-aligned (AI) timestamps need a left-pad equal to the Ghost
+  // avatar width + the flex gap inside AIMessage so the timestamp sits
+  // under the bubble rather than orphaned at the far-left under the
+  // avatar. Right-aligned (user) timestamps already line up with the
+  // bubble's right edge because the user bubble itself is right-aligned.
   return (
     <p
       className={cn(
-        'mt-1 text-[11px] text-muted-foreground/80 select-none',
-        align === 'right' ? 'text-right' : 'text-left'
+        'mt-0.5 text-[11px] text-muted-foreground/80 select-none leading-snug',
+        align === 'right' ? 'text-right' : 'text-left pl-10'
       )}
-      // Surface full ISO on hover so users can copy exact time if needed —
-      // the visible form is intentionally short to keep the chat tidy.
       title={raw}
     >
       {formatted}


### PR DESCRIPTION
## Summary

- **`2c96558` auth client isolation** — `auth_service` now holds a dedicated Supabase client so `sign_in_with_password` can't pollute the data-path singleton's identity. Fixes the `permission denied for function exec_freshdesk_query` regression (singleton was getting downgraded from `service_role` to `authenticated`, and PR #266 had revoked `authenticated` from that function).
- **`6340fe6` insight bg user_id** — background insight refreshes pass the saved `owner_user_id` into `send_message` so the chat flow attributes correctly to the right user instead of falling back to `DEFAULT_USER_ID` and crashing the `brand_config` FK.
- **`35365ca` chat timestamp spacing** — AI-side timestamps now sit under the bubble (indented past the avatar) and the vertical gap is tightened on both sides.

## Test plan

- [ ] Send a Freshdesk question in chat — backend should return real ticket counts, not `permission denied`
- [ ] Save an insight, click Refresh, wait ~30-60s — `last_result` populates, no FK constraint error
- [ ] Open chat with messages — AI timestamps align under the bubble, not the avatar