### PR TITLE
feat(chat): auto-check project DB sources on new chat (Sno 40 / #247)

### DIFF
--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -18,6 +18,11 @@ from app.services.integrations.supabase import get_supabase, is_supabase_enabled
 
 logger = logging.getLogger(__name__)
 
+# Source types that represent live data connectors ("DB sources").
+# New chats start with these auto-selected so users don't have to toggle
+# them on every time (roadmap Sno 40 / GH #247).
+DB_SOURCE_TYPES = ("DATABASE", "CSV", "FRESHDESK", "JIRA", "MIXPANEL", "MCP")
+
 
 class ChatService:
     """
@@ -153,6 +158,35 @@ class ChatService:
             text = str(content) if content else ""
         return bool(text.strip())
 
+    def _default_source_ids(self, project_id: str) -> Optional[List[str]]:
+        """
+        Resolve the source IDs to pre-select on a freshly created chat.
+
+        We auto-check every ready, globally-active DB-type source (DATABASE,
+        CSV, FRESHDESK, JIRA, MIXPANEL, MCP) so users don't have to toggle
+        them every time they start a new chat (roadmap Sno 40 / GH #247).
+
+        Returns None when the project has no DB-type sources, which keeps
+        the legacy `selected_source_ids IS NULL` fallback semantics (use all
+        active sources) intact for projects that only have documents/links.
+        """
+        try:
+            response = (
+                self.supabase.table("sources")
+                .select("id")
+                .eq("project_id", project_id)
+                .in_("type", list(DB_SOURCE_TYPES))
+                .eq("status", "ready")
+                .eq("is_active", True)
+                .execute()
+            )
+        except Exception as exc:
+            logger.warning("Failed to load default DB sources for %s: %s", project_id, exc)
+            return None
+
+        ids = [row["id"] for row in (response.data or []) if row.get("id")]
+        return ids if ids else None
+
     def create_chat(self, project_id: str, title: str = "New Chat") -> Dict[str, Any]:
         """
         Create a new chat in a project.
@@ -171,6 +205,10 @@ class ChatService:
             "project_id": project_id,
             "title": title
         }
+
+        default_source_ids = self._default_source_ids(project_id)
+        if default_source_ids is not None:
+            chat_data["selected_source_ids"] = default_source_ids
 
         response = (
             self.supabase.table(self.table)

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -187,7 +187,12 @@ class ChatService:
         ids = [row["id"] for row in (response.data or []) if row.get("id")]
         return ids if ids else None
 
-    def create_chat(self, project_id: str, title: str = "New Chat") -> Dict[str, Any]:
+    def create_chat(
+        self,
+        project_id: str,
+        title: str = "New Chat",
+        seed_default_sources: bool = True,
+    ) -> Dict[str, Any]:
         """
         Create a new chat in a project.
 
@@ -197,6 +202,13 @@ class ChatService:
         Args:
             project_id: The project UUID
             title: Initial chat title
+            seed_default_sources: When True (default — user-initiated chats),
+                pre-select the project's DB-type sources so the user doesn't
+                have to toggle them on (Sno 40 / #247). When False (programmatic
+                callers like insight refreshes), leave `selected_source_ids`
+                NULL so the context loader falls back to "all active sources" —
+                preserving legacy behavior for content that lives outside the
+                DB-source allowlist (PDFs, links, audio, etc.).
 
         Returns:
             Created chat metadata
@@ -206,9 +218,10 @@ class ChatService:
             "title": title
         }
 
-        default_source_ids = self._default_source_ids(project_id)
-        if default_source_ids is not None:
-            chat_data["selected_source_ids"] = default_source_ids
+        if seed_default_sources:
+            default_source_ids = self._default_source_ids(project_id)
+            if default_source_ids is not None:
+                chat_data["selected_source_ids"] = default_source_ids
 
         response = (
             self.supabase.table(self.table)

--- a/backend/app/services/data_services/insight_service.py
+++ b/backend/app/services/data_services/insight_service.py
@@ -264,9 +264,14 @@ class InsightService:
                     # refresh is better than failing the insight forever.
                     chat_id = None
             if not chat_id:
+                # seed_default_sources=False so a legacy insight whose
+                # original chat searched all active sources doesn't suddenly
+                # get filtered to DB-only on its first post-deploy refresh
+                # (Sno 40 / #247 — auto-seed is only for user-initiated chats).
                 chat = chat_service.create_chat(
                     project_id,
                     title=insight["title"][:50] or "Saved insight",
+                    seed_default_sources=False,
                 )
                 chat_id = chat["id"]
                 self.supabase.table(self.TABLE).update({"chat_id": chat_id}).eq(

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -981,7 +981,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       const newChat = await chatsAPI.createChat(projectId, 'New Chat');
       setAllChats((prev) => [newChat, ...prev]);
       await loadFullChat(newChat.id);
-      // New chats start with no sources selected (loadFullChat will call onActiveChatChange)
+      // Backend pre-seeds selected_source_ids with the project's DB-type
+      // sources on chat create (Sno 40 / #247); loadFullChat fetches that
+      // selection and notifies parents via onActiveChatChange.
       setShowChatList(false);
       success('New chat created');
     } catch (err) {


### PR DESCRIPTION
## Summary
- New chats now start with every ready, globally-active DB-type source (`DATABASE`, `CSV`, `FRESHDESK`, `JIRA`, `MIXPANEL`, `MCP`) pre-selected — users no longer have to toggle them on at the start of every conversation.
- `chat_service.create_chat()` resolves the default set via a new `_default_source_ids()` helper that queries `sources` filtered by `type IN DB_SOURCE_TYPES`, `status = 'ready'`, `is_active = true`.
- Projects with **no** DB-type sources keep the legacy `selected_source_ids IS NULL` fallback (use all active sources via `context_loader.py`), so document/link-only projects are unaffected.

## How it works
1. Frontend `handleNewChat()` calls `POST /projects/{id}/chats` (unchanged payload — just `{ title }`).
2. Backend seeds `selected_source_ids` with the project's DB-type sources at insert time.
3. Frontend `loadFullChat()` immediately fetches the new chat and propagates `selected_source_ids` to `SourcesPanel` via `onActiveChatChange`, so the right checkboxes are ticked from the first render.

## Safety
- Query failure → logged + falls back to NULL (no chat-creation regression).
- Per-chat overrides still work — user toggles persist to `selected_source_ids` as before.
- No schema migration, no new UI, no breaking change to API surface.

Closes #247
Roadmap: Sno 40 (last open item from #256)

## Test plan
- [ ] Create a new chat in a project with at least one DATABASE source → DB source is checked by default.
- [ ] Create a new chat in a project with mixed sources (DB + PDF) → only the DB sources are checked.
- [ ] Create a new chat in a project with only PDFs → behaves as before (NULL fallback → all active sources usable by search).
- [ ] Toggle a DB source off in a new chat → state persists across reloads (per-chat override still works).
- [ ] Run backend `pytest` — no existing tests cover `create_chat`, but confirm nothing else regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)