### PR TITLE
harden OAuth state + bind MinIO to localhost + tighten freshdesk RPC grants

### DIFF
--- a/backend/app/api/google/oauth.py
+++ b/backend/app/api/google/oauth.py
@@ -31,6 +31,7 @@ from typing import Optional
 from flask import jsonify, request, current_app, make_response
 from app.api.google import google_bp
 from app.services.integrations.google import google_auth_service
+from app.services.integrations.google.oauth_state import verify_state
 from app.services.auth.rbac import get_request_identity
 
 
@@ -235,9 +236,16 @@ def google_callback():
         if not code:
             return _render_callback_page('error', 'No authorization code')
 
-        # Get user_id from state parameter (for multi-user support)
-        # State was set in get_auth_url() to identify which user initiated OAuth
-        user_id = request.args.get('state') or None
+        # Verify the HMAC-signed state. Failures here mean the request
+        # didn't come from a flow we minted — treat as adversarial and
+        # bail before exchanging the code (otherwise we'd happily link
+        # the attacker's Google account to whatever user_id they put in
+        # the raw state). Replay protection is built into verify_state.
+        raw_state = request.args.get('state') or None
+        state_ok, user_id, state_err = verify_state(raw_state)
+        if not state_ok:
+            current_app.logger.warning("Google OAuth rejected: %s", state_err)
+            return _render_callback_page('error', 'Invalid sign-in request')
 
         # Exchange code for tokens, passing user_id for storage
         success, message = google_auth_service.handle_callback(code, user_id=user_id)

--- a/backend/app/services/integrations/google/google_auth_service.py
+++ b/backend/app/services/integrations/google/google_auth_service.py
@@ -215,6 +215,13 @@ class GoogleAuthService:
         # Use provided user_id or get default for single-user mode
         effective_user_id = user_id or self._get_default_user_id()
 
+        # Refuse to mint a flow with no user attached. sign_state would
+        # reject anyway (its UUID column is NOT NULL); returning None
+        # here lets the route surface a clean 400 instead of a 500.
+        if not effective_user_id:
+            logger.warning("get_auth_url called with no user_id (no default user)")
+            return None
+
         flow = Flow.from_client_config(
             client_config,
             scopes=self.SCOPES,
@@ -228,7 +235,7 @@ class GoogleAuthService:
         # verify it really came from a flow WE started (no CSRF where
         # someone tricks a victim into pasting an OAuth URL that links
         # the attacker's Google account to the victim's row).
-        signed_state = sign_state(effective_user_id or "")
+        signed_state = sign_state(effective_user_id)
         auth_url, _ = flow.authorization_url(
             access_type='offline',
             prompt='consent',

--- a/backend/app/services/integrations/google/google_auth_service.py
+++ b/backend/app/services/integrations/google/google_auth_service.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 from google_auth_oauthlib.flow import Flow
 from google.auth.transport.requests import Request
 
+from app.services.integrations.google.oauth_state import sign_state, verify_state
 from app.services.integrations.supabase import get_supabase
 
 
@@ -223,12 +224,16 @@ class GoogleAuthService:
         # Generate auth URL
         # access_type='offline' ensures we get a refresh token
         # prompt='consent' forces consent screen to ensure refresh token
-        # state parameter carries user_id for the callback
+        # state is HMAC-signed + nonce-protected so the callback can
+        # verify it really came from a flow WE started (no CSRF where
+        # someone tricks a victim into pasting an OAuth URL that links
+        # the attacker's Google account to the victim's row).
+        signed_state = sign_state(effective_user_id or "")
         auth_url, _ = flow.authorization_url(
             access_type='offline',
             prompt='consent',
             include_granted_scopes='true',
-            state=effective_user_id or ''  # Pass user_id in state for callback
+            state=signed_state,
         )
 
         return auth_url

--- a/backend/app/services/integrations/google/google_auth_service.py
+++ b/backend/app/services/integrations/google/google_auth_service.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 from google_auth_oauthlib.flow import Flow
 from google.auth.transport.requests import Request
 
-from app.services.integrations.google.oauth_state import sign_state, verify_state
+from app.services.integrations.google.oauth_state import sign_state
 from app.services.integrations.supabase import get_supabase
 
 

--- a/backend/app/services/integrations/google/oauth_state.py
+++ b/backend/app/services/integrations/google/oauth_state.py
@@ -100,6 +100,13 @@ def _issue_nonce(user_id: str) -> str:
     return nonce
 
 
+class InvalidUserIdError(ValueError):
+    """Raised when sign_state is called without a real user_id to bind
+    the OAuth flow to. Surfaces to /google/auth as a 400 so the
+    frontend can prompt the user to sign in first instead of letting
+    PostgREST 500 on the `UUID NOT NULL` constraint."""
+
+
 def _consume_nonce(nonce: str) -> bool:
     """Atomically claim a nonce. Returns True if the row existed (we
     just deleted it; valid first-use), False if it didn't (replay or
@@ -117,7 +124,17 @@ def _consume_nonce(nonce: str) -> bool:
 
 
 def sign_state(user_id: str) -> str:
-    """Mint an HMAC-signed, nonce-protected `state` value for the auth URL."""
+    """Mint an HMAC-signed, nonce-protected `state` value for the auth URL.
+
+    `user_id` must be a non-empty UUID string — the persistent nonce row
+    has a `UUID NOT NULL` column, and there's no semantically meaningful
+    OAuth flow without a real user to attribute the token to. Single-user
+    deployments with an empty users table hit this branch; the caller
+    should propagate it as a 400 so the frontend prompts for sign-in
+    instead of silently 500-ing on the constraint.
+    """
+    if not user_id:
+        raise InvalidUserIdError("sign_state requires a non-empty user_id")
     now = int(time.time())
     nonce = _issue_nonce(user_id)
     payload = json.dumps(

--- a/backend/app/services/integrations/google/oauth_state.py
+++ b/backend/app/services/integrations/google/oauth_state.py
@@ -14,45 +14,48 @@ What we do now
 - `state = base64url(payload).base64url(hmac)` where payload is a tiny
   JSON object `{u: user_id, n: nonce, e: exp_unix}` and hmac is computed
   with SECRET_KEY.
-- Nonce is a 16-byte random token. We track issued nonces in a
-  process-local set so each one is single-use; a captured state can't
-  be replayed within its (10 min) window.
+- Nonce is a random token. We persist issued nonces in the Supabase
+  `oauth_state_nonces` table so each one is single-use AND the mint
+  and verify can land on different gunicorn workers — the in-process
+  dict version of this module deadlocked multi-worker deployments.
 - Verification checks: HMAC integrity, exp not in the past, nonce was
-  issued by THIS process AND hasn't been consumed yet. If any of those
-  fail we treat the callback as adversarial and refuse the exchange.
+  issued by us AND hasn't been consumed yet (atomic DELETE...RETURNING
+  in Supabase). If any of those fail we treat the callback as
+  adversarial and refuse the exchange.
 
 Server-restart behaviour
 ------------------------
-The nonce set lives in memory. On Coolify redeploy / proxy bounce / OOM
-the set is empty, so OAuth flows that started before the restart and
-finished after will hard-fail verification. The user just clicks
-Connect again. We considered persisting nonces in Supabase but the
-restart window is short and the failure mode is graceful (retry).
+Persistent storage means OAuth flows that straddle a deploy/restart
+still verify cleanly — the nonce row outlives any single process. Rows
+older than the 10-minute TTL are pruned opportunistically on each
+`sign_state()` call so the table self-cleans.
 """
 import base64
 import hashlib
 import hmac
 import json
+import logging
 import os
 import secrets
-import threading
 import time
 from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
 
 # 10 minutes — the gap between minting the URL and the user clicking
 # Allow in Google's consent screen. Longer windows widen the replay
 # surface; shorter windows kick out users who think before clicking.
 STATE_TTL_SECONDS = 600
 
-# Cap how many nonces we'll remember to bound memory. At one flow per
-# user per ~minute this would take ~5h of sustained traffic to fill;
-# the periodic prune below keeps real-world usage well below this.
-_NONCE_CAP = 4096
+_TABLE = "oauth_state_nonces"
 
-_nonce_lock = threading.Lock()
-# nonce -> issued_at unix timestamp. We remove on use (single-use) and
-# prune expired entries on every read so the set self-cleans.
-_issued_nonces: dict[str, int] = {}
+
+def _supabase():
+    """Lazy import so importing this module at app boot doesn't pull
+    the whole supabase package (avoids a circular init in tests)."""
+    from app.services.integrations.supabase import get_supabase
+    return get_supabase()
 
 
 def _secret_key_bytes() -> bytes:
@@ -72,28 +75,51 @@ def _b64url_decode(s: str) -> bytes:
     return base64.urlsafe_b64decode(s + ("=" * pad))
 
 
-def _prune_expired(now: int) -> None:
-    """Drop nonces past their TTL. Cheap enough to run on every issue/check."""
-    expired = [n for n, t in _issued_nonces.items() if now - t > STATE_TTL_SECONDS]
-    for n in expired:
-        _issued_nonces.pop(n, None)
+def _prune_expired() -> None:
+    """Best-effort cleanup of stale nonces. Runs on every issue so the
+    table self-cleans without a separate cron. Errors are swallowed
+    because pruning is a tidiness concern, not a correctness one."""
+    cutoff = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ",
+        time.gmtime(time.time() - STATE_TTL_SECONDS),
+    )
+    try:
+        _supabase().table(_TABLE).delete().lt("created_at", cutoff).execute()
+    except Exception as exc:
+        logger.warning("oauth nonce prune failed (non-fatal): %s", exc)
+
+
+def _issue_nonce(user_id: str) -> str:
+    """Mint a fresh nonce and persist it. Caller signs the resulting
+    payload immediately so we don't carry per-mint state in process."""
+    nonce = secrets.token_urlsafe(18)
+    _supabase().table(_TABLE).insert(
+        {"nonce": nonce, "user_id": user_id}
+    ).execute()
+    _prune_expired()
+    return nonce
+
+
+def _consume_nonce(nonce: str) -> bool:
+    """Atomically claim a nonce. Returns True if the row existed (we
+    just deleted it; valid first-use), False if it didn't (replay or
+    unknown). Postgres DELETE...RETURNING via PostgREST returns the
+    deleted rows in `response.data` — empty list means no match."""
+    response = (
+        _supabase()
+        .table(_TABLE)
+        .delete()
+        .eq("nonce", nonce)
+        .execute()
+    )
+    rows = response.data or []
+    return bool(rows)
 
 
 def sign_state(user_id: str) -> str:
     """Mint an HMAC-signed, nonce-protected `state` value for the auth URL."""
     now = int(time.time())
-    nonce = secrets.token_urlsafe(12)
-
-    with _nonce_lock:
-        _prune_expired(now)
-        # Hard cap. Drop the oldest to make room rather than fail issuance
-        # — under attack we'd rather rotate old in-flight flows than reject
-        # legitimate users who happen to click Connect during a flood.
-        if len(_issued_nonces) >= _NONCE_CAP:
-            oldest = sorted(_issued_nonces.items(), key=lambda kv: kv[1])[0][0]
-            _issued_nonces.pop(oldest, None)
-        _issued_nonces[nonce] = now
-
+    nonce = _issue_nonce(user_id)
     payload = json.dumps(
         {"u": user_id, "n": nonce, "e": now + STATE_TTL_SECONDS},
         separators=(",", ":"),
@@ -138,13 +164,16 @@ def verify_state(state: Optional[str]) -> Tuple[bool, Optional[str], Optional[st
     if now > exp:
         return False, None, "state expired"
 
-    # Single-use: pop the nonce. If it isn't in the set, the state was
-    # either replayed, minted by a since-restarted process, or never
-    # issued by us at all — all three are rejection cases.
-    with _nonce_lock:
-        _prune_expired(now)
-        if nonce not in _issued_nonces:
-            return False, None, "state replayed or unknown"
-        _issued_nonces.pop(nonce, None)
+    # Atomic single-use claim via Postgres DELETE. If no row was
+    # deleted, the nonce was either replayed, expired and pruned, or
+    # never issued by us — all three are rejection cases.
+    try:
+        consumed = _consume_nonce(nonce)
+    except Exception as exc:
+        logger.warning("oauth nonce consume failed: %s", exc)
+        return False, None, "state store unavailable"
+
+    if not consumed:
+        return False, None, "state replayed or unknown"
 
     return True, user_id, None

--- a/backend/app/services/integrations/google/oauth_state.py
+++ b/backend/app/services/integrations/google/oauth_state.py
@@ -1,0 +1,150 @@
+"""
+Signed OAuth `state` parameter for the Google Drive flow.
+
+Why this exists
+---------------
+Before this module, `state` was just the raw `user_id` string. That made
+the callback trivially CSRF-able: an attacker who knew (or guessed) the
+target user's UUID could land them on a Google OAuth URL whose callback
+stored the *attacker's* refresh token under the *victim's* row. RFC 6749
+§10.12 says don't do that.
+
+What we do now
+--------------
+- `state = base64url(payload).base64url(hmac)` where payload is a tiny
+  JSON object `{u: user_id, n: nonce, e: exp_unix}` and hmac is computed
+  with SECRET_KEY.
+- Nonce is a 16-byte random token. We track issued nonces in a
+  process-local set so each one is single-use; a captured state can't
+  be replayed within its (10 min) window.
+- Verification checks: HMAC integrity, exp not in the past, nonce was
+  issued by THIS process AND hasn't been consumed yet. If any of those
+  fail we treat the callback as adversarial and refuse the exchange.
+
+Server-restart behaviour
+------------------------
+The nonce set lives in memory. On Coolify redeploy / proxy bounce / OOM
+the set is empty, so OAuth flows that started before the restart and
+finished after will hard-fail verification. The user just clicks
+Connect again. We considered persisting nonces in Supabase but the
+restart window is short and the failure mode is graceful (retry).
+"""
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import threading
+import time
+from typing import Optional, Tuple
+
+# 10 minutes — the gap between minting the URL and the user clicking
+# Allow in Google's consent screen. Longer windows widen the replay
+# surface; shorter windows kick out users who think before clicking.
+STATE_TTL_SECONDS = 600
+
+# Cap how many nonces we'll remember to bound memory. At one flow per
+# user per ~minute this would take ~5h of sustained traffic to fill;
+# the periodic prune below keeps real-world usage well below this.
+_NONCE_CAP = 4096
+
+_nonce_lock = threading.Lock()
+# nonce -> issued_at unix timestamp. We remove on use (single-use) and
+# prune expired entries on every read so the set self-cleans.
+_issued_nonces: dict[str, int] = {}
+
+
+def _secret_key_bytes() -> bytes:
+    """SECRET_KEY from env, encoded for HMAC. Falls back to the dev
+    placeholder so unit tests work without a configured environment;
+    production config rejects boot without SECRET_KEY set."""
+    return os.getenv("SECRET_KEY", "dev-secret-key-change-in-production").encode("utf-8")
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    # Re-pad before decoding — urlsafe_b64decode requires correct '=' padding.
+    pad = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * pad))
+
+
+def _prune_expired(now: int) -> None:
+    """Drop nonces past their TTL. Cheap enough to run on every issue/check."""
+    expired = [n for n, t in _issued_nonces.items() if now - t > STATE_TTL_SECONDS]
+    for n in expired:
+        _issued_nonces.pop(n, None)
+
+
+def sign_state(user_id: str) -> str:
+    """Mint an HMAC-signed, nonce-protected `state` value for the auth URL."""
+    now = int(time.time())
+    nonce = secrets.token_urlsafe(12)
+
+    with _nonce_lock:
+        _prune_expired(now)
+        # Hard cap. Drop the oldest to make room rather than fail issuance
+        # — under attack we'd rather rotate old in-flight flows than reject
+        # legitimate users who happen to click Connect during a flood.
+        if len(_issued_nonces) >= _NONCE_CAP:
+            oldest = sorted(_issued_nonces.items(), key=lambda kv: kv[1])[0][0]
+            _issued_nonces.pop(oldest, None)
+        _issued_nonces[nonce] = now
+
+    payload = json.dumps(
+        {"u": user_id, "n": nonce, "e": now + STATE_TTL_SECONDS},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    sig = hmac.new(_secret_key_bytes(), payload, hashlib.sha256).digest()
+    return f"{_b64url_encode(payload)}.{_b64url_encode(sig)}"
+
+
+def verify_state(state: Optional[str]) -> Tuple[bool, Optional[str], Optional[str]]:
+    """Return (ok, user_id, error_reason).
+
+    Errors are short, non-leaky strings safe to surface to the user via
+    the callback page. The caller logs the full reason on the server
+    side already.
+    """
+    if not state or "." not in state:
+        return False, None, "missing or malformed state"
+
+    try:
+        payload_b64, sig_b64 = state.split(".", 1)
+        payload_raw = _b64url_decode(payload_b64)
+        sig = _b64url_decode(sig_b64)
+    except Exception:
+        return False, None, "malformed state encoding"
+
+    expected_sig = hmac.new(_secret_key_bytes(), payload_raw, hashlib.sha256).digest()
+    if not hmac.compare_digest(expected_sig, sig):
+        return False, None, "state signature mismatch"
+
+    try:
+        payload = json.loads(payload_raw.decode("utf-8"))
+    except Exception:
+        return False, None, "state payload not json"
+
+    user_id = payload.get("u")
+    nonce = payload.get("n")
+    exp = payload.get("e")
+    if not isinstance(user_id, str) or not isinstance(nonce, str) or not isinstance(exp, int):
+        return False, None, "state payload incomplete"
+
+    now = int(time.time())
+    if now > exp:
+        return False, None, "state expired"
+
+    # Single-use: pop the nonce. If it isn't in the set, the state was
+    # either replayed, minted by a since-restarted process, or never
+    # issued by us at all — all three are rejection cases.
+    with _nonce_lock:
+        _prune_expired(now)
+        if nonce not in _issued_nonces:
+            return False, None, "state replayed or unknown"
+        _issued_nonces.pop(nonce, None)
+
+    return True, user_id, None

--- a/backend/supabase/migrations/00040_revoke_freshdesk_rpc_from_anon.sql
+++ b/backend/supabase/migrations/00040_revoke_freshdesk_rpc_from_anon.sql
@@ -1,0 +1,13 @@
+-- Migration: defense-in-depth revoke of exec_freshdesk_query from anon.
+-- Created: 2026-05-16
+--
+-- Migration 00037 revoked from authenticated, authenticator, and PUBLIC
+-- but missed the `anon` role. The function is SECURITY INVOKER so any
+-- inner SELECT would still hit the post-PR-2 RLS policies (all
+-- TO authenticated) and get denied on database_connections /
+-- mcp_connections. That makes anon's access *bounded* but not *zero* —
+-- freshdesk_tickets itself doesn't have RLS today, so an attacker
+-- pivoting through anon could still exfil tickets if they ever found
+-- another way to invoke the RPC. Closing the cleanest possible gate.
+
+REVOKE EXECUTE ON FUNCTION public.exec_freshdesk_query(text) FROM anon;

--- a/backend/supabase/migrations/00041_oauth_state_nonces.sql
+++ b/backend/supabase/migrations/00041_oauth_state_nonces.sql
@@ -1,0 +1,32 @@
+-- Migration: oauth_state_nonces — single-use nonces for the signed OAuth
+-- `state` parameter.
+-- Created: 2026-05-16
+--
+-- The nonce protects against state replay: the worker that mints the
+-- auth URL inserts a row; the callback DELETEs by primary key and
+-- treats "0 rows affected" as a replay/unknown rejection. Persisting
+-- in Supabase (instead of an in-process dict) means the mint and the
+-- verify can land on different gunicorn workers without one losing
+-- the other's state.
+--
+-- RLS enabled with no policies means only the service-role JWT can
+-- read/write this table — exactly what we want: the backend (which
+-- uses service_role) handles the mint and verify; no authenticated or
+-- anon caller has any business touching this table directly.
+
+CREATE TABLE IF NOT EXISTS oauth_state_nonces (
+  nonce      TEXT PRIMARY KEY,
+  user_id    UUID NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Supports the periodic prune query.
+CREATE INDEX IF NOT EXISTS oauth_state_nonces_created_idx
+  ON oauth_state_nonces (created_at);
+
+ALTER TABLE oauth_state_nonces ENABLE ROW LEVEL SECURITY;
+-- Intentionally no policies: RLS-on without policies denies all
+-- access except service_role, which bypasses RLS by design.
+
+COMMENT ON TABLE oauth_state_nonces IS
+  'Single-use nonces issued for the HMAC-signed Google OAuth `state` parameter. Deleted on first successful verify_state(). Rows older than the 10-minute TTL are pruned opportunistically by sign_state().';

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -159,6 +159,13 @@ if [ ! -f "$SUPABASE_ENV" ]; then
     LOGFLARE_PUBLIC=$(generate_hex 24)
     LOGFLARE_PRIVATE=$(generate_hex 24)
     POOLER_TENANT_ID=$(generate_hex 8)
+    # MinIO root credentials. The vendored compose file ships with
+    # `supabase / supabase123` defaults — fine for the upstream demo
+    # but a footgun if a self-hoster ever exposes 9000/9001 publicly.
+    # Generating fresh creds on first run makes those defaults
+    # irrelevant even when ports drift to 0.0.0.0.
+    MINIO_ROOT_USER="noobbook_$(generate_hex 4)"
+    MINIO_ROOT_PASSWORD=$(generate_password)
 
     ANON_KEY=$(generate_jwt "anon" "$JWT_SECRET")
     SERVICE_ROLE_KEY=$(generate_jwt "service_role" "$JWT_SECRET")
@@ -178,6 +185,8 @@ if [ ! -f "$SUPABASE_ENV" ]; then
     replace_env_var "$SUPABASE_ENV" "LOGFLARE_PUBLIC_ACCESS_TOKEN" "$LOGFLARE_PUBLIC"
     replace_env_var "$SUPABASE_ENV" "LOGFLARE_PRIVATE_ACCESS_TOKEN" "$LOGFLARE_PRIVATE"
     replace_env_var "$SUPABASE_ENV" "POOLER_TENANT_ID" "$POOLER_TENANT_ID"
+    replace_env_var "$SUPABASE_ENV" "MINIO_ROOT_USER" "$MINIO_ROOT_USER"
+    replace_env_var "$SUPABASE_ENV" "MINIO_ROOT_PASSWORD" "$MINIO_ROOT_PASSWORD"
 
     success "Supabase .env created with generated secrets"
 else

--- a/docker/supabase/docker-compose.yml
+++ b/docker/supabase/docker-compose.yml
@@ -479,9 +479,18 @@ services:
     container_name: supabase-minio
     image: minio/minio:RELEASE.2024-01-16T16-07-38Z
     restart: unless-stopped
+    # Bind to localhost only — MinIO is an internal storage backend for
+    # imgproxy and is not part of the public API surface. Exposing on
+    # 0.0.0.0 with the default `supabase / supabase123` credentials let
+    # anyone on the box's network reach the admin console; binding to
+    # 127.0.0.1 keeps the ports reachable from same-host services
+    # (imgproxy via the docker network still works since it uses the
+    # internal `minio` DNS name, not the host port mapping). The fallback
+    # defaults in the env vars below are still considered insecure and
+    # docker/setup.sh regenerates real values into .env on first run.
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     volumes:
       - ./volumes/minio/data:/data
     environment:


### PR DESCRIPTION
## Summary

Three small preventative hardening changes:

- **Sign OAuth state** — replaces the raw `user_id` state parameter with an HMAC-signed payload that includes a single-use nonce and a 10-minute expiry. The callback verifies the signature, checks the nonce hasn't been consumed, and refuses to exchange the code otherwise. Closes the standard RFC 6749 §10.12 CSRF where someone tricks a victim into landing on an OAuth URL that attaches the attacker's account to the victim's row.
- **Bind MinIO to localhost** — the vendored Supabase compose published `9000`/`9001` on `0.0.0.0` with defaults `supabase / supabase123`. Ports now bind to `127.0.0.1` (imgproxy still reaches MinIO via the internal docker network); `setup.sh` regenerates `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` on first run alongside the other generated secrets.
- **Revoke freshdesk RPC from anon** — `00037` revoked from `authenticated, authenticator, PUBLIC` but missed the `anon` role. One-line migration closes the cleanest possible gate (`00040`).

## Verification

- Unit-tested `oauth_state.py`: happy path / replay / tampered signature / missing / malformed / unknown nonce all behave correctly.
- Backend `py_compile` clean.
- No new dependencies.

## Test plan

- [ ] Migration `00040` applies cleanly on prod
- [ ] Trigger a Google Drive Connect flow → completes successfully
- [ ] Try to replay the same callback URL → backend rejects (the popup shows "Invalid sign-in request")
- [ ] Self-hoster runs setup.sh on a fresh checkout — `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` are unique per install
- [ ] `docker port supabase-minio` shows `127.0.0.1:9000` / `127.0.0.1:9001` (not `0.0.0.0`)