### PR TITLE
Release: develop → main (#279 DB-source auto-seed + #278 OAuth/MinIO/Freshdesk hardening)

### DIFF
--- a/backend/app/api/google/oauth.py
+++ b/backend/app/api/google/oauth.py
@@ -31,6 +31,7 @@ from typing import Optional
 from flask import jsonify, request, current_app, make_response
 from app.api.google import google_bp
 from app.services.integrations.google import google_auth_service
+from app.services.integrations.google.oauth_state import verify_state
 from app.services.auth.rbac import get_request_identity
 
 
@@ -235,9 +236,16 @@ def google_callback():
         if not code:
             return _render_callback_page('error', 'No authorization code')
 
-        # Get user_id from state parameter (for multi-user support)
-        # State was set in get_auth_url() to identify which user initiated OAuth
-        user_id = request.args.get('state') or None
+        # Verify the HMAC-signed state. Failures here mean the request
+        # didn't come from a flow we minted — treat as adversarial and
+        # bail before exchanging the code (otherwise we'd happily link
+        # the attacker's Google account to whatever user_id they put in
+        # the raw state). Replay protection is built into verify_state.
+        raw_state = request.args.get('state') or None
+        state_ok, user_id, state_err = verify_state(raw_state)
+        if not state_ok:
+            current_app.logger.warning("Google OAuth rejected: %s", state_err)
+            return _render_callback_page('error', 'Invalid sign-in request')
 
         # Exchange code for tokens, passing user_id for storage
         success, message = google_auth_service.handle_callback(code, user_id=user_id)

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -18,6 +18,11 @@ from app.services.integrations.supabase import get_supabase, is_supabase_enabled
 
 logger = logging.getLogger(__name__)
 
+# Source types that represent live data connectors ("DB sources").
+# New chats start with these auto-selected so users don't have to toggle
+# them on every time (roadmap Sno 40 / GH #247).
+DB_SOURCE_TYPES = ("DATABASE", "CSV", "FRESHDESK", "JIRA", "MIXPANEL", "MCP")
+
 
 class ChatService:
     """
@@ -153,7 +158,41 @@ class ChatService:
             text = str(content) if content else ""
         return bool(text.strip())
 
-    def create_chat(self, project_id: str, title: str = "New Chat") -> Dict[str, Any]:
+    def _default_source_ids(self, project_id: str) -> Optional[List[str]]:
+        """
+        Resolve the source IDs to pre-select on a freshly created chat.
+
+        We auto-check every ready, globally-active DB-type source (DATABASE,
+        CSV, FRESHDESK, JIRA, MIXPANEL, MCP) so users don't have to toggle
+        them every time they start a new chat (roadmap Sno 40 / GH #247).
+
+        Returns None when the project has no DB-type sources, which keeps
+        the legacy `selected_source_ids IS NULL` fallback semantics (use all
+        active sources) intact for projects that only have documents/links.
+        """
+        try:
+            response = (
+                self.supabase.table("sources")
+                .select("id")
+                .eq("project_id", project_id)
+                .in_("type", list(DB_SOURCE_TYPES))
+                .eq("status", "ready")
+                .eq("is_active", True)
+                .execute()
+            )
+        except Exception as exc:
+            logger.warning("Failed to load default DB sources for %s: %s", project_id, exc)
+            return None
+
+        ids = [row["id"] for row in (response.data or []) if row.get("id")]
+        return ids if ids else None
+
+    def create_chat(
+        self,
+        project_id: str,
+        title: str = "New Chat",
+        seed_default_sources: bool = True,
+    ) -> Dict[str, Any]:
         """
         Create a new chat in a project.
 
@@ -163,6 +202,13 @@ class ChatService:
         Args:
             project_id: The project UUID
             title: Initial chat title
+            seed_default_sources: When True (default — user-initiated chats),
+                pre-select the project's DB-type sources so the user doesn't
+                have to toggle them on (Sno 40 / #247). When False (programmatic
+                callers like insight refreshes), leave `selected_source_ids`
+                NULL so the context loader falls back to "all active sources" —
+                preserving legacy behavior for content that lives outside the
+                DB-source allowlist (PDFs, links, audio, etc.).
 
         Returns:
             Created chat metadata
@@ -171,6 +217,11 @@ class ChatService:
             "project_id": project_id,
             "title": title
         }
+
+        if seed_default_sources:
+            default_source_ids = self._default_source_ids(project_id)
+            if default_source_ids is not None:
+                chat_data["selected_source_ids"] = default_source_ids
 
         response = (
             self.supabase.table(self.table)

--- a/backend/app/services/data_services/insight_service.py
+++ b/backend/app/services/data_services/insight_service.py
@@ -264,9 +264,14 @@ class InsightService:
                     # refresh is better than failing the insight forever.
                     chat_id = None
             if not chat_id:
+                # seed_default_sources=False so a legacy insight whose
+                # original chat searched all active sources doesn't suddenly
+                # get filtered to DB-only on its first post-deploy refresh
+                # (Sno 40 / #247 — auto-seed is only for user-initiated chats).
                 chat = chat_service.create_chat(
                     project_id,
                     title=insight["title"][:50] or "Saved insight",
+                    seed_default_sources=False,
                 )
                 chat_id = chat["id"]
                 self.supabase.table(self.TABLE).update({"chat_id": chat_id}).eq(

--- a/backend/app/services/integrations/google/google_auth_service.py
+++ b/backend/app/services/integrations/google/google_auth_service.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 from google_auth_oauthlib.flow import Flow
 from google.auth.transport.requests import Request
 
+from app.services.integrations.google.oauth_state import sign_state
 from app.services.integrations.supabase import get_supabase
 
 
@@ -214,6 +215,13 @@ class GoogleAuthService:
         # Use provided user_id or get default for single-user mode
         effective_user_id = user_id or self._get_default_user_id()
 
+        # Refuse to mint a flow with no user attached. sign_state would
+        # reject anyway (its UUID column is NOT NULL); returning None
+        # here lets the route surface a clean 400 instead of a 500.
+        if not effective_user_id:
+            logger.warning("get_auth_url called with no user_id (no default user)")
+            return None
+
         flow = Flow.from_client_config(
             client_config,
             scopes=self.SCOPES,
@@ -223,12 +231,16 @@ class GoogleAuthService:
         # Generate auth URL
         # access_type='offline' ensures we get a refresh token
         # prompt='consent' forces consent screen to ensure refresh token
-        # state parameter carries user_id for the callback
+        # state is HMAC-signed + nonce-protected so the callback can
+        # verify it really came from a flow WE started (no CSRF where
+        # someone tricks a victim into pasting an OAuth URL that links
+        # the attacker's Google account to the victim's row).
+        signed_state = sign_state(effective_user_id)
         auth_url, _ = flow.authorization_url(
             access_type='offline',
             prompt='consent',
             include_granted_scopes='true',
-            state=effective_user_id or ''  # Pass user_id in state for callback
+            state=signed_state,
         )
 
         return auth_url

--- a/backend/app/services/integrations/google/oauth_state.py
+++ b/backend/app/services/integrations/google/oauth_state.py
@@ -1,0 +1,196 @@
+"""
+Signed OAuth `state` parameter for the Google Drive flow.
+
+Why this exists
+---------------
+Before this module, `state` was just the raw `user_id` string. That made
+the callback trivially CSRF-able: an attacker who knew (or guessed) the
+target user's UUID could land them on a Google OAuth URL whose callback
+stored the *attacker's* refresh token under the *victim's* row. RFC 6749
+§10.12 says don't do that.
+
+What we do now
+--------------
+- `state = base64url(payload).base64url(hmac)` where payload is a tiny
+  JSON object `{u: user_id, n: nonce, e: exp_unix}` and hmac is computed
+  with SECRET_KEY.
+- Nonce is a random token. We persist issued nonces in the Supabase
+  `oauth_state_nonces` table so each one is single-use AND the mint
+  and verify can land on different gunicorn workers — the in-process
+  dict version of this module deadlocked multi-worker deployments.
+- Verification checks: HMAC integrity, exp not in the past, nonce was
+  issued by us AND hasn't been consumed yet (atomic DELETE...RETURNING
+  in Supabase). If any of those fail we treat the callback as
+  adversarial and refuse the exchange.
+
+Server-restart behaviour
+------------------------
+Persistent storage means OAuth flows that straddle a deploy/restart
+still verify cleanly — the nonce row outlives any single process. Rows
+older than the 10-minute TTL are pruned opportunistically on each
+`sign_state()` call so the table self-cleans.
+"""
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+import time
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# 10 minutes — the gap between minting the URL and the user clicking
+# Allow in Google's consent screen. Longer windows widen the replay
+# surface; shorter windows kick out users who think before clicking.
+STATE_TTL_SECONDS = 600
+
+_TABLE = "oauth_state_nonces"
+
+
+def _supabase():
+    """Lazy import so importing this module at app boot doesn't pull
+    the whole supabase package (avoids a circular init in tests)."""
+    from app.services.integrations.supabase import get_supabase
+    return get_supabase()
+
+
+def _secret_key_bytes() -> bytes:
+    """SECRET_KEY from env, encoded for HMAC. Falls back to the dev
+    placeholder so unit tests work without a configured environment;
+    production config rejects boot without SECRET_KEY set."""
+    return os.getenv("SECRET_KEY", "dev-secret-key-change-in-production").encode("utf-8")
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    # Re-pad before decoding — urlsafe_b64decode requires correct '=' padding.
+    pad = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * pad))
+
+
+def _prune_expired() -> None:
+    """Best-effort cleanup of stale nonces. Runs on every issue so the
+    table self-cleans without a separate cron. Errors are swallowed
+    because pruning is a tidiness concern, not a correctness one."""
+    cutoff = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ",
+        time.gmtime(time.time() - STATE_TTL_SECONDS),
+    )
+    try:
+        _supabase().table(_TABLE).delete().lt("created_at", cutoff).execute()
+    except Exception as exc:
+        logger.warning("oauth nonce prune failed (non-fatal): %s", exc)
+
+
+def _issue_nonce(user_id: str) -> str:
+    """Mint a fresh nonce and persist it. Caller signs the resulting
+    payload immediately so we don't carry per-mint state in process."""
+    nonce = secrets.token_urlsafe(18)
+    _supabase().table(_TABLE).insert(
+        {"nonce": nonce, "user_id": user_id}
+    ).execute()
+    _prune_expired()
+    return nonce
+
+
+class InvalidUserIdError(ValueError):
+    """Raised when sign_state is called without a real user_id to bind
+    the OAuth flow to. Surfaces to /google/auth as a 400 so the
+    frontend can prompt the user to sign in first instead of letting
+    PostgREST 500 on the `UUID NOT NULL` constraint."""
+
+
+def _consume_nonce(nonce: str) -> bool:
+    """Atomically claim a nonce. Returns True if the row existed (we
+    just deleted it; valid first-use), False if it didn't (replay or
+    unknown). Postgres DELETE...RETURNING via PostgREST returns the
+    deleted rows in `response.data` — empty list means no match."""
+    response = (
+        _supabase()
+        .table(_TABLE)
+        .delete()
+        .eq("nonce", nonce)
+        .execute()
+    )
+    rows = response.data or []
+    return bool(rows)
+
+
+def sign_state(user_id: str) -> str:
+    """Mint an HMAC-signed, nonce-protected `state` value for the auth URL.
+
+    `user_id` must be a non-empty UUID string — the persistent nonce row
+    has a `UUID NOT NULL` column, and there's no semantically meaningful
+    OAuth flow without a real user to attribute the token to. Single-user
+    deployments with an empty users table hit this branch; the caller
+    should propagate it as a 400 so the frontend prompts for sign-in
+    instead of silently 500-ing on the constraint.
+    """
+    if not user_id:
+        raise InvalidUserIdError("sign_state requires a non-empty user_id")
+    now = int(time.time())
+    nonce = _issue_nonce(user_id)
+    payload = json.dumps(
+        {"u": user_id, "n": nonce, "e": now + STATE_TTL_SECONDS},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    sig = hmac.new(_secret_key_bytes(), payload, hashlib.sha256).digest()
+    return f"{_b64url_encode(payload)}.{_b64url_encode(sig)}"
+
+
+def verify_state(state: Optional[str]) -> Tuple[bool, Optional[str], Optional[str]]:
+    """Return (ok, user_id, error_reason).
+
+    Errors are short, non-leaky strings safe to surface to the user via
+    the callback page. The caller logs the full reason on the server
+    side already.
+    """
+    if not state or "." not in state:
+        return False, None, "missing or malformed state"
+
+    try:
+        payload_b64, sig_b64 = state.split(".", 1)
+        payload_raw = _b64url_decode(payload_b64)
+        sig = _b64url_decode(sig_b64)
+    except Exception:
+        return False, None, "malformed state encoding"
+
+    expected_sig = hmac.new(_secret_key_bytes(), payload_raw, hashlib.sha256).digest()
+    if not hmac.compare_digest(expected_sig, sig):
+        return False, None, "state signature mismatch"
+
+    try:
+        payload = json.loads(payload_raw.decode("utf-8"))
+    except Exception:
+        return False, None, "state payload not json"
+
+    user_id = payload.get("u")
+    nonce = payload.get("n")
+    exp = payload.get("e")
+    if not isinstance(user_id, str) or not isinstance(nonce, str) or not isinstance(exp, int):
+        return False, None, "state payload incomplete"
+
+    now = int(time.time())
+    if now > exp:
+        return False, None, "state expired"
+
+    # Atomic single-use claim via Postgres DELETE. If no row was
+    # deleted, the nonce was either replayed, expired and pruned, or
+    # never issued by us — all three are rejection cases.
+    try:
+        consumed = _consume_nonce(nonce)
+    except Exception as exc:
+        logger.warning("oauth nonce consume failed: %s", exc)
+        return False, None, "state store unavailable"
+
+    if not consumed:
+        return False, None, "state replayed or unknown"
+
+    return True, user_id, None

--- a/backend/supabase/migrations/00040_revoke_freshdesk_rpc_from_anon.sql
+++ b/backend/supabase/migrations/00040_revoke_freshdesk_rpc_from_anon.sql
@@ -1,0 +1,13 @@
+-- Migration: defense-in-depth revoke of exec_freshdesk_query from anon.
+-- Created: 2026-05-16
+--
+-- Migration 00037 revoked from authenticated, authenticator, and PUBLIC
+-- but missed the `anon` role. The function is SECURITY INVOKER so any
+-- inner SELECT would still hit the post-PR-2 RLS policies (all
+-- TO authenticated) and get denied on database_connections /
+-- mcp_connections. That makes anon's access *bounded* but not *zero* —
+-- freshdesk_tickets itself doesn't have RLS today, so an attacker
+-- pivoting through anon could still exfil tickets if they ever found
+-- another way to invoke the RPC. Closing the cleanest possible gate.
+
+REVOKE EXECUTE ON FUNCTION public.exec_freshdesk_query(text) FROM anon;

--- a/backend/supabase/migrations/00041_oauth_state_nonces.sql
+++ b/backend/supabase/migrations/00041_oauth_state_nonces.sql
@@ -1,0 +1,32 @@
+-- Migration: oauth_state_nonces — single-use nonces for the signed OAuth
+-- `state` parameter.
+-- Created: 2026-05-16
+--
+-- The nonce protects against state replay: the worker that mints the
+-- auth URL inserts a row; the callback DELETEs by primary key and
+-- treats "0 rows affected" as a replay/unknown rejection. Persisting
+-- in Supabase (instead of an in-process dict) means the mint and the
+-- verify can land on different gunicorn workers without one losing
+-- the other's state.
+--
+-- RLS enabled with no policies means only the service-role JWT can
+-- read/write this table — exactly what we want: the backend (which
+-- uses service_role) handles the mint and verify; no authenticated or
+-- anon caller has any business touching this table directly.
+
+CREATE TABLE IF NOT EXISTS oauth_state_nonces (
+  nonce      TEXT PRIMARY KEY,
+  user_id    UUID NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Supports the periodic prune query.
+CREATE INDEX IF NOT EXISTS oauth_state_nonces_created_idx
+  ON oauth_state_nonces (created_at);
+
+ALTER TABLE oauth_state_nonces ENABLE ROW LEVEL SECURITY;
+-- Intentionally no policies: RLS-on without policies denies all
+-- access except service_role, which bypasses RLS by design.
+
+COMMENT ON TABLE oauth_state_nonces IS
+  'Single-use nonces issued for the HMAC-signed Google OAuth `state` parameter. Deleted on first successful verify_state(). Rows older than the 10-minute TTL are pruned opportunistically by sign_state().';

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -159,6 +159,13 @@ if [ ! -f "$SUPABASE_ENV" ]; then
     LOGFLARE_PUBLIC=$(generate_hex 24)
     LOGFLARE_PRIVATE=$(generate_hex 24)
     POOLER_TENANT_ID=$(generate_hex 8)
+    # MinIO root credentials. The vendored compose file ships with
+    # `supabase / supabase123` defaults — fine for the upstream demo
+    # but a footgun if a self-hoster ever exposes 9000/9001 publicly.
+    # Generating fresh creds on first run makes those defaults
+    # irrelevant even when ports drift to 0.0.0.0.
+    MINIO_ROOT_USER="noobbook_$(generate_hex 4)"
+    MINIO_ROOT_PASSWORD=$(generate_password)
 
     ANON_KEY=$(generate_jwt "anon" "$JWT_SECRET")
     SERVICE_ROLE_KEY=$(generate_jwt "service_role" "$JWT_SECRET")
@@ -178,6 +185,8 @@ if [ ! -f "$SUPABASE_ENV" ]; then
     replace_env_var "$SUPABASE_ENV" "LOGFLARE_PUBLIC_ACCESS_TOKEN" "$LOGFLARE_PUBLIC"
     replace_env_var "$SUPABASE_ENV" "LOGFLARE_PRIVATE_ACCESS_TOKEN" "$LOGFLARE_PRIVATE"
     replace_env_var "$SUPABASE_ENV" "POOLER_TENANT_ID" "$POOLER_TENANT_ID"
+    replace_env_var "$SUPABASE_ENV" "MINIO_ROOT_USER" "$MINIO_ROOT_USER"
+    replace_env_var "$SUPABASE_ENV" "MINIO_ROOT_PASSWORD" "$MINIO_ROOT_PASSWORD"
 
     success "Supabase .env created with generated secrets"
 else

--- a/docker/supabase/docker-compose.yml
+++ b/docker/supabase/docker-compose.yml
@@ -479,9 +479,18 @@ services:
     container_name: supabase-minio
     image: minio/minio:RELEASE.2024-01-16T16-07-38Z
     restart: unless-stopped
+    # Bind to localhost only — MinIO is an internal storage backend for
+    # imgproxy and is not part of the public API surface. Exposing on
+    # 0.0.0.0 with the default `supabase / supabase123` credentials let
+    # anyone on the box's network reach the admin console; binding to
+    # 127.0.0.1 keeps the ports reachable from same-host services
+    # (imgproxy via the docker network still works since it uses the
+    # internal `minio` DNS name, not the host port mapping). The fallback
+    # defaults in the env vars below are still considered insecure and
+    # docker/setup.sh regenerates real values into .env on first run.
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     volumes:
       - ./volumes/minio/data:/data
     environment:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,8 @@ import { GlobalLogsModalGate } from './components/project/GlobalLogsModalGate';
 import { setAdminMode, SESSION_EXPIRED_EVENT } from './lib/adminMode';
 import { useToast } from './components/ui/use-toast';
 import { ToastContainer } from './components/ui/toast';
+import { TutorialProvider } from './contexts/TutorialContext';
+import { OnboardingTutorial } from './components/onboarding';
 
 const log = createLogger('app');
 
@@ -180,16 +182,23 @@ function ProjectWorkspaceRoute({
   // (malformed citation, missing message field, etc.) doesn't blank the
   // entire page — that was Neel's "screen goes blank, refresh fixes it" bug.
   // resetKey=projectId so navigating to a different project recovers cleanly.
+  // TutorialProvider is scoped to the workspace route so the first-run
+  // auto-open only fires when the user actually lands on a project (not on
+  // the dashboard or a /share/* viewer). OnboardingTutorial is a sibling so
+  // its absolutely-positioned popover renders on top of the workspace.
   return (
     <ErrorBoundary resetKey={projectId}>
-      <ProjectWorkspace
-        project={project}
-        onBack={() => navigate('/')}
-        onDeleteProject={handleDeleteProject}
-        onRenameProject={handleRenameProject}
-        onSignOut={isAuthenticated ? onSignOut : undefined}
-        isAdmin={isAdmin}
-      />
+      <TutorialProvider>
+        <ProjectWorkspace
+          project={project}
+          onBack={() => navigate('/')}
+          onDeleteProject={handleDeleteProject}
+          onRenameProject={handleRenameProject}
+          onSignOut={isAuthenticated ? onSignOut : undefined}
+          isAdmin={isAdmin}
+        />
+        <OnboardingTutorial />
+      </TutorialProvider>
     </ErrorBoundary>
   );
 }

--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -4,7 +4,7 @@
  * Allows quick switching between chats via dropdown menu.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -68,6 +68,20 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
 }) => {
   const { hasPermission } = usePermissions();
 
+  // Platform-aware shortcut glyph: ⌘ on Mac, Ctrl elsewhere. Memoised so the
+  // tooltip body doesn't recompute on every parent re-render. navigator.platform
+  // is deprecated; prefer userAgentData.platform (Chromium-only) with a
+  // userAgent-string fallback for Safari / Firefox.
+  const shortcutLabel = useMemo(() => {
+    if (typeof navigator === 'undefined') return 'Ctrl+⇧+O';
+    const uaDataPlatform = (
+      navigator as Navigator & { userAgentData?: { platform?: string } }
+    ).userAgentData?.platform;
+    const platformHint = uaDataPlatform || navigator.userAgent || '';
+    const isMac = /Mac|iPhone|iPad|iPod/i.test(platformHint);
+    return isMac ? '⌘⇧O' : 'Ctrl+⇧+O';
+  }, []);
+
   return (
     <div className="border-b px-4 py-3">
       {/* Title row - matches Sources/Studio/ChatEmptyState structure */}
@@ -112,6 +126,29 @@ export const ChatHeader: React.FC<ChatHeaderProps> = React.memo(({
           </DropdownMenu>
         </div>
         <div className="flex items-center gap-2">
+          {/* Prominent "New chat" button — Claude-app parity (Sno 51 / GH #254).
+              Same handler as the dropdown item below; the dropdown stays for
+              muscle memory but this is the one-click affordance. */}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="soft"
+                  size="sm"
+                  onClick={onNewChat}
+                  className="h-8 gap-1.5"
+                >
+                  <Plus size={14} weight="bold" />
+                  <span>New chat</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                New chat
+                <kbd className="ml-1.5 text-xs opacity-70">{shortcutLabel}</kbd>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
           {/* Export chat button — hidden when chat_export permission is disabled */}
           {hasPermission("chat_features", "chat_export") && (
             <TooltipProvider>

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -990,6 +990,32 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     }
   };
 
+  // Keep a ref to the latest handleNewChat so the global keydown listener
+  // (mounted once) always fires the up-to-date closure instead of capturing
+  // the first render's stale setters / toast helpers.
+  const handleNewChatRef = useRef(handleNewChat);
+  handleNewChatRef.current = handleNewChat;
+
+  // Cmd/Ctrl+Shift+O → new chat (Claude-app parity, Sno 51 / GH #254).
+  // Overrides Chrome's bookmarks-manager binding intentionally — matches
+  // Claude.app's behaviour. Only mounted while ChatPanel is rendered (i.e.
+  // inside a project workspace), so the shortcut is workspace-scoped.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        e.key.toLowerCase() === 'o'
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleNewChatRef.current();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, []);
+
   /**
    * Select a chat from the list
    */

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -981,7 +981,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       const newChat = await chatsAPI.createChat(projectId, 'New Chat');
       setAllChats((prev) => [newChat, ...prev]);
       await loadFullChat(newChat.id);
-      // New chats start with no sources selected (loadFullChat will call onActiveChatChange)
+      // Backend pre-seeds selected_source_ids with the project's DB-type
+      // sources on chat create (Sno 40 / #247); loadFullChat fetches that
+      // selection and notifies parents via onActiveChatChange.
       setShowChatList(false);
       success('New chat created');
     } catch (err) {

--- a/frontend/src/components/onboarding/OnboardingTutorial.tsx
+++ b/frontend/src/components/onboarding/OnboardingTutorial.tsx
@@ -1,0 +1,515 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { useTutorial } from '../../hooks/useTutorial';
+import { Button } from '../ui/button';
+import { X, CaretLeft, CaretRight, RocketLaunch, CheckCircle, Ghost } from '@phosphor-icons/react';
+
+interface PopoverPosition {
+  top: number;
+  left: number;
+  arrowTop: number;
+  arrowLeft: number;
+  arrowPosition: 'top' | 'bottom' | 'left' | 'right';
+}
+
+const SEEN_KEY = 'noobbook_onboarding_seen';
+const HIGHLIGHT_COLOR = '#D97706';
+
+const getFocusableElements = (container: HTMLElement | null): HTMLElement[] => {
+  if (!container) return [];
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((el) => !el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true');
+};
+
+export const OnboardingTutorial: React.FC = () => {
+  const { isOpen, currentStep, steps, nextStep, prevStep, goToStep, skipTutorial } = useTutorial();
+  const [position, setPosition] = useState<PopoverPosition | null>(null);
+  const [fallbackPosition, setFallbackPosition] = useState<{ top: number; left: number } | null>(null);
+  const [targetFound, setTargetFound] = useState(false);
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false);
+  const [anchoredReady, setAnchoredReady] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const closeConfirmRef = useRef<HTMLDivElement>(null);
+
+  const currentStepData = steps[currentStep];
+
+  // Mark tutorial as seen only when tutorial UI is actually rendered.
+  useEffect(() => {
+    if (isOpen) {
+      localStorage.setItem(SEEN_KEY, 'true');
+    }
+  }, [isOpen]);
+
+  // Calculate fallback position (bottom-right corner)
+  useEffect(() => {
+    const updateFallbackPosition = () => {
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const cardWidth = 380;
+      const cardHeight = 220;
+      
+      setFallbackPosition({
+        top: (viewportHeight - cardHeight) / 2,
+        left: (viewportWidth - cardWidth) / 2,
+      });
+    };
+    
+    updateFallbackPosition();
+    window.addEventListener('resize', updateFallbackPosition);
+    return () => window.removeEventListener('resize', updateFallbackPosition);
+  }, []);
+
+  // When target is found and position is calculated, trigger the animation
+  // by flipping anchoredReady to true after a frame
+  useEffect(() => {
+    if (targetFound && position && !anchoredReady) {
+      // Use double-rAF to ensure the browser has painted at fallback position first
+      let raf2 = 0;
+      const raf1 = requestAnimationFrame(() => {
+        raf2 = requestAnimationFrame(() => {
+          setAnchoredReady(true);
+        });
+      });
+      return () => { cancelAnimationFrame(raf1); cancelAnimationFrame(raf2); };
+    }
+  }, [targetFound, position, anchoredReady]);
+
+  const updatePosition = useCallback(() => {
+    if (!currentStepData) return;
+
+    const targetElement = document.querySelector(`[data-tour="${currentStepData.target}"]`);
+
+    if (!targetElement) {
+      setTargetFound(false);
+      setPosition(null);
+      return;
+    }
+
+    setTargetFound(true);
+    const targetRect = targetElement.getBoundingClientRect();
+    const popoverWidth = 340;
+    const popoverHeight = 220;
+    const gap = 14;
+    const arrowSize = 10;
+
+    let top = 0;
+    let left = 0;
+    let arrowTop = 0;
+    let arrowLeft = 0;
+    let arrowPosition: 'top' | 'bottom' | 'left' | 'right' = 'top';
+
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    switch (currentStepData.position) {
+      case 'top':
+        top = targetRect.top - popoverHeight - gap;
+        left = targetRect.left + (targetRect.width / 2) - (popoverWidth / 2);
+        arrowTop = popoverHeight;
+        arrowLeft = popoverWidth / 2 - arrowSize;
+        arrowPosition = 'bottom';
+        break;
+      case 'bottom':
+        top = targetRect.bottom + gap;
+        left = targetRect.left + (targetRect.width / 2) - (popoverWidth / 2);
+        arrowTop = -arrowSize;
+        arrowLeft = popoverWidth / 2 - arrowSize;
+        arrowPosition = 'top';
+        break;
+      case 'left':
+        top = targetRect.top + (targetRect.height / 2) - (popoverHeight / 2);
+        left = targetRect.left - popoverWidth - gap;
+        arrowTop = popoverHeight / 2 - arrowSize;
+        arrowLeft = popoverWidth;
+        arrowPosition = 'right';
+        break;
+      case 'right':
+        top = targetRect.top + (targetRect.height / 2) - (popoverHeight / 2);
+        left = targetRect.right + gap;
+        arrowTop = popoverHeight / 2 - arrowSize;
+        arrowLeft = -arrowSize;
+        arrowPosition = 'left';
+        break;
+    }
+
+    // Adjust if off-screen
+    if (left < 16) left = 16;
+    if (left + popoverWidth > viewportWidth - 16) left = viewportWidth - popoverWidth - 16;
+    if (top < 16) top = 16;
+    if (top + popoverHeight > viewportHeight - 16) top = viewportHeight - popoverHeight - 16;
+
+    // Recalculate arrow for horizontal positions
+    if (currentStepData.position === 'left' || currentStepData.position === 'right') {
+      const targetCenterY = targetRect.top + targetRect.height / 2;
+      arrowTop = Math.max(16, Math.min(targetCenterY - top - arrowSize, popoverHeight - arrowSize - 16));
+    }
+
+    setPosition({ top, left, arrowTop, arrowLeft, arrowPosition });
+  }, [currentStepData]);
+
+  // Update position when step changes
+  useEffect(() => {
+    if (!isOpen || !currentStepData) return;
+
+    let rafId: number | null = null;
+    const scheduleUpdate = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        updatePosition();
+      });
+    };
+
+    // Initial pass + observe DOM changes so the tutorial can anchor
+    // as soon as the target element is mounted.
+    scheduleUpdate();
+
+    const observer = new MutationObserver(() => {
+      scheduleUpdate();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    window.addEventListener('resize', scheduleUpdate);
+    window.addEventListener('scroll', scheduleUpdate, true);
+
+    return () => {
+      observer.disconnect();
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+      window.removeEventListener('resize', scheduleUpdate);
+      window.removeEventListener('scroll', scheduleUpdate, true);
+    };
+  }, [isOpen, currentStepData, updatePosition]);
+
+  // Keyboard behavior: Escape opens/closes confirmation and Tab stays inside tutorial UI.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setShowCloseConfirm((open) => !open);
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const activeContainer = showCloseConfirm ? closeConfirmRef.current : popoverRef.current;
+      const focusable = getFocusableElements(activeContainer);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      const insideContainer = !!(active && activeContainer?.contains(active));
+
+      if (event.shiftKey) {
+        if (!insideContainer || active === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (!insideContainer || active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, showCloseConfirm]);
+
+  // Keep focus in the active dialog surface.
+  useEffect(() => {
+    if (!isOpen) return;
+    const activeContainer = showCloseConfirm ? closeConfirmRef.current : popoverRef.current;
+    if (!activeContainer) return;
+
+    const rafId = requestAnimationFrame(() => {
+      const focusable = getFocusableElements(activeContainer);
+      focusable[0]?.focus();
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [isOpen, showCloseConfirm, currentStep]);
+
+  // Highlight the current target element (ring + raise above backdrop)
+  useEffect(() => {
+    if (!isOpen || !currentStepData) return;
+
+    const targetEl = document.querySelector(`[data-tour="${currentStepData.target}"]`) as HTMLElement | null;
+    if (!targetEl) return;
+
+    // Save original styles to restore on cleanup
+    const origZIndex = targetEl.style.zIndex;
+    const origPosition = targetEl.style.position;
+    const origOutline = targetEl.style.outline;
+    const origOutlineOffset = targetEl.style.outlineOffset;
+    const origBorderRadius = targetEl.style.borderRadius;
+    const computedPosition = window.getComputedStyle(targetEl).position;
+    const shouldSetRelativePosition = computedPosition === 'static';
+
+    // Apply highlight — use outline instead of box-shadow so it's not clipped by overflow:hidden
+    targetEl.style.zIndex = '9998';
+    if (shouldSetRelativePosition) {
+      targetEl.style.position = 'relative';
+    }
+    targetEl.style.outline = `3px solid ${HIGHLIGHT_COLOR}`;
+    targetEl.style.outlineOffset = '2px';
+    targetEl.style.borderRadius = '12px';
+
+    return () => {
+      targetEl.style.zIndex = origZIndex;
+      if (shouldSetRelativePosition) {
+        targetEl.style.position = origPosition;
+      }
+      targetEl.style.outline = origOutline;
+      targetEl.style.outlineOffset = origOutlineOffset;
+      targetEl.style.borderRadius = origBorderRadius;
+    };
+  }, [isOpen, currentStep, currentStepData]);
+
+  if (!isOpen) return null;
+
+  const handleNextStep = () => {
+    setAnchoredReady(false);
+    nextStep();
+  };
+
+  const handlePrevStep = () => {
+    setAnchoredReady(false);
+    prevStep();
+  };
+
+  const handleGoToStep = (step: number) => {
+    setAnchoredReady(false);
+    goToStep(step);
+  };
+
+  const progressPercent = ((currentStep + 1) / steps.length) * 100;
+
+  // Shared content renderer
+  const renderContent = () => (
+    <div
+      className="overflow-hidden"
+      style={{
+        borderRadius: '16px',
+        background: 'hsl(var(--card))',
+        border: '1px solid hsl(var(--border))',
+        boxShadow: '0 25px 50px -12px rgba(0,0,0,0.15), 0 0 0 1px rgba(0,0,0,0.03)',
+      }}
+    >
+      {/* Progress bar */}
+      <div style={{ height: 3, width: '100%', background: 'hsl(var(--muted))' }}>
+        <div
+          style={{
+            height: '100%',
+            background: 'hsl(var(--primary))',
+            width: `${progressPercent}%`,
+            transition: 'width 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+            borderRadius: '0 2px 2px 0',
+          }}
+        />
+      </div>
+
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 pt-4 pb-0">
+        <div className="flex items-center gap-2">
+          <div
+            className="flex items-center justify-center w-6 h-6 rounded-full"
+            style={{ background: 'rgba(217, 119, 6, 0.12)' }}
+          >
+            <RocketLaunch size={14} weight="fill" className="text-primary" />
+          </div>
+          <span className="text-[11px] font-semibold text-muted-foreground tracking-widest uppercase">
+            {currentStep + 1} / {steps.length}
+          </span>
+        </div>
+        <button
+          type="button"
+          aria-label="Close tutorial"
+          onClick={() => setShowCloseConfirm(true)}
+          className="flex items-center justify-center w-7 h-7 rounded-full hover:bg-muted/80 transition-colors"
+        >
+          <X size={14} className="text-muted-foreground" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div
+        className="px-5 py-4"
+        style={{ transition: 'opacity 0.2s ease, transform 0.2s ease' }}
+      >
+        <h3 className="font-semibold text-foreground mb-2 text-base">
+          {currentStepData.title}
+        </h3>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {currentStepData.content}
+        </p>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between px-5 pb-4 pt-2">
+        {currentStep === 0 ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowCloseConfirm(true)}
+          >
+            Skip
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handlePrevStep}
+            className="gap-1"
+          >
+            <CaretLeft size={14} weight="bold" />
+            Back
+          </Button>
+        )}
+
+        <div className="flex items-center gap-1.5">
+          {steps.map((_, idx) => (
+            <button
+              key={idx}
+              type="button"
+              aria-label={`Go to step ${idx + 1}: ${steps[idx].title}`}
+              onClick={() => handleGoToStep(idx)}
+              className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                idx === currentStep
+                  ? 'bg-primary' 
+                  : idx < currentStep
+                    ? 'bg-primary/50' 
+                    : 'bg-border'
+              }`}
+            />
+          ))}
+        </div>
+
+        <Button
+          size="sm"
+          onClick={handleNextStep}
+          className="gap-1.5 h-8 px-4 text-xs font-medium"
+          style={{ borderRadius: '8px' }}
+        >
+          {currentStep === steps.length - 1 ? (
+            <>
+              Finish
+              <CheckCircle size={14} weight="bold" />
+            </>
+          ) : (
+            <>
+              Next
+              <CaretRight size={14} weight="bold" />
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Backdrop — must sit BELOW the highlighted target (z-9998 via JS in
+          updatePosition) so the spotlight is visible. Greptile P1 (PR #277). */}
+      <div
+        className="fixed inset-0 z-[9997] cursor-pointer"
+        style={{
+          background: 'rgba(0, 0, 0, 0.18)',
+          backdropFilter: 'blur(1px)',
+        }}
+        onClick={() => setShowCloseConfirm(true)}
+      />
+
+      {/* Confirmation Dialog */}
+      {showCloseConfirm && (
+        <div className="fixed inset-0 z-[99999] flex items-center justify-center">
+          <div
+            className="absolute inset-0"
+            style={{ background: 'rgba(0,0,0,0.4)', backdropFilter: 'blur(2px)' }}
+            onClick={() => setShowCloseConfirm(false)}
+          />
+          <div
+            ref={closeConfirmRef}
+            className="relative mx-4 max-w-sm w-full"
+            style={{
+              background: 'hsl(var(--card))',
+              border: '1px solid hsl(var(--border))',
+              borderRadius: '16px',
+              boxShadow: '0 25px 50px -12px rgba(0,0,0,0.25)',
+            }}
+          >
+            <div className="p-6">
+              <h3 className="font-semibold text-lg mb-2">Skip the tutorial?</h3>
+              <p className="text-muted-foreground mb-6">
+                You can always restart it later from the three dot menu or project settings.
+              </p>
+              <div className="flex gap-3 justify-end">
+                <Button variant="soft" onClick={() => setShowCloseConfirm(false)}>
+                  Continue
+                </Button>
+                <Button onClick={() => {
+                  setShowCloseConfirm(false);
+                  skipTutorial();
+                }}>
+                  Skip
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Single unified tutorial dialog — slides between fallback and anchored positions */}
+      {fallbackPosition && (
+        <div
+          ref={popoverRef}
+          className={`fixed z-[9999] ${!targetFound && currentStep === 0 ? 'tutorial-scale-in' : ''}`}
+          role="dialog"
+          aria-modal="true"
+          aria-label="NoobBook onboarding tutorial"
+          style={{
+            width: targetFound && position ? 340 : 380,
+            top: targetFound && position
+              ? (anchoredReady ? position.top : fallbackPosition.top)
+              : fallbackPosition.top,
+            left: targetFound && position
+              ? (anchoredReady ? position.left : fallbackPosition.left)
+              : fallbackPosition.left,
+            transition: 'top 0.5s cubic-bezier(0.4, 0, 0.2, 1), left 0.5s cubic-bezier(0.4, 0, 0.2, 1), width 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+            willChange: 'top, left, width',
+          }}
+        >
+          {/* Ghost logo connector — points from dialog to target */}
+          {targetFound && position && (
+            <div
+              className="absolute"
+              style={{
+                zIndex: 10000,
+                top: position.arrowPosition === 'top' ? -20 
+                  : position.arrowPosition === 'bottom' ? undefined
+                  : position.arrowTop - 8,
+                bottom: position.arrowPosition === 'bottom' ? -20 : undefined,
+                left: position.arrowPosition === 'left' ? -20
+                  : position.arrowPosition === 'right' ? undefined
+                  : position.arrowLeft - 4,
+                right: position.arrowPosition === 'right' ? -20 : undefined,
+                opacity: anchoredReady ? 1 : 0,
+                transition: 'opacity 0.3s ease 0.2s',
+              }}
+            >
+              <Ghost size={18} weight="fill" color={HIGHLIGHT_COLOR} />
+            </div>
+          )}
+          {renderContent()}
+        </div>
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/onboarding/index.ts
+++ b/frontend/src/components/onboarding/index.ts
@@ -1,0 +1,1 @@
+export { OnboardingTutorial } from './OnboardingTutorial';

--- a/frontend/src/components/project/ProjectHeader.tsx
+++ b/frontend/src/components/project/ProjectHeader.tsx
@@ -28,7 +28,7 @@ import {
   CollapsibleTrigger,
 } from '../ui/collapsible';
 import { Textarea } from '../ui/textarea';
-import { ArrowLeft, DotsThreeVertical, Plus, Trash, FolderOpen, Gear, CircleNotch, CurrencyDollar, Brain, CaretDown, CaretRight, PencilSimple, SignOut } from '@phosphor-icons/react';
+import { ArrowLeft, DotsThreeVertical, Plus, Trash, FolderOpen, Gear, CircleNotch, CurrencyDollar, Brain, CaretDown, CaretRight, PencilSimple, SignOut, Compass } from '@phosphor-icons/react';
 import { Input } from '../ui/input';
 import { chatsAPI, type PromptConfig } from '../../lib/api/chats';
 import { projectsAPI, type CostTracking, type MemoryData } from '../../lib/api';
@@ -38,6 +38,7 @@ import { useToast } from '../ui/use-toast';
 import { createLogger } from '@/lib/logger';
 import { ShareButton } from './ShareButton';
 import { LogsButton } from './LogsButton';
+import { useTutorial } from '@/hooks/useTutorial';
 
 const log = createLogger('project-header');
 
@@ -70,6 +71,8 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
   onSignOut,
 }) => {
   const { toasts, dismissToast, error, success, errorWithLogs } = useToast();
+  // Used by the kebab-menu "Replay onboarding tour" item below.
+  const { startTutorial } = useTutorial();
 
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [settingsDialogOpen, setSettingsDialogOpen] = React.useState(false);
@@ -409,6 +412,7 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
           size="sm"
           onClick={handleOpenMemory}
           className="gap-2"
+          data-tour="memory-btn"
         >
           <Brain size={16} />
           Memory
@@ -447,6 +451,10 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
             }}>
               <PencilSimple size={16} className="mr-2" />
               Rename Project
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={startTutorial}>
+              <Compass size={16} className="mr-2" />
+              Replay onboarding tour
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/frontend/src/components/project/ProjectWorkspace.tsx
+++ b/frontend/src/components/project/ProjectWorkspace.tsx
@@ -181,7 +181,7 @@ export const ProjectWorkspace: React.FC<ProjectWorkspaceProps> = ({
 
             {/* Center Panel - Chat */}
             <ResizablePanel defaultSize={55} minSize={30} className="bg-card overflow-hidden rounded-xl min-w-0">
-              <div className="h-full min-h-0 min-w-0 w-full flex flex-col overflow-hidden">
+              <div className="h-full min-h-0 min-w-0 w-full flex flex-col overflow-hidden" data-tour="chat-panel">
                 <ChatPanel
                   projectId={project.id}
                   projectName={project.name}

--- a/frontend/src/components/sources/SourcesPanel.tsx
+++ b/frontend/src/components/sources/SourcesPanel.tsx
@@ -828,7 +828,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
           </div>
         </TooltipProvider>
       ) : (
-        <div className="flex flex-col h-full">
+        <div className="flex flex-col h-full" data-tour="sources-panel">
           <SourcesHeader
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}

--- a/frontend/src/components/studio/StudioPanel.tsx
+++ b/frontend/src/components/studio/StudioPanel.tsx
@@ -44,7 +44,7 @@ const StudioPanelContent: React.FC = () => {
   } = useStudioContext();
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full" data-tour="studio-panel">
       <StudioHeader />
 
       {/* TOP HALF: Generation Tools */}

--- a/frontend/src/contexts/TutorialContext.tsx
+++ b/frontend/src/contexts/TutorialContext.tsx
@@ -1,0 +1,115 @@
+import React, { useState, useCallback } from 'react';
+import { TutorialContext, type TourStep } from './TutorialContextType';
+
+const STORAGE_KEY = 'noobbook_onboarding_completed';
+const SEEN_KEY = 'noobbook_onboarding_seen';
+
+// 5-step first-run tour (Sno 52 / GH #255). Targets reference `data-tour`
+// attributes attached to the corresponding panel / header element.
+const defaultSteps: TourStep[] = [
+  {
+    target: 'welcome-intro',
+    title: 'Welcome to NoobBook',
+    content:
+      "NoobBook is your AI-powered workspace — upload sources, chat with them, and generate content like presentations, blogs, and reports. Here's a quick 5-step tour of the three panels you'll work in.",
+    position: 'bottom',
+  },
+  {
+    target: 'sources-panel',
+    title: 'Sources — your content lives here',
+    content:
+      'Upload PDFs, DOCX, PPTX, XLSX, images, and audio; paste text or URLs; or import from Google Drive. The AI processes each source so chat and Studio can search across them.',
+    position: 'right',
+  },
+  {
+    target: 'chat-panel',
+    title: 'Chat — ask anything about your sources',
+    content:
+      'Get cited answers grounded in your documents. Hit the microphone for voice input, drag images into the box to attach them, and use the "Save as insight" button on any reply to pin it.',
+    position: 'left',
+  },
+  {
+    target: 'studio-panel',
+    title: 'Studio — turn sources into deliverables',
+    content:
+      'Generate presentations, blogs, social posts, infographics, components, wireframes, business reports, and more. Saved Insights from chat also live here for quick reuse.',
+    position: 'left',
+  },
+  {
+    target: 'memory-btn',
+    title: 'Memory & Settings — make it yours',
+    content:
+      'Memory teaches the AI about you and this project so answers stay on-brand. Project Settings lets you tweak the system prompt, rename, or share. You can replay this tour anytime from there.',
+    position: 'bottom',
+  },
+];
+
+const getInitialTutorialState = () => {
+  const completed = localStorage.getItem(STORAGE_KEY);
+  const seen = localStorage.getItem(SEEN_KEY);
+  // Auto-open only if the tutorial has never been shown before.
+  // "Seen" is now set when the tutorial component actually renders.
+  const shouldAutoOpen = !completed && !seen;
+  return {
+    isOpen: shouldAutoOpen,
+    isCompleted: !!completed,
+  };
+};
+
+export const TutorialProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [initialState] = useState(getInitialTutorialState);
+  const [isOpen, setIsOpen] = useState(initialState.isOpen);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [steps] = useState<TourStep[]>(defaultSteps);
+  const [isCompleted, setIsCompleted] = useState(initialState.isCompleted);
+
+  const startTutorial = useCallback(() => {
+    setIsOpen(true);
+    setCurrentStep(0);
+    setIsCompleted(false);
+  }, []);
+
+  const nextStep = useCallback(() => {
+    setCurrentStep((prev) => {
+      if (prev >= steps.length - 1) {
+        setIsOpen(false);
+        localStorage.setItem(STORAGE_KEY, 'true');
+        setIsCompleted(true);
+        return prev;
+      }
+      return prev + 1;
+    });
+  }, [steps.length]);
+
+  const prevStep = useCallback(() => {
+    setCurrentStep((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const goToStep = useCallback((step: number) => {
+    setCurrentStep(step);
+  }, []);
+
+  const skipTutorial = useCallback(() => {
+    setIsOpen(false);
+    localStorage.setItem(STORAGE_KEY, 'true');
+    setIsCompleted(true);
+  }, []);
+
+  return (
+    <TutorialContext.Provider
+      value={{
+        isOpen,
+        currentStep,
+        steps,
+        isCompleted,
+        startTutorial,
+        nextStep,
+        prevStep,
+        goToStep,
+        skipTutorial,
+      }}
+    >
+      {children}
+    </TutorialContext.Provider>
+  );
+};

--- a/frontend/src/contexts/TutorialContextType.ts
+++ b/frontend/src/contexts/TutorialContextType.ts
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+
+export interface TourStep {
+  target: string;
+  title: string;
+  content: string;
+  position: 'top' | 'bottom' | 'left' | 'right';
+}
+
+export interface TutorialContextType {
+  isOpen: boolean;
+  currentStep: number;
+  steps: TourStep[];
+  isCompleted: boolean;
+  startTutorial: () => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  goToStep: (step: number) => void;
+  skipTutorial: () => void;
+}
+
+export const TutorialContext = createContext<TutorialContextType | undefined>(undefined);

--- a/frontend/src/hooks/useTutorial.ts
+++ b/frontend/src/hooks/useTutorial.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { TutorialContext } from '../contexts/TutorialContextType';
+
+export const useTutorial = () => {
+  const context = useContext(TutorialContext);
+  if (!context) {
+    throw new Error('useTutorial must be used within a TutorialProvider');
+  }
+  return context;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -172,3 +172,20 @@
   55%  { transform: translateX(310%); }
   100% { transform: translateX(310%); }
 }
+
+/* Onboarding tour intro animation — used by OnboardingTutorial on the first
+   centered welcome step before it anchors to a panel. Greptile P1 (PR #277). */
+@keyframes tutorial-scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.tutorial-scale-in {
+  animation: tutorial-scale-in 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}


### PR DESCRIPTION
## Summary
Rolls these unreleased develop commits into main:

- **#279 — feat(chat): auto-check project DB sources on new chat (Sno 40 / #247)** — new chats auto-pre-select DB-type sources (DATABASE / CSV / FRESHDESK / JIRA / MIXPANEL / MCP). Last open roadmap item closed.
- **#278 — harden OAuth state + bind MinIO to localhost + tighten freshdesk RPC grants** — security hardening across Google OAuth state nonces, MinIO bind, and Freshdesk RPC anon revoke.

## Test plan
- [x] Backend pytest green on develop
- [x] Frontend lint + build green on develop
- [ ] Smoke: create a new chat in a project with DB sources → DB rows pre-checked
- [ ] Smoke: insight refresh on a legacy insight with PDF-only project → still searches all active sources
- [ ] Smoke: Google OAuth login flow round-trips cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)