### PR TITLE
Release: develop → main (insight auto-load + chat live-update)

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -253,6 +253,24 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openChatId]);
 
+  // Refetch the active chat when something background writes to it
+  // (e.g. a saved-insight refresh appending a turn). Listening for a
+  // window event keeps ChatPanel decoupled from whatever fired the
+  // refresh; the event detail just carries the chat_id so we can
+  // skip refetches for chats the user isn't viewing.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ chatId?: string }>).detail;
+      if (detail?.chatId && detail.chatId === activeChatIdRef.current) {
+        loadFullChat(detail.chatId);
+      }
+    };
+    window.addEventListener('noobbook:chat:updated', handler);
+    return () => window.removeEventListener('noobbook:chat:updated', handler);
+    // loadFullChat is stable for our purposes (closes over projectId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   /**
    * Refetch sources when sourcesVersion changes
    * Educational Note: This triggers when SourcesPanel notifies us that sources

--- a/frontend/src/components/chat/SaveAsInsightButton.tsx
+++ b/frontend/src/components/chat/SaveAsInsightButton.tsx
@@ -68,6 +68,10 @@ export const SaveAsInsightButton: React.FC<Props> = ({ projectId, chatId, prompt
         chat_id: chatId,
       });
       if (created) {
+        // Notify the Studio panel's SavedInsightsSection so the new card
+        // appears immediately — without this it stays invisible until the
+        // user reloads the page (no save → list signal otherwise).
+        window.dispatchEvent(new CustomEvent('noobbook:insight:saved'));
         success('Saved as a recurring insight');
         setOpen(false);
       } else {

--- a/frontend/src/components/studio/sections/SavedInsightsSection.tsx
+++ b/frontend/src/components/studio/sections/SavedInsightsSection.tsx
@@ -56,10 +56,39 @@ export const SavedInsightsSection: React.FC = () => {
     loadInsights();
   }, [loadInsights]);
 
-  // Poll while any insight is refreshing so the latest result lands
-  // without a manual reload. Stops cleanly when nothing's running.
+  // Reload when a new insight is saved from the chat. SaveAsInsightButton
+  // dispatches this event so the new card appears immediately — without
+  // it, the section stays stale until the user reloads the page.
   useEffect(() => {
-    if (!insights.some((i) => i.is_running)) return;
+    const handler = () => loadInsights();
+    window.addEventListener('noobbook:insight:saved', handler);
+    return () => window.removeEventListener('noobbook:insight:saved', handler);
+  }, [loadInsights]);
+
+  // Poll while any insight is refreshing so the latest result lands
+  // without a manual reload. Stops cleanly when nothing's running. We
+  // also fan a `noobbook:chat:updated` event whenever an insight flips
+  // from running → not-running so ChatPanel can re-fetch the source
+  // chat if the user happens to be viewing it (the refresh appended a
+  // new turn to that chat).
+  const prevRunningRef = React.useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const running = new Set(insights.filter((i) => i.is_running).map((i) => i.id));
+    // Anything in prev but not in current = just finished.
+    prevRunningRef.current.forEach((id) => {
+      if (!running.has(id)) {
+        const finished = insights.find((i) => i.id === id);
+        const chatId = finished?.chat_id;
+        if (chatId) {
+          window.dispatchEvent(
+            new CustomEvent('noobbook:chat:updated', { detail: { chatId } }),
+          );
+        }
+      }
+    });
+    prevRunningRef.current = running;
+
+    if (running.size === 0) return;
     const interval = setInterval(loadInsights, POLL_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [insights, loadInsights]);


### PR DESCRIPTION
## Summary

- **Auto-load saved insights** — SaveAsInsightButton now dispatches `noobbook:insight:saved`; SavedInsightsSection listens and refetches the list so the new card appears immediately without a page reload.
- **Live-update the chat panel during refresh** — when an insight finishes (is_running flips back to false), SavedInsightsSection fires `noobbook:chat:updated` with the chat_id. ChatPanel listens, and if the user is viewing that exact chat, it re-fetches so the new turn appears inline.

Both are pure frontend; no migration, no API change.

## Test plan

- [ ] Click "Save as insight" on a chat message → card appears in Studio panel right away
- [ ] Open the source chat → click Refresh on the insight → within ~60s the new user+assistant turn appears at the bottom of the chat without manual reload