### PR TITLE
feat(chat): prominent New chat button + Cmd/Ctrl+Shift+O (Sno 51 / #254)

### DIFF
--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -69,11 +69,16 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
   const { hasPermission } = usePermissions();
 
   // Platform-aware shortcut glyph: ⌘ on Mac, Ctrl elsewhere. Memoised so the
-  // tooltip body doesn't recompute on every parent re-render.
+  // tooltip body doesn't recompute on every parent re-render. navigator.platform
+  // is deprecated; prefer userAgentData.platform (Chromium-only) with a
+  // userAgent-string fallback for Safari / Firefox.
   const shortcutLabel = useMemo(() => {
-    const isMac =
-      typeof navigator !== 'undefined' &&
-      /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+    if (typeof navigator === 'undefined') return 'Ctrl+⇧+O';
+    const uaDataPlatform = (
+      navigator as Navigator & { userAgentData?: { platform?: string } }
+    ).userAgentData?.platform;
+    const platformHint = uaDataPlatform || navigator.userAgent || '';
+    const isMac = /Mac|iPhone|iPad|iPod/i.test(platformHint);
     return isMac ? '⌘⇧O' : 'Ctrl+⇧+O';
   }, []);
 

--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -4,7 +4,7 @@
  * Allows quick switching between chats via dropdown menu.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -68,6 +68,15 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
 }) => {
   const { hasPermission } = usePermissions();
 
+  // Platform-aware shortcut glyph: ⌘ on Mac, Ctrl elsewhere. Memoised so the
+  // tooltip body doesn't recompute on every parent re-render.
+  const shortcutLabel = useMemo(() => {
+    const isMac =
+      typeof navigator !== 'undefined' &&
+      /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+    return isMac ? '⌘⇧O' : 'Ctrl+⇧+O';
+  }, []);
+
   return (
     <div className="border-b px-4 py-3">
       {/* Title row - matches Sources/Studio/ChatEmptyState structure */}
@@ -112,6 +121,29 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
           </DropdownMenu>
         </div>
         <div className="flex items-center gap-2">
+          {/* Prominent "New chat" button — Claude-app parity (Sno 51 / GH #254).
+              Same handler as the dropdown item below; the dropdown stays for
+              muscle memory but this is the one-click affordance. */}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="soft"
+                  size="sm"
+                  onClick={onNewChat}
+                  className="h-8 gap-1.5"
+                >
+                  <Plus size={14} weight="bold" />
+                  <span>New chat</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                New chat
+                <kbd className="ml-1.5 text-xs opacity-70">{shortcutLabel}</kbd>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
           {/* Export chat button — hidden when chat_export permission is disabled */}
           {hasPermission("chat_features", "chat_export") && (
             <TooltipProvider>

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -990,6 +990,32 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     }
   };
 
+  // Keep a ref to the latest handleNewChat so the global keydown listener
+  // (mounted once) always fires the up-to-date closure instead of capturing
+  // the first render's stale setters / toast helpers.
+  const handleNewChatRef = useRef(handleNewChat);
+  handleNewChatRef.current = handleNewChat;
+
+  // Cmd/Ctrl+Shift+O → new chat (Claude-app parity, Sno 51 / GH #254).
+  // Overrides Chrome's bookmarks-manager binding intentionally — matches
+  // Claude.app's behaviour. Only mounted while ChatPanel is rendered (i.e.
+  // inside a project workspace), so the shortcut is workspace-scoped.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        e.key.toLowerCase() === 'o'
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleNewChatRef.current();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, []);
+
   /**
    * Select a chat from the list
    */


### PR DESCRIPTION
## Summary

Closes #254 (Sno 51). Today the only direct "new chat" entry point is buried three clicks deep in the chat title dropdown. This adds a one-click prominent button in the chat header, plus a `Cmd/Ctrl+Shift+O` global shortcut — Claude-app parity.

## Changes

- **`ChatHeader.tsx`**: prominent `[+ New chat]` button (`variant=soft`, matches the existing `ChatList` button visually) placed between the title group and the right-side icon cluster. Tooltip shows platform-aware shortcut (`⌘⇧O` on Mac, `Ctrl+⇧+O` elsewhere).
- **`ChatPanel.tsx`**: `useEffect` + ref-pattern keydown listener. The ref keeps the latest `handleNewChat` closure so the listener (mounted once) never goes stale. Intentional `preventDefault` on `Cmd+Shift+O` — overrides Chrome's bookmarks-manager binding to match Claude.app.

## What's intentionally untouched

- `ChatHeader` dropdown "New Chat" item — kept as a backup for muscle memory.
- `ChatList` modal's "New Chat" button — unchanged.
- `ChatEmptyState` CTA — unchanged.
- 3-panel workspace layout — no proportion changes, no new sidebar.

## Verification done

- `npm run lint` — clean on touched files (2 pre-existing warnings in unrelated files: `ModelsSection.tsx`, `PromptEditor.tsx`).
- `npx tsc --noEmit` — clean.

## Test plan

- [ ] Click `[+ New chat]` button in chat header → new chat created, panel switches to it, toast appears.
- [ ] Press `⌘⇧O` (Mac) / `Ctrl+Shift+O` (Linux/Win) from any focus state inside the workspace → same behaviour.
- [ ] Confirm Chrome's bookmarks manager does NOT open.
- [ ] Hover the button → tooltip shows the correct platform-specific shortcut glyph.
- [ ] Regression: dropdown's "New Chat" item + ChatList modal button + empty-state CTA all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)