### PR TITLE
Release: develop → main (same-chat insights + library-card UI)

### DIFF
--- a/backend/app/api/insights/routes.py
+++ b/backend/app/api/insights/routes.py
@@ -68,6 +68,7 @@ def create_insight(project_id: str):
     prompt = (data.get("prompt") or "").strip()
     cadence = (data.get("cadence") or "weekly").strip()
     title = (data.get("title") or prompt[:60]).strip()
+    chat_id = (data.get("chat_id") or None) or None
     if not prompt:
         return jsonify({"success": False, "error": "Prompt is required"}), 400
     if cadence not in ("daily", "weekly"):
@@ -79,6 +80,7 @@ def create_insight(project_id: str):
             title=title,
             prompt=prompt,
             cadence=cadence,
+            chat_id=chat_id,
         )
         return jsonify({"success": True, "insight": insight}), 201
     except Exception as exc:

--- a/backend/app/services/data_services/insight_service.py
+++ b/backend/app/services/data_services/insight_service.py
@@ -55,16 +55,22 @@ class InsightService:
         title: str,
         prompt: str,
         cadence: str,
+        chat_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         if cadence not in CADENCE_INTERVALS:
             raise ValueError(f"Invalid cadence {cadence!r}; expected 'daily' or 'weekly'")
-        row = {
+        row: Dict[str, Any] = {
             "project_id": project_id,
             "owner_user_id": owner_user_id,
             "title": title.strip() or prompt[:60].strip(),
             "prompt": prompt.strip(),
             "cadence": cadence,
         }
+        # chat_id is optional — created insights from a live chat carry it
+        # so refresh writes additional turns into that same chat. Legacy
+        # rows (no chat_id) get one lazily on first refresh.
+        if chat_id:
+            row["chat_id"] = chat_id
         response = self.supabase.table(self.TABLE).insert(row).execute()
         if not response.data:
             raise RuntimeError("Failed to create saved insight")
@@ -243,13 +249,29 @@ class InsightService:
             project_id = insight["project_id"]
             prompt = insight["prompt"]
 
-            # Fresh chat per refresh keeps the runs auditable and avoids
-            # any context carry-over from previous turns.
-            chat = chat_service.create_chat(
-                project_id,
-                title=f"Insight refresh: {insight['title'][:50]}",
-            )
-            chat_id = chat["id"]
+            # Reuse the insight's persistent chat so every refresh
+            # appends a turn to the same conversation — users get a
+            # natural visual history of how the answer evolves over
+            # weeks. Lazy-create on the first refresh of legacy rows
+            # (rows created before chat_id existed) and persist the
+            # new chat_id back so future refreshes follow suit.
+            chat_id = insight.get("chat_id")
+            if chat_id:
+                chat = chat_service.get_chat(project_id, chat_id)
+                if not chat:
+                    # The source chat was deleted; bootstrap a new one
+                    # and adopt it. Saving the result of one orphaned
+                    # refresh is better than failing the insight forever.
+                    chat_id = None
+            if not chat_id:
+                chat = chat_service.create_chat(
+                    project_id,
+                    title=insight["title"][:50] or "Saved insight",
+                )
+                chat_id = chat["id"]
+                self.supabase.table(self.TABLE).update({"chat_id": chat_id}).eq(
+                    "id", insight_id
+                ).execute()
 
             # Background refresh runs outside any HTTP request context, so
             # main_chat_service can't resolve the active user from the

--- a/backend/supabase/migrations/00039_saved_insights_chat_id.sql
+++ b/backend/supabase/migrations/00039_saved_insights_chat_id.sql
@@ -1,0 +1,21 @@
+-- Migration: add chat_id to saved_insights for same-chat refresh.
+-- Created: 2026-05-16
+--
+-- Until now every refresh spawned a fresh chat which produced a noisy
+-- chat list and lost the visual history of how an answer evolved.
+-- Switching to a stable chat per insight means each refresh appends a
+-- new turn to the same conversation; users can scroll to see the same
+-- question answered over weeks. The column is nullable so legacy rows
+-- created before this migration keep working — refresh falls back to
+-- creating a chat the first time it runs and persists that chat_id
+-- onto the row.
+
+ALTER TABLE saved_insights
+  ADD COLUMN IF NOT EXISTS chat_id UUID;
+
+CREATE INDEX IF NOT EXISTS saved_insights_chat_id_idx
+  ON saved_insights(chat_id)
+  WHERE chat_id IS NOT NULL;
+
+COMMENT ON COLUMN saved_insights.chat_id IS
+  'Chat this insight refreshes into. NULL means refresh will lazily create one and write it back here.';

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -86,6 +86,11 @@ interface ChatMessagesProps {
   messages: Message[];
   sending: boolean;
   projectId: string;
+  /**
+   * Active chat id — passed into `SaveAsInsightButton` so an insight
+   * saved from a chat refreshes into THIS chat, not a fresh one.
+   */
+  chatId?: string | null;
   streamingAssistantContent?: string;
   /**
    * Live progress message emitted by the running tool (e.g. the
@@ -661,6 +666,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
   messages,
   sending,
   projectId,
+  chatId,
   streamingAssistantContent = '',
   toolProgress,
   readOnly: _readOnly,
@@ -756,7 +762,11 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
               )}
               {isUser && userPromptText && (
                 <div className="flex justify-end mt-1">
-                  <SaveAsInsightButton projectId={projectId} prompt={userPromptText} />
+                  <SaveAsInsightButton
+                    projectId={projectId}
+                    chatId={chatId ?? null}
+                    prompt={userPromptText}
+                  />
                 </div>
               )}
               <MessageTimestamp raw={msg.timestamp} align={isUser ? 'right' : 'left'} />

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1155,6 +1155,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           messages={activeChat?.messages || []}
           sending={sending}
           projectId={projectId}
+          chatId={activeChat?.id ?? null}
           streamingAssistantContent={streamingAssistantContent}
           toolProgress={toolProgress}
         />

--- a/frontend/src/components/chat/SaveAsInsightButton.tsx
+++ b/frontend/src/components/chat/SaveAsInsightButton.tsx
@@ -36,10 +36,12 @@ const log = createLogger('save-as-insight');
 
 interface Props {
   projectId: string;
+  /** Chat this prompt came from; refreshes will append into this same chat. */
+  chatId: string | null;
   prompt: string;
 }
 
-export const SaveAsInsightButton: React.FC<Props> = ({ projectId, prompt }) => {
+export const SaveAsInsightButton: React.FC<Props> = ({ projectId, chatId, prompt }) => {
   const trimmed = prompt.trim();
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState('');
@@ -63,6 +65,7 @@ export const SaveAsInsightButton: React.FC<Props> = ({ projectId, prompt }) => {
         title: title.trim() || trimmed.slice(0, 60),
         prompt: trimmed,
         cadence,
+        chat_id: chatId,
       });
       if (created) {
         success('Saved as a recurring insight');

--- a/frontend/src/components/project/ProjectWorkspace.tsx
+++ b/frontend/src/components/project/ProjectWorkspace.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Button } from '../ui/button';
 import { SourcesPanel } from '../sources';
 import { ChatPanel } from '../chat';
@@ -111,6 +111,18 @@ export const ProjectWorkspace: React.FC<ProjectWorkspaceProps> = ({
     // Reset after a tick so clicking "Open" on the same chat again works
     setTimeout(() => setOpenChatId(null), 100);
   }, []);
+
+  // Cross-panel hook: any descendant (e.g. SavedInsightsSection in the
+  // Studio panel) can fire `noobbook:chat:open` to switch the chat panel
+  // to a specific chat. Keeps the studio decoupled from ProjectWorkspace.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ chatId?: string }>).detail;
+      if (detail?.chatId) handleOpenChat(detail.chatId);
+    };
+    window.addEventListener('noobbook:chat:open', handler);
+    return () => window.removeEventListener('noobbook:chat:open', handler);
+  }, [handleOpenChat]);
 
   return (
     <div className="h-screen flex flex-col bg-background">

--- a/frontend/src/components/studio/savedInsights/InsightCard.tsx
+++ b/frontend/src/components/studio/savedInsights/InsightCard.tsx
@@ -1,0 +1,168 @@
+/**
+ * InsightCard — compact, editorial library-card row for one saved insight.
+ *
+ * Design notes:
+ * - 3px amber-600 left bar accents the "this is a clipping" mental model
+ * - Serif italic title matches the existing "Jump to latest" pill voice
+ * - Status dot is pre-attentive: emerald (fresh), stone (never run), rose (failed)
+ * - Hover surfaces the inline icon row to keep the resting state quiet
+ * - Whole card is the click target for the detail sheet; the small arrow
+ *   button in the bottom-right is a separate target that jumps directly
+ *   to the source chat for users who want full history instead of a peek.
+ */
+import React from 'react';
+import { ArrowsClockwise, ArrowUpRight, CircleNotch, Trash, Warning } from '@phosphor-icons/react';
+import { cn } from '@/lib/utils';
+import type { SavedInsight } from '@/lib/api/insights';
+
+const cadenceLabel = (c: SavedInsight['cadence']) => (c === 'daily' ? 'Daily' : 'Weekly');
+
+const formatLastRun = (iso: string | null): string => {
+  if (!iso) return 'Never run';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'Never run';
+  const diffMs = Date.now() - d.getTime();
+  const mins = Math.round(diffMs / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+};
+
+type Status = 'fresh' | 'never' | 'failed';
+
+const statusOf = (i: SavedInsight): Status => {
+  if (i.last_error) return 'failed';
+  if (!i.last_run_at) return 'never';
+  return 'fresh';
+};
+
+const statusDotClass: Record<Status, string> = {
+  fresh: 'bg-emerald-500',
+  never: 'bg-stone-300',
+  failed: 'bg-rose-500',
+};
+
+interface Props {
+  insight: SavedInsight;
+  onOpen: (insight: SavedInsight) => void;
+  onRefresh: (insight: SavedInsight) => void;
+  onDelete: (insight: SavedInsight) => void;
+  onJumpToChat: (insight: SavedInsight) => void;
+}
+
+export const InsightCard: React.FC<Props> = ({
+  insight,
+  onOpen,
+  onRefresh,
+  onDelete,
+  onJumpToChat,
+}) => {
+  const status = statusOf(insight);
+  const running = insight.is_running;
+
+  const stop = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(insight)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen(insight);
+        }
+      }}
+      className={cn(
+        'group relative overflow-hidden rounded-lg border border-stone-200 bg-white pl-4 pr-3 py-3',
+        'transition-all duration-150',
+        'hover:border-stone-300 hover:shadow-[0_2px_8px_-2px_rgba(120,113,108,0.12)] hover:-translate-y-px',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1',
+        'cursor-pointer',
+      )}
+    >
+      {/* amber accent bar */}
+      <span
+        aria-hidden
+        className="absolute left-0 top-0 bottom-0 w-[3px] bg-amber-600"
+      />
+
+      <div className="flex items-start gap-2">
+        <div className="flex-1 min-w-0">
+          <p className="font-serif italic text-[15px] leading-snug text-stone-800 line-clamp-2">
+            {insight.title}
+          </p>
+          <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
+            <span
+              aria-hidden
+              className={cn('inline-block h-1.5 w-1.5 rounded-full', statusDotClass[status])}
+            />
+            <span className="inline-flex items-center rounded-full bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700">
+              {cadenceLabel(insight.cadence)}
+            </span>
+            <span className="text-[11px] text-stone-500">
+              {running ? 'refreshing…' : formatLastRun(insight.last_run_at)}
+            </span>
+            {status === 'failed' && !running && (
+              <span className="inline-flex items-center gap-0.5 text-[10px] text-rose-600">
+                <Warning size={10} weight="bold" />
+                failed
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Hover-revealed action row — keeps resting state tidy */}
+        <div className="flex-shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+          <button
+            type="button"
+            onClick={(e) => {
+              stop(e);
+              onRefresh(insight);
+            }}
+            disabled={running}
+            title="Refresh now"
+            aria-label="Refresh insight"
+            className="p-1 rounded text-stone-500 hover:text-amber-700 hover:bg-amber-50 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {running ? (
+              <CircleNotch size={13} className="animate-spin" />
+            ) : (
+              <ArrowsClockwise size={13} weight="bold" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              stop(e);
+              onJumpToChat(insight);
+            }}
+            disabled={!insight.chat_id}
+            title="Open the chat"
+            aria-label="Open source chat"
+            className="p-1 rounded text-stone-500 hover:text-amber-700 hover:bg-amber-50 disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <ArrowUpRight size={13} weight="bold" />
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              stop(e);
+              onDelete(insight);
+            }}
+            title="Delete insight"
+            aria-label="Delete insight"
+            className="p-1 rounded text-stone-500 hover:text-rose-600 hover:bg-rose-50"
+          >
+            <Trash size={13} weight="bold" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/studio/savedInsights/InsightDetailSheet.tsx
+++ b/frontend/src/components/studio/savedInsights/InsightDetailSheet.tsx
@@ -1,0 +1,169 @@
+/**
+ * InsightDetailSheet — right-side reading surface for one saved insight.
+ *
+ * Why a Sheet (not inline expand or modal):
+ * - The Studio panel is ~25vw, way too narrow to render rich markdown.
+ *   The sheet opens at ~480px and overlays the chat, giving the result
+ *   real reading width while keeping the chat one click away.
+ * - Modals trap attention; sheets feel like a peek you can dismiss
+ *   with one esc/click. Matches the cozy editorial vibe of the rest of
+ *   the app — like flipping over a library card to read the back.
+ */
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  ArrowsClockwise,
+  ArrowUpRight,
+  CircleNotch,
+  Warning,
+} from '@phosphor-icons/react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import type { SavedInsight } from '@/lib/api/insights';
+
+const cadenceLabel = (c: SavedInsight['cadence']) => (c === 'daily' ? 'Daily' : 'Weekly');
+
+const formatLastRun = (iso: string | null): string => {
+  if (!iso) return 'Never run';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'Never run';
+  const diffMs = Date.now() - d.getTime();
+  const mins = Math.round(diffMs / 60_000);
+  if (mins < 1) return 'refreshed just now';
+  if (mins < 60) return `refreshed ${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `refreshed ${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `refreshed ${days}d ago`;
+};
+
+interface Props {
+  insight: SavedInsight | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRefresh: (insight: SavedInsight) => void;
+  onJumpToChat: (insight: SavedInsight) => void;
+}
+
+export const InsightDetailSheet: React.FC<Props> = ({
+  insight,
+  open,
+  onOpenChange,
+  onRefresh,
+  onJumpToChat,
+}) => {
+  if (!insight) return null;
+
+  const running = insight.is_running;
+  const hasResult = !!(insight.last_result && insight.last_result.trim());
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        // Override shadcn's default sm:max-w-sm (384px) — the editorial
+        // markdown needs more reading width to breathe.
+        className="w-full sm:max-w-[520px] p-0 bg-[#fcfaf6] flex flex-col"
+      >
+        {/* Header — masthead-style with serif title and meta */}
+        <SheetHeader className="px-6 pt-6 pb-4 space-y-3 border-b border-stone-200/70">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-amber-700 font-semibold">
+            ━━ Insight
+          </p>
+          <SheetTitle className="font-serif italic text-2xl leading-tight text-stone-900 text-left">
+            {insight.title}
+          </SheetTitle>
+          <SheetDescription className="text-xs text-stone-500 text-left">
+            <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700 mr-2">
+              {cadenceLabel(insight.cadence)}
+            </span>
+            {running ? 'refreshing now…' : formatLastRun(insight.last_run_at)}
+          </SheetDescription>
+
+          <div className="flex items-center gap-2 pt-1">
+            <Button
+              size="sm"
+              onClick={() => onRefresh(insight)}
+              disabled={running}
+              className="bg-amber-600 hover:bg-amber-700 text-white"
+            >
+              {running ? (
+                <>
+                  <CircleNotch size={14} className="mr-1.5 animate-spin" />
+                  Refreshing
+                </>
+              ) : (
+                <>
+                  <ArrowsClockwise size={14} weight="bold" className="mr-1.5" />
+                  Refresh now
+                </>
+              )}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onJumpToChat(insight)}
+              disabled={!insight.chat_id}
+              title={insight.chat_id ? 'Open the source chat' : 'No chat linked yet'}
+            >
+              <ArrowUpRight size={14} weight="bold" className="mr-1.5" />
+              Open the chat
+            </Button>
+          </div>
+        </SheetHeader>
+
+        {/* Body — prompt + result with proper markdown rendering */}
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          {/* Prompt block — set off as a quote so the question reads */}
+          {/* like an editor's note before the article. */}
+          <section>
+            <p className="text-[10px] uppercase tracking-[0.16em] text-stone-500 font-medium mb-1.5">
+              Prompt
+            </p>
+            <blockquote className="border-l-2 border-amber-300 pl-3 py-1 text-sm italic text-stone-700 whitespace-pre-wrap">
+              {insight.prompt}
+            </blockquote>
+          </section>
+
+          {insight.last_error && (
+            <section className="rounded-md bg-rose-50 border border-rose-200 px-3 py-2.5">
+              <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-rose-700">
+                <Warning size={12} weight="bold" />
+                Last refresh failed
+              </div>
+              <p className="mt-1 text-xs text-rose-800 whitespace-pre-wrap">
+                {insight.last_error}
+              </p>
+            </section>
+          )}
+
+          <section>
+            <p className="text-[10px] uppercase tracking-[0.16em] text-stone-500 font-medium mb-2">
+              {hasResult ? 'Latest answer' : 'No answer yet'}
+            </p>
+            {hasResult ? (
+              <div className="prose prose-sm prose-stone max-w-none prose-headings:font-serif prose-headings:italic prose-pre:bg-stone-900 prose-pre:text-stone-100">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {insight.last_result ?? ''}
+                </ReactMarkdown>
+              </div>
+            ) : (
+              <p className="text-sm text-stone-500 italic">
+                Hit <span className="font-medium text-amber-700">Refresh now</span> to fetch the
+                first answer. The scheduler will keep it updated on its{' '}
+                {cadenceLabel(insight.cadence).toLowerCase()} cadence after that.
+              </p>
+            )}
+          </section>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/frontend/src/components/studio/sections/SavedInsightsSection.tsx
+++ b/frontend/src/components/studio/sections/SavedInsightsSection.tsx
@@ -1,30 +1,18 @@
 /**
  * SavedInsightsSection — auto-refreshing chat prompts in the Studio panel.
  *
- * A saved insight is a user prompt that the backend re-runs daily or
- * weekly. This section lists them with their latest result and lets the
- * user trigger a manual refresh or delete one. Creation happens from the
- * chat surface (the "Save as insight" button on user messages); this
- * section is read-and-manage only.
+ * Renders compact library-card rows for each saved insight. Clicking a
+ * card opens a 520px detail sheet with full markdown rendering, refresh,
+ * and a button that jumps to the source chat for full history.
  *
- * Hidden when there are no saved insights so we don't add empty noise
- * to the Studio panel.
+ * Hidden when there are no saved insights so we don't add empty noise to
+ * the Studio panel. Polls every 15s while any insight is mid-refresh so
+ * the latest result lands without a manual reload.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  ArrowsClockwise,
-  CircleNotch,
-  Lightbulb,
-  Trash,
-  Warning,
-} from '@phosphor-icons/react';
+import { Lightbulb } from '@phosphor-icons/react';
 import { useStudioContext } from '../studio-hooks';
-import {
-  insightsAPI,
-  type SavedInsight,
-  type InsightCadence,
-} from '@/lib/api/insights';
-import { Button } from '@/components/ui/button';
+import { insightsAPI, type SavedInsight } from '@/lib/api/insights';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -37,26 +25,12 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { InsightCard } from '../savedInsights/InsightCard';
+import { InsightDetailSheet } from '../savedInsights/InsightDetailSheet';
 
 const log = createLogger('saved-insights-section');
 
 const POLL_INTERVAL_MS = 15_000;
-
-const cadenceLabel = (c: InsightCadence) => (c === 'daily' ? 'Daily' : 'Weekly');
-
-const formatLastRun = (iso: string | null): string => {
-  if (!iso) return 'Not run yet';
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return 'Not run yet';
-  const diffMs = Date.now() - d.getTime();
-  const mins = Math.round(diffMs / 60_000);
-  if (mins < 1) return 'Just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.round(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  return `${days}d ago`;
-};
 
 export const SavedInsightsSection: React.FC = () => {
   const { projectId } = useStudioContext();
@@ -64,7 +38,7 @@ export const SavedInsightsSection: React.FC = () => {
 
   const [insights, setInsights] = useState<SavedInsight[]>([]);
   const [loaded, setLoaded] = useState(false);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [openInsightId, setOpenInsightId] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<SavedInsight | null>(null);
 
   const loadInsights = useCallback(async () => {
@@ -82,8 +56,8 @@ export const SavedInsightsSection: React.FC = () => {
     loadInsights();
   }, [loadInsights]);
 
-  // Poll while any insight is currently running so the user sees the new
-  // result land without a manual reload. Stops when no row is running.
+  // Poll while any insight is refreshing so the latest result lands
+  // without a manual reload. Stops cleanly when nothing's running.
   useEffect(() => {
     if (!insights.some((i) => i.is_running)) return;
     const interval = setInterval(loadInsights, POLL_INTERVAL_MS);
@@ -94,8 +68,8 @@ export const SavedInsightsSection: React.FC = () => {
     async (insight: SavedInsight) => {
       const ok = await insightsAPI.refresh(projectId, insight.id);
       if (ok) {
-        // Optimistically flip is_running so the spinner shows; the next
-        // poll picks up the canonical state from the backend.
+        // Optimistically flip is_running so the spinner shows immediately;
+        // the poll picks up the canonical state from the backend.
         setInsights((prev) =>
           prev.map((row) => (row.id === insight.id ? { ...row, is_running: true } : row)),
         );
@@ -111,6 +85,7 @@ export const SavedInsightsSection: React.FC = () => {
     if (!pendingDelete) return;
     const insight = pendingDelete;
     setPendingDelete(null);
+    if (openInsightId === insight.id) setOpenInsightId(null);
     const ok = await insightsAPI.remove(projectId, insight.id);
     if (ok) {
       setInsights((prev) => prev.filter((row) => row.id !== insight.id));
@@ -118,97 +93,55 @@ export const SavedInsightsSection: React.FC = () => {
     } else {
       error('Could not delete insight');
     }
-  }, [pendingDelete, projectId, success, error]);
+  }, [pendingDelete, projectId, openInsightId, success, error]);
+
+  // Switching to the source chat lives on ProjectWorkspace — we fire a
+  // window event it listens for. Keeps the studio decoupled from the
+  // chat panel's internals.
+  const handleJumpToChat = useCallback((insight: SavedInsight) => {
+    if (!insight.chat_id) return;
+    window.dispatchEvent(
+      new CustomEvent('noobbook:chat:open', { detail: { chatId: insight.chat_id } }),
+    );
+    setOpenInsightId(null);
+  }, []);
+
+  const openInsight = insights.find((i) => i.id === openInsightId) || null;
 
   if (!loaded || insights.length === 0) {
     return null;
   }
 
   return (
-    <section className="space-y-2">
+    <section className="space-y-2.5">
       <div className="flex items-center gap-2 px-1">
         <Lightbulb size={16} weight="bold" className="text-amber-600" />
-        <h3 className="text-xs font-semibold uppercase tracking-wide text-stone-700">
+        <h3 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-stone-700">
           Saved Insights
         </h3>
+        <span className="text-[11px] text-stone-400">{insights.length}</span>
       </div>
 
       <div className="space-y-2">
-        {insights.map((insight) => {
-          const isExpanded = expandedId === insight.id;
-          return (
-            <div
-              key={insight.id}
-              className="rounded-lg border border-stone-200 bg-white p-3 text-sm"
-            >
-              <div className="flex items-start gap-2">
-                <button
-                  type="button"
-                  onClick={() => setExpandedId(isExpanded ? null : insight.id)}
-                  className="flex-1 min-w-0 text-left"
-                >
-                  <div className="font-medium text-stone-800 truncate">
-                    {insight.title}
-                  </div>
-                  <div className="mt-0.5 text-xs text-muted-foreground">
-                    {cadenceLabel(insight.cadence)} · {formatLastRun(insight.last_run_at)}
-                    {insight.last_error && (
-                      <span className="ml-2 inline-flex items-center gap-1 text-destructive">
-                        <Warning size={12} weight="bold" />
-                        last refresh failed
-                      </span>
-                    )}
-                  </div>
-                </button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleRefresh(insight)}
-                  disabled={insight.is_running}
-                  title="Refresh now"
-                  className="h-7 w-7 p-0"
-                >
-                  {insight.is_running ? (
-                    <CircleNotch size={14} className="animate-spin" />
-                  ) : (
-                    <ArrowsClockwise size={14} />
-                  )}
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setPendingDelete(insight)}
-                  title="Delete insight"
-                  className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                >
-                  <Trash size={14} />
-                </Button>
-              </div>
-
-              {isExpanded && (
-                <div className="mt-3 space-y-2 border-t border-stone-100 pt-2">
-                  <div>
-                    <div className="text-xs font-medium text-stone-500">Prompt</div>
-                    <p className="mt-0.5 text-xs text-stone-700 whitespace-pre-wrap">
-                      {insight.prompt}
-                    </p>
-                  </div>
-                  <div>
-                    <div className="text-xs font-medium text-stone-500">
-                      {insight.last_error ? 'Last error' : 'Last result'}
-                    </div>
-                    <p className="mt-0.5 text-xs text-stone-700 whitespace-pre-wrap">
-                      {insight.last_error
-                        ? insight.last_error
-                        : insight.last_result || 'No result yet — refresh to populate.'}
-                    </p>
-                  </div>
-                </div>
-              )}
-            </div>
-          );
-        })}
+        {insights.map((insight) => (
+          <InsightCard
+            key={insight.id}
+            insight={insight}
+            onOpen={(i) => setOpenInsightId(i.id)}
+            onRefresh={handleRefresh}
+            onDelete={(i) => setPendingDelete(i)}
+            onJumpToChat={handleJumpToChat}
+          />
+        ))}
       </div>
+
+      <InsightDetailSheet
+        insight={openInsight}
+        open={!!openInsight}
+        onOpenChange={(open) => !open && setOpenInsightId(null)}
+        onRefresh={handleRefresh}
+        onJumpToChat={handleJumpToChat}
+      />
 
       <AlertDialog open={!!pendingDelete} onOpenChange={(open) => !open && setPendingDelete(null)}>
         <AlertDialogContent>
@@ -216,7 +149,7 @@ export const SavedInsightsSection: React.FC = () => {
             <AlertDialogTitle>Delete saved insight?</AlertDialogTitle>
             <AlertDialogDescription>
               This stops the scheduled refresh and removes the stored result.
-              The chats that were already run stay intact.
+              The chat where it was saved stays intact.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/frontend/src/lib/api/insights.ts
+++ b/frontend/src/lib/api/insights.ts
@@ -20,8 +20,11 @@ export interface SavedInsight {
   title: string;
   prompt: string;
   cadence: InsightCadence;
+  /** Chat the insight refreshes into. Refreshes append turns to this chat. */
+  chat_id: string | null;
   last_run_at: string | null;
   last_result: string | null;
+  /** Mirror of `chat_id` after the latest refresh — kept for backwards compat. */
   last_chat_id: string | null;
   last_error: string | null;
   is_running: boolean;
@@ -33,6 +36,8 @@ export interface CreateInsightInput {
   title?: string;
   prompt: string;
   cadence: InsightCadence;
+  /** Chat to associate with this insight so refreshes append turns to it. */
+  chat_id?: string | null;
 }
 
 export const insightsAPI = {


### PR DESCRIPTION
## Summary

- **Same-chat refresh** — saved insights now persist a `chat_id` and every refresh appends a turn to that same chat instead of spawning a fresh one. Legacy rows (no chat_id) lazy-create on first refresh and adopt it.
- **Library-card UI** — compact editorial cards in the Studio panel with amber accent bar, serif-italic title, status dot, hover-revealed icon row. Click opens a 520px side sheet rendering the answer as full markdown (no more wall-of-text in the narrow column). Buttons inline: Refresh now / Open the chat.
- Migration `00039_saved_insights_chat_id.sql` adds the column + partial index.

## Test plan

- [ ] Migration applies cleanly on prod
- [ ] Saving an insight from a chat sets `chat_id` to that chat
- [ ] Refresh appends a new turn to the saved chat (visible in chat history)
- [ ] Studio shows compact cards, click opens sheet with rendered markdown
- [ ] "Open the chat" button jumps the Chat panel to the source chat