### PR TITLE
feat(onboarding): 5-step first-run coachmark tour (Sno 52 / #255)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,8 @@ import { GlobalLogsModalGate } from './components/project/GlobalLogsModalGate';
 import { setAdminMode, SESSION_EXPIRED_EVENT } from './lib/adminMode';
 import { useToast } from './components/ui/use-toast';
 import { ToastContainer } from './components/ui/toast';
+import { TutorialProvider } from './contexts/TutorialContext';
+import { OnboardingTutorial } from './components/onboarding';
 
 const log = createLogger('app');
 
@@ -180,16 +182,23 @@ function ProjectWorkspaceRoute({
   // (malformed citation, missing message field, etc.) doesn't blank the
   // entire page — that was Neel's "screen goes blank, refresh fixes it" bug.
   // resetKey=projectId so navigating to a different project recovers cleanly.
+  // TutorialProvider is scoped to the workspace route so the first-run
+  // auto-open only fires when the user actually lands on a project (not on
+  // the dashboard or a /share/* viewer). OnboardingTutorial is a sibling so
+  // its absolutely-positioned popover renders on top of the workspace.
   return (
     <ErrorBoundary resetKey={projectId}>
-      <ProjectWorkspace
-        project={project}
-        onBack={() => navigate('/')}
-        onDeleteProject={handleDeleteProject}
-        onRenameProject={handleRenameProject}
-        onSignOut={isAuthenticated ? onSignOut : undefined}
-        isAdmin={isAdmin}
-      />
+      <TutorialProvider>
+        <ProjectWorkspace
+          project={project}
+          onBack={() => navigate('/')}
+          onDeleteProject={handleDeleteProject}
+          onRenameProject={handleRenameProject}
+          onSignOut={isAuthenticated ? onSignOut : undefined}
+          isAdmin={isAdmin}
+        />
+        <OnboardingTutorial />
+      </TutorialProvider>
     </ErrorBoundary>
   );
 }

--- a/frontend/src/components/onboarding/OnboardingTutorial.tsx
+++ b/frontend/src/components/onboarding/OnboardingTutorial.tsx
@@ -1,0 +1,514 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { useTutorial } from '../../hooks/useTutorial';
+import { Button } from '../ui/button';
+import { X, CaretLeft, CaretRight, RocketLaunch, CheckCircle, Ghost } from '@phosphor-icons/react';
+
+interface PopoverPosition {
+  top: number;
+  left: number;
+  arrowTop: number;
+  arrowLeft: number;
+  arrowPosition: 'top' | 'bottom' | 'left' | 'right';
+}
+
+const SEEN_KEY = 'noobbook_onboarding_seen';
+const HIGHLIGHT_COLOR = '#D97706';
+
+const getFocusableElements = (container: HTMLElement | null): HTMLElement[] => {
+  if (!container) return [];
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((el) => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true');
+};
+
+export const OnboardingTutorial: React.FC = () => {
+  const { isOpen, currentStep, steps, nextStep, prevStep, goToStep, skipTutorial } = useTutorial();
+  const [position, setPosition] = useState<PopoverPosition | null>(null);
+  const [fallbackPosition, setFallbackPosition] = useState<{ top: number; left: number } | null>(null);
+  const [targetFound, setTargetFound] = useState(false);
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false);
+  const [anchoredReady, setAnchoredReady] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const closeConfirmRef = useRef<HTMLDivElement>(null);
+
+  const currentStepData = steps[currentStep];
+
+  // Mark tutorial as seen only when tutorial UI is actually rendered.
+  useEffect(() => {
+    if (isOpen) {
+      localStorage.setItem(SEEN_KEY, 'true');
+    }
+  }, [isOpen]);
+
+  // Calculate fallback position (bottom-right corner)
+  useEffect(() => {
+    const updateFallbackPosition = () => {
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const cardWidth = 380;
+      const cardHeight = 220;
+      
+      setFallbackPosition({
+        top: (viewportHeight - cardHeight) / 2,
+        left: (viewportWidth - cardWidth) / 2,
+      });
+    };
+    
+    updateFallbackPosition();
+    window.addEventListener('resize', updateFallbackPosition);
+    return () => window.removeEventListener('resize', updateFallbackPosition);
+  }, []);
+
+  // When target is found and position is calculated, trigger the animation
+  // by flipping anchoredReady to true after a frame
+  useEffect(() => {
+    if (targetFound && position && !anchoredReady) {
+      // Use double-rAF to ensure the browser has painted at fallback position first
+      let raf2 = 0;
+      const raf1 = requestAnimationFrame(() => {
+        raf2 = requestAnimationFrame(() => {
+          setAnchoredReady(true);
+        });
+      });
+      return () => { cancelAnimationFrame(raf1); cancelAnimationFrame(raf2); };
+    }
+  }, [targetFound, position, anchoredReady]);
+
+  const updatePosition = useCallback(() => {
+    if (!currentStepData) return;
+
+    const targetElement = document.querySelector(`[data-tour="${currentStepData.target}"]`);
+
+    if (!targetElement) {
+      setTargetFound(false);
+      setPosition(null);
+      return;
+    }
+
+    setTargetFound(true);
+    const targetRect = targetElement.getBoundingClientRect();
+    const popoverWidth = 340;
+    const popoverHeight = 220;
+    const gap = 14;
+    const arrowSize = 10;
+
+    let top = 0;
+    let left = 0;
+    let arrowTop = 0;
+    let arrowLeft = 0;
+    let arrowPosition: 'top' | 'bottom' | 'left' | 'right' = 'top';
+
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    switch (currentStepData.position) {
+      case 'top':
+        top = targetRect.top - popoverHeight - gap;
+        left = targetRect.left + (targetRect.width / 2) - (popoverWidth / 2);
+        arrowTop = popoverHeight;
+        arrowLeft = popoverWidth / 2 - arrowSize;
+        arrowPosition = 'bottom';
+        break;
+      case 'bottom':
+        top = targetRect.bottom + gap;
+        left = targetRect.left + (targetRect.width / 2) - (popoverWidth / 2);
+        arrowTop = -arrowSize;
+        arrowLeft = popoverWidth / 2 - arrowSize;
+        arrowPosition = 'top';
+        break;
+      case 'left':
+        top = targetRect.top + (targetRect.height / 2) - (popoverHeight / 2);
+        left = targetRect.left - popoverWidth - gap;
+        arrowTop = popoverHeight / 2 - arrowSize;
+        arrowLeft = popoverWidth;
+        arrowPosition = 'right';
+        break;
+      case 'right':
+        top = targetRect.top + (targetRect.height / 2) - (popoverHeight / 2);
+        left = targetRect.right + gap;
+        arrowTop = popoverHeight / 2 - arrowSize;
+        arrowLeft = -arrowSize;
+        arrowPosition = 'left';
+        break;
+    }
+
+    // Adjust if off-screen
+    if (left < 16) left = 16;
+    if (left + popoverWidth > viewportWidth - 16) left = viewportWidth - popoverWidth - 16;
+    if (top < 16) top = 16;
+    if (top + popoverHeight > viewportHeight - 16) top = viewportHeight - popoverHeight - 16;
+
+    // Recalculate arrow for horizontal positions
+    if (currentStepData.position === 'left' || currentStepData.position === 'right') {
+      const targetCenterY = targetRect.top + targetRect.height / 2;
+      arrowTop = Math.max(16, Math.min(targetCenterY - top - arrowSize, popoverHeight - arrowSize - 16));
+    }
+
+    setPosition({ top, left, arrowTop, arrowLeft, arrowPosition });
+  }, [currentStepData]);
+
+  // Update position when step changes
+  useEffect(() => {
+    if (!isOpen || !currentStepData) return;
+
+    let rafId: number | null = null;
+    const scheduleUpdate = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        updatePosition();
+      });
+    };
+
+    // Initial pass + observe DOM changes so the tutorial can anchor
+    // as soon as the target element is mounted.
+    scheduleUpdate();
+
+    const observer = new MutationObserver(() => {
+      scheduleUpdate();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    window.addEventListener('resize', scheduleUpdate);
+    window.addEventListener('scroll', scheduleUpdate, true);
+
+    return () => {
+      observer.disconnect();
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+      window.removeEventListener('resize', scheduleUpdate);
+      window.removeEventListener('scroll', scheduleUpdate, true);
+    };
+  }, [isOpen, currentStepData, updatePosition]);
+
+  // Keyboard behavior: Escape opens/closes confirmation and Tab stays inside tutorial UI.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setShowCloseConfirm((open) => !open);
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const activeContainer = showCloseConfirm ? closeConfirmRef.current : popoverRef.current;
+      const focusable = getFocusableElements(activeContainer);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      const insideContainer = !!(active && activeContainer?.contains(active));
+
+      if (event.shiftKey) {
+        if (!insideContainer || active === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (!insideContainer || active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, showCloseConfirm]);
+
+  // Keep focus in the active dialog surface.
+  useEffect(() => {
+    if (!isOpen) return;
+    const activeContainer = showCloseConfirm ? closeConfirmRef.current : popoverRef.current;
+    if (!activeContainer) return;
+
+    const rafId = requestAnimationFrame(() => {
+      const focusable = getFocusableElements(activeContainer);
+      focusable[0]?.focus();
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [isOpen, showCloseConfirm, currentStep]);
+
+  // Highlight the current target element (ring + raise above backdrop)
+  useEffect(() => {
+    if (!isOpen || !currentStepData) return;
+
+    const targetEl = document.querySelector(`[data-tour="${currentStepData.target}"]`) as HTMLElement | null;
+    if (!targetEl) return;
+
+    // Save original styles to restore on cleanup
+    const origZIndex = targetEl.style.zIndex;
+    const origPosition = targetEl.style.position;
+    const origOutline = targetEl.style.outline;
+    const origOutlineOffset = targetEl.style.outlineOffset;
+    const origBorderRadius = targetEl.style.borderRadius;
+    const computedPosition = window.getComputedStyle(targetEl).position;
+    const shouldSetRelativePosition = computedPosition === 'static';
+
+    // Apply highlight — use outline instead of box-shadow so it's not clipped by overflow:hidden
+    targetEl.style.zIndex = '9998';
+    if (shouldSetRelativePosition) {
+      targetEl.style.position = 'relative';
+    }
+    targetEl.style.outline = `3px solid ${HIGHLIGHT_COLOR}`;
+    targetEl.style.outlineOffset = '2px';
+    targetEl.style.borderRadius = '12px';
+
+    return () => {
+      targetEl.style.zIndex = origZIndex;
+      if (shouldSetRelativePosition) {
+        targetEl.style.position = origPosition;
+      }
+      targetEl.style.outline = origOutline;
+      targetEl.style.outlineOffset = origOutlineOffset;
+      targetEl.style.borderRadius = origBorderRadius;
+    };
+  }, [isOpen, currentStep, currentStepData]);
+
+  if (!isOpen) return null;
+
+  const handleNextStep = () => {
+    setAnchoredReady(false);
+    nextStep();
+  };
+
+  const handlePrevStep = () => {
+    setAnchoredReady(false);
+    prevStep();
+  };
+
+  const handleGoToStep = (step: number) => {
+    setAnchoredReady(false);
+    goToStep(step);
+  };
+
+  const progressPercent = ((currentStep + 1) / steps.length) * 100;
+
+  // Shared content renderer
+  const renderContent = () => (
+    <div
+      className="overflow-hidden"
+      style={{
+        borderRadius: '16px',
+        background: 'hsl(var(--card))',
+        border: '1px solid hsl(var(--border))',
+        boxShadow: '0 25px 50px -12px rgba(0,0,0,0.15), 0 0 0 1px rgba(0,0,0,0.03)',
+      }}
+    >
+      {/* Progress bar */}
+      <div style={{ height: 3, width: '100%', background: 'hsl(var(--muted))' }}>
+        <div
+          style={{
+            height: '100%',
+            background: 'hsl(var(--primary))',
+            width: `${progressPercent}%`,
+            transition: 'width 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+            borderRadius: '0 2px 2px 0',
+          }}
+        />
+      </div>
+
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 pt-4 pb-0">
+        <div className="flex items-center gap-2">
+          <div
+            className="flex items-center justify-center w-6 h-6 rounded-full"
+            style={{ background: 'rgba(217, 119, 6, 0.12)' }}
+          >
+            <RocketLaunch size={14} weight="fill" className="text-primary" />
+          </div>
+          <span className="text-[11px] font-semibold text-muted-foreground tracking-widest uppercase">
+            {currentStep + 1} / {steps.length}
+          </span>
+        </div>
+        <button
+          type="button"
+          aria-label="Close tutorial"
+          onClick={() => setShowCloseConfirm(true)}
+          className="flex items-center justify-center w-7 h-7 rounded-full hover:bg-muted/80 transition-colors"
+        >
+          <X size={14} className="text-muted-foreground" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div
+        className="px-5 py-4"
+        style={{ transition: 'opacity 0.2s ease, transform 0.2s ease' }}
+      >
+        <h3 className="font-semibold text-foreground mb-2 text-base">
+          {currentStepData.title}
+        </h3>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {currentStepData.content}
+        </p>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between px-5 pb-4 pt-2">
+        {currentStep === 0 ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowCloseConfirm(true)}
+          >
+            Skip
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handlePrevStep}
+            className="gap-1"
+          >
+            <CaretLeft size={14} weight="bold" />
+            Back
+          </Button>
+        )}
+
+        <div className="flex items-center gap-1.5">
+          {steps.map((_, idx) => (
+            <button
+              key={idx}
+              type="button"
+              aria-label={`Go to step ${idx + 1}: ${steps[idx].title}`}
+              onClick={() => handleGoToStep(idx)}
+              className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                idx === currentStep
+                  ? 'bg-primary' 
+                  : idx < currentStep
+                    ? 'bg-primary/50' 
+                    : 'bg-border'
+              }`}
+            />
+          ))}
+        </div>
+
+        <Button
+          size="sm"
+          onClick={handleNextStep}
+          className="gap-1.5 h-8 px-4 text-xs font-medium"
+          style={{ borderRadius: '8px' }}
+        >
+          {currentStep === steps.length - 1 ? (
+            <>
+              Finish
+              <CheckCircle size={14} weight="bold" />
+            </>
+          ) : (
+            <>
+              Next
+              <CaretRight size={14} weight="bold" />
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-[9998] cursor-pointer"
+        style={{
+          background: 'rgba(0, 0, 0, 0.18)',
+          backdropFilter: 'blur(1px)',
+        }}
+        onClick={() => setShowCloseConfirm(true)}
+      />
+
+      {/* Confirmation Dialog */}
+      {showCloseConfirm && (
+        <div className="fixed inset-0 z-[99999] flex items-center justify-center">
+          <div
+            className="absolute inset-0"
+            style={{ background: 'rgba(0,0,0,0.4)', backdropFilter: 'blur(2px)' }}
+            onClick={() => setShowCloseConfirm(false)}
+          />
+          <div
+            ref={closeConfirmRef}
+            className="relative mx-4 max-w-sm w-full"
+            style={{
+              background: 'hsl(var(--card))',
+              border: '1px solid hsl(var(--border))',
+              borderRadius: '16px',
+              boxShadow: '0 25px 50px -12px rgba(0,0,0,0.25)',
+            }}
+          >
+            <div className="p-6">
+              <h3 className="font-semibold text-lg mb-2">Skip the tutorial?</h3>
+              <p className="text-muted-foreground mb-6">
+                You can always restart it later from the three dot menu or project settings.
+              </p>
+              <div className="flex gap-3 justify-end">
+                <Button variant="soft" onClick={() => setShowCloseConfirm(false)}>
+                  Continue
+                </Button>
+                <Button onClick={() => {
+                  setShowCloseConfirm(false);
+                  skipTutorial();
+                }}>
+                  Skip
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Single unified tutorial dialog — slides between fallback and anchored positions */}
+      {fallbackPosition && (
+        <div
+          ref={popoverRef}
+          className={`fixed z-[9999] ${!targetFound && currentStep === 0 ? 'tutorial-scale-in' : ''}`}
+          role="dialog"
+          aria-modal="true"
+          aria-label="NoobBook onboarding tutorial"
+          style={{
+            width: targetFound && position ? 340 : 380,
+            top: targetFound && position
+              ? (anchoredReady ? position.top : fallbackPosition.top)
+              : fallbackPosition.top,
+            left: targetFound && position
+              ? (anchoredReady ? position.left : fallbackPosition.left)
+              : fallbackPosition.left,
+            transition: 'top 0.5s cubic-bezier(0.4, 0, 0.2, 1), left 0.5s cubic-bezier(0.4, 0, 0.2, 1), width 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+            willChange: 'top, left, width',
+          }}
+        >
+          {/* Ghost logo connector — points from dialog to target */}
+          {targetFound && position && (
+            <div
+              className="absolute"
+              style={{
+                zIndex: 10000,
+                top: position.arrowPosition === 'top' ? -20 
+                  : position.arrowPosition === 'bottom' ? undefined
+                  : position.arrowTop - 8,
+                bottom: position.arrowPosition === 'bottom' ? -20 : undefined,
+                left: position.arrowPosition === 'left' ? -20
+                  : position.arrowPosition === 'right' ? undefined
+                  : position.arrowLeft - 4,
+                right: position.arrowPosition === 'right' ? -20 : undefined,
+                opacity: anchoredReady ? 1 : 0,
+                transition: 'opacity 0.3s ease 0.2s',
+              }}
+            >
+              <Ghost size={18} weight="fill" color={HIGHLIGHT_COLOR} />
+            </div>
+          )}
+          {renderContent()}
+        </div>
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/onboarding/OnboardingTutorial.tsx
+++ b/frontend/src/components/onboarding/OnboardingTutorial.tsx
@@ -416,9 +416,10 @@ export const OnboardingTutorial: React.FC = () => {
 
   return (
     <>
-      {/* Backdrop */}
+      {/* Backdrop — must sit BELOW the highlighted target (z-9998 via JS in
+          updatePosition) so the spotlight is visible. Greptile P1 (PR #277). */}
       <div
-        className="fixed inset-0 z-[9998] cursor-pointer"
+        className="fixed inset-0 z-[9997] cursor-pointer"
         style={{
           background: 'rgba(0, 0, 0, 0.18)',
           backdropFilter: 'blur(1px)',

--- a/frontend/src/components/onboarding/index.ts
+++ b/frontend/src/components/onboarding/index.ts
@@ -1,0 +1,1 @@
+export { OnboardingTutorial } from './OnboardingTutorial';

--- a/frontend/src/components/project/ProjectHeader.tsx
+++ b/frontend/src/components/project/ProjectHeader.tsx
@@ -28,7 +28,7 @@ import {
   CollapsibleTrigger,
 } from '../ui/collapsible';
 import { Textarea } from '../ui/textarea';
-import { ArrowLeft, DotsThreeVertical, Plus, Trash, FolderOpen, Gear, CircleNotch, CurrencyDollar, Brain, CaretDown, CaretRight, PencilSimple, SignOut } from '@phosphor-icons/react';
+import { ArrowLeft, DotsThreeVertical, Plus, Trash, FolderOpen, Gear, CircleNotch, CurrencyDollar, Brain, CaretDown, CaretRight, PencilSimple, SignOut, Compass } from '@phosphor-icons/react';
 import { Input } from '../ui/input';
 import { chatsAPI, type PromptConfig } from '../../lib/api/chats';
 import { projectsAPI, type CostTracking, type MemoryData } from '../../lib/api';
@@ -38,6 +38,7 @@ import { useToast } from '../ui/use-toast';
 import { createLogger } from '@/lib/logger';
 import { ShareButton } from './ShareButton';
 import { LogsButton } from './LogsButton';
+import { useTutorial } from '@/hooks/useTutorial';
 
 const log = createLogger('project-header');
 
@@ -70,6 +71,8 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
   onSignOut,
 }) => {
   const { toasts, dismissToast, error, success, errorWithLogs } = useToast();
+  // Used by the kebab-menu "Replay onboarding tour" item below.
+  const { startTutorial } = useTutorial();
 
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [settingsDialogOpen, setSettingsDialogOpen] = React.useState(false);
@@ -409,6 +412,7 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
           size="sm"
           onClick={handleOpenMemory}
           className="gap-2"
+          data-tour="memory-btn"
         >
           <Brain size={16} />
           Memory
@@ -447,6 +451,10 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
             }}>
               <PencilSimple size={16} className="mr-2" />
               Rename Project
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={startTutorial}>
+              <Compass size={16} className="mr-2" />
+              Replay onboarding tour
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/frontend/src/components/project/ProjectWorkspace.tsx
+++ b/frontend/src/components/project/ProjectWorkspace.tsx
@@ -181,7 +181,7 @@ export const ProjectWorkspace: React.FC<ProjectWorkspaceProps> = ({
 
             {/* Center Panel - Chat */}
             <ResizablePanel defaultSize={55} minSize={30} className="bg-card overflow-hidden rounded-xl min-w-0">
-              <div className="h-full min-h-0 min-w-0 w-full flex flex-col overflow-hidden">
+              <div className="h-full min-h-0 min-w-0 w-full flex flex-col overflow-hidden" data-tour="chat-panel">
                 <ChatPanel
                   projectId={project.id}
                   projectName={project.name}

--- a/frontend/src/components/sources/SourcesPanel.tsx
+++ b/frontend/src/components/sources/SourcesPanel.tsx
@@ -828,7 +828,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
           </div>
         </TooltipProvider>
       ) : (
-        <div className="flex flex-col h-full">
+        <div className="flex flex-col h-full" data-tour="sources-panel">
           <SourcesHeader
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}

--- a/frontend/src/components/studio/StudioPanel.tsx
+++ b/frontend/src/components/studio/StudioPanel.tsx
@@ -44,7 +44,7 @@ const StudioPanelContent: React.FC = () => {
   } = useStudioContext();
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full" data-tour="studio-panel">
       <StudioHeader />
 
       {/* TOP HALF: Generation Tools */}

--- a/frontend/src/contexts/TutorialContext.tsx
+++ b/frontend/src/contexts/TutorialContext.tsx
@@ -1,0 +1,115 @@
+import React, { useState, useCallback } from 'react';
+import { TutorialContext, type TourStep } from './TutorialContextType';
+
+const STORAGE_KEY = 'noobbook_onboarding_completed';
+const SEEN_KEY = 'noobbook_onboarding_seen';
+
+// 5-step first-run tour (Sno 52 / GH #255). Targets reference `data-tour`
+// attributes attached to the corresponding panel / header element.
+const defaultSteps: TourStep[] = [
+  {
+    target: 'welcome-intro',
+    title: 'Welcome to NoobBook',
+    content:
+      "NoobBook is your AI-powered workspace — upload sources, chat with them, and generate content like presentations, blogs, and reports. Here's a quick 5-step tour of the three panels you'll work in.",
+    position: 'bottom',
+  },
+  {
+    target: 'sources-panel',
+    title: 'Sources — your content lives here',
+    content:
+      'Upload PDFs, DOCX, PPTX, XLSX, images, and audio; paste text or URLs; or import from Google Drive. The AI processes each source so chat and Studio can search across them.',
+    position: 'right',
+  },
+  {
+    target: 'chat-panel',
+    title: 'Chat — ask anything about your sources',
+    content:
+      'Get cited answers grounded in your documents. Hit the microphone for voice input, drag images into the box to attach them, and use the "Save as insight" button on any reply to pin it.',
+    position: 'left',
+  },
+  {
+    target: 'studio-panel',
+    title: 'Studio — turn sources into deliverables',
+    content:
+      'Generate presentations, blogs, social posts, infographics, components, wireframes, business reports, and more. Saved Insights from chat also live here for quick reuse.',
+    position: 'left',
+  },
+  {
+    target: 'memory-btn',
+    title: 'Memory & Settings — make it yours',
+    content:
+      'Memory teaches the AI about you and this project so answers stay on-brand. Project Settings lets you tweak the system prompt, rename, or share. You can replay this tour anytime from there.',
+    position: 'bottom',
+  },
+];
+
+const getInitialTutorialState = () => {
+  const completed = localStorage.getItem(STORAGE_KEY);
+  const seen = localStorage.getItem(SEEN_KEY);
+  // Auto-open only if the tutorial has never been shown before.
+  // "Seen" is now set when the tutorial component actually renders.
+  const shouldAutoOpen = !completed && !seen;
+  return {
+    isOpen: shouldAutoOpen,
+    isCompleted: !!completed,
+  };
+};
+
+export const TutorialProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [initialState] = useState(getInitialTutorialState);
+  const [isOpen, setIsOpen] = useState(initialState.isOpen);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [steps] = useState<TourStep[]>(defaultSteps);
+  const [isCompleted, setIsCompleted] = useState(initialState.isCompleted);
+
+  const startTutorial = useCallback(() => {
+    setIsOpen(true);
+    setCurrentStep(0);
+    setIsCompleted(false);
+  }, []);
+
+  const nextStep = useCallback(() => {
+    setCurrentStep((prev) => {
+      if (prev >= steps.length - 1) {
+        setIsOpen(false);
+        localStorage.setItem(STORAGE_KEY, 'true');
+        setIsCompleted(true);
+        return prev;
+      }
+      return prev + 1;
+    });
+  }, [steps.length]);
+
+  const prevStep = useCallback(() => {
+    setCurrentStep((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const goToStep = useCallback((step: number) => {
+    setCurrentStep(step);
+  }, []);
+
+  const skipTutorial = useCallback(() => {
+    setIsOpen(false);
+    localStorage.setItem(STORAGE_KEY, 'true');
+    setIsCompleted(true);
+  }, []);
+
+  return (
+    <TutorialContext.Provider
+      value={{
+        isOpen,
+        currentStep,
+        steps,
+        isCompleted,
+        startTutorial,
+        nextStep,
+        prevStep,
+        goToStep,
+        skipTutorial,
+      }}
+    >
+      {children}
+    </TutorialContext.Provider>
+  );
+};

--- a/frontend/src/contexts/TutorialContextType.ts
+++ b/frontend/src/contexts/TutorialContextType.ts
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+
+export interface TourStep {
+  target: string;
+  title: string;
+  content: string;
+  position: 'top' | 'bottom' | 'left' | 'right';
+}
+
+export interface TutorialContextType {
+  isOpen: boolean;
+  currentStep: number;
+  steps: TourStep[];
+  isCompleted: boolean;
+  startTutorial: () => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  goToStep: (step: number) => void;
+  skipTutorial: () => void;
+}
+
+export const TutorialContext = createContext<TutorialContextType | undefined>(undefined);

--- a/frontend/src/hooks/useTutorial.ts
+++ b/frontend/src/hooks/useTutorial.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { TutorialContext } from '../contexts/TutorialContextType';
+
+export const useTutorial = () => {
+  const context = useContext(TutorialContext);
+  if (!context) {
+    throw new Error('useTutorial must be used within a TutorialProvider');
+  }
+  return context;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -172,3 +172,20 @@
   55%  { transform: translateX(310%); }
   100% { transform: translateX(310%); }
 }
+
+/* Onboarding tour intro animation — used by OnboardingTutorial on the first
+   centered welcome step before it anchors to a panel. Greptile P1 (PR #277). */
+@keyframes tutorial-scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.tutorial-scale-in {
+  animation: tutorial-scale-in 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}


### PR DESCRIPTION
## Summary

Closes #255 (Sno 52). Salvages the popover engine + provider from the abandoned PR #103 (merged to a deleted feature branch back in Feb 2026, never reached develop/main) and refreshes it for today's app.

## What's in this PR

**Imported verbatim from `cfa6152` (the abandoned merge commit):**
- `frontend/src/components/onboarding/OnboardingTutorial.tsx` (514 lines) — full popover engine: fallback centered position if target not found, double-rAF anchor animation, focus trap, skip-confirmation, arrow positioning, amber highlight matching design system, Ghost / RocketLaunch / CheckCircle Phosphor icons.
- `frontend/src/contexts/TutorialContext.tsx` + `TutorialContextType.ts` — provider with `isOpen` / `currentStep` / `nextStep` / `prevStep` / `goToStep` / `startTutorial` / `skipTutorial`.
- `frontend/src/hooks/useTutorial.ts` — context hook.

**Refreshed / re-applied for current app:**
- **Trimmed 8 → 5 steps** to match the acceptance criteria ("3-5 step tour"): welcome, sources, chat, studio, memory+settings combo.
- **Refreshed copy** to reflect today's app: XLSX support, Saved Insights, voice input, drag-to-attach images.
- **`TutorialProvider` scoped to the workspace route** (inside `ProjectWorkspaceRoute` in `App.tsx`) so auto-open only fires when a project is opened — not on dashboard or `/share/*` viewer.
- **`data-tour` anchors** re-applied to today's versions of `ProjectWorkspace.tsx` (chat panel wrapper), `SourcesPanel.tsx` (root), `StudioPanel.tsx` (root), `ProjectHeader.tsx` (memory button). The old PR's files have drifted too far in 3 months for a clean cherry-pick.
- **"Replay onboarding tour"** item added to the project header kebab dropdown (Compass icon) so users can re-trigger after dismissing.

**Persistence:** localStorage (`noobbook_onboarding_seen` + `_completed`), as in the original. Matches the roadmap acceptance "dismissible + suppressed after first dismiss" without adding a backend write. If account-level persistence ever matters, follow up later.

## Verification done

- `npm run lint` clean on touched files (2 pre-existing warnings in unrelated `ModelsSection.tsx` / `PromptEditor.tsx`).
- `npx tsc --noEmit` clean.
- Local build fails only on `@uiw/react-md-editor` (pre-existing on develop, CI has the package).

## Test plan

- [ ] Fresh incognito window → open a project → tour auto-shows, 5 steps, dismissible.
- [ ] Refresh page → tour does NOT auto-show again.
- [ ] Open project header kebab menu → "Replay onboarding tour" → tour re-opens from step 1.
- [ ] Click skip mid-tour → close-confirmation appears → confirming closes the tour and suppresses future auto-opens.
- [ ] Navigate to dashboard or `/share/<token>` → tour does NOT mount (provider is workspace-scoped).
- [ ] Smoke regression: source upload, chat send, studio generate all work normally with tour dismissed.

## Credits

Original tour engine by @SarthakWade in PR #103 (closed/abandoned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)