### PR TITLE
fix(supabase): isolate auth-verify + service-role from data singleton

### DIFF
--- a/backend/app/services/auth/rbac.py
+++ b/backend/app/services/auth/rbac.py
@@ -23,7 +23,11 @@ from typing import Any, Callable, Dict, Optional, TypeVar
 import jwt
 from flask import g, jsonify, request
 
-from app.services.integrations.supabase import get_supabase, is_supabase_enabled
+from app.services.integrations.supabase import (
+    get_supabase,
+    get_auth_verifier_client,
+    is_supabase_enabled,
+)
 from app.services.data_services.project_service import DEFAULT_USER_ID
 
 
@@ -178,8 +182,12 @@ def _resolve_identity() -> RequestIdentity:
 
         # Slow path: original Supabase Auth roundtrip. Only reached
         # when JWT_SECRET isn't set or local decode unexpectedly failed.
+        # Dedicated client so gotrue's auth-event listener can't flip the
+        # data singleton's role to authenticated (see
+        # supabase_client.get_auth_verifier_client for the full incident
+        # write-up).
         try:
-            supabase = get_supabase()
+            supabase = get_auth_verifier_client()
             user_resp = supabase.auth.get_user(token)
             user = getattr(user_resp, "user", None) or user_resp
             user_id = getattr(user, "id", None) or (user.get("id") if isinstance(user, dict) else None)

--- a/backend/app/services/integrations/supabase/__init__.py
+++ b/backend/app/services/integrations/supabase/__init__.py
@@ -7,12 +7,20 @@ This module provides services for interacting with Supabase:
 - storage_service: File storage operations (raw files, processed, chunks)
 """
 
-from .supabase_client import get_supabase, is_supabase_enabled, SupabaseClient
+from .supabase_client import (
+    get_supabase,
+    get_auth_verifier_client,
+    get_service_role_client,
+    is_supabase_enabled,
+    SupabaseClient,
+)
 from .auth_service import auth_service, AuthService
 from . import storage_service
 
 __all__ = [
     "get_supabase",
+    "get_auth_verifier_client",
+    "get_service_role_client",
     "is_supabase_enabled",
     "SupabaseClient",
     "auth_service",

--- a/backend/app/services/integrations/supabase/supabase_client.py
+++ b/backend/app/services/integrations/supabase/supabase_client.py
@@ -8,6 +8,7 @@ from environment variables and provides a clean interface for database operation
 
 import logging
 import os
+import threading
 from typing import Optional
 from supabase import create_client, Client
 from dotenv import load_dotenv
@@ -153,6 +154,68 @@ def create_dedicated_client() -> Client:
     if not supabase_url or not supabase_key:
         raise ValueError("SUPABASE_URL and SUPABASE_SERVICE_KEY (or ANON_KEY) must be set")
     return create_client(supabase_url, supabase_key)
+
+
+# Process-wide dedicated clients for the two roles that must not share state
+# with the data singleton. Lazy-initialised; locked so the first concurrent
+# requests don't race and build two clients.
+_auth_verifier_client: Optional[Client] = None
+_auth_verifier_lock = threading.Lock()
+
+_service_role_client: Optional[Client] = None
+_service_role_lock = threading.Lock()
+
+
+def get_auth_verifier_client() -> Client:
+    """Dedicated client used ONLY for verifying user JWTs.
+
+    Why: supabase-py 2.x registers an `on_auth_state_change` listener on
+    the Client that resets `self._postgrest` and rewrites
+    `self.options.headers['Authorization']` whenever the gotrue client
+    fires SIGNED_IN / TOKEN_REFRESHED. Calling `auth.get_user(token)`
+    against the data singleton from `get_supabase()` can — depending on
+    gotrue's in-memory session state and the events it emits — flip the
+    singleton's role from `service_role` to `authenticated`. Once
+    flipped, every subsequent `.table()` / `.rpc()` from the singleton
+    runs as the user, which 42501-s any RPC the migrations revoked from
+    authenticated (notably `exec_freshdesk_query` after migration 00037).
+
+    Symptoms we have seen in production: a sign-in is followed within
+    seconds by `permission denied for function exec_freshdesk_query`
+    that only clears on container restart.
+
+    Use this client EXCLUSIVELY for `auth.get_user(token)` /
+    revocation-check calls. Never call `.table()` / `.rpc()` on it —
+    pollution stays contained even if the listener fires.
+    """
+    global _auth_verifier_client
+    if _auth_verifier_client is None:
+        with _auth_verifier_lock:
+            if _auth_verifier_client is None:
+                _auth_verifier_client = create_dedicated_client()
+    return _auth_verifier_client
+
+
+def get_service_role_client() -> Client:
+    """Dedicated service-role client for calls that must run as service_role.
+
+    Defense-in-depth twin of `get_auth_verifier_client`. Even though the
+    auth verifier already keeps gotrue events off the data singleton,
+    some future code path could regress that. RPCs that the migrations
+    revoked from `authenticated` (e.g. `exec_freshdesk_query`) need a
+    hard guarantee that their client's Authorization header stays
+    `Bearer <SUPABASE_SERVICE_KEY>` for the life of the process.
+
+    Use this client for RPCs that are revoked from `authenticated`.
+    Never call `auth.*` methods on it — that is what guarantees the
+    listener never fires and the postgrest header never flips.
+    """
+    global _service_role_client
+    if _service_role_client is None:
+        with _service_role_lock:
+            if _service_role_client is None:
+                _service_role_client = create_dedicated_client()
+    return _service_role_client
 
 
 def is_supabase_enabled() -> bool:

--- a/backend/app/services/integrations/supabase/supabase_client.py
+++ b/backend/app/services/integrations/supabase/supabase_client.py
@@ -209,12 +209,29 @@ def get_service_role_client() -> Client:
     Use this client for RPCs that are revoked from `authenticated`.
     Never call `auth.*` methods on it — that is what guarantees the
     listener never fires and the postgrest header never flips.
+
+    Hard-requires `SUPABASE_SERVICE_KEY`: falling back to the anon key
+    would silently produce a non-service-role client and only surface
+    as a 42501 inside the RPC — defeating the entire point of having
+    a separately-named accessor for this. Mirrors the explicit check
+    in `user_service.__init__`.
     """
     global _service_role_client
     if _service_role_client is None:
         with _service_role_lock:
             if _service_role_client is None:
-                _service_role_client = create_dedicated_client()
+                supabase_url = os.getenv("SUPABASE_URL")
+                service_key = os.getenv("SUPABASE_SERVICE_KEY")
+                if not supabase_url or not service_key:
+                    raise RuntimeError(
+                        "get_service_role_client() requires SUPABASE_URL and "
+                        "SUPABASE_SERVICE_KEY. Anon key is not accepted here — "
+                        "callers (e.g. exec_freshdesk_query) need a hard "
+                        "service_role guarantee, and the anon fallback would "
+                        "silently 42501 at call time. Set SUPABASE_SERVICE_KEY "
+                        "in the backend env."
+                    )
+                _service_role_client = create_client(supabase_url, service_key)
     return _service_role_client
 
 

--- a/backend/app/services/tool_executors/freshdesk_executor.py
+++ b/backend/app/services/tool_executors/freshdesk_executor.py
@@ -255,10 +255,17 @@ class FreshdeskExecutor:
         a direct DB route.
         """
         try:
-            from app.services.integrations.supabase import get_supabase
+            # Dedicated service-role client (defense in depth). Migration
+            # 00037 revoked EXECUTE on this RPC from `authenticated`,
+            # leaving only `service_role`. Even with the auth-verifier
+            # fix keeping gotrue events off the data singleton, this
+            # callsite must NEVER run as `authenticated` or it 42501-s,
+            # so we pin it to a client whose Authorization header is
+            # guaranteed-immutable for the life of the process.
+            from app.services.integrations.supabase import get_service_role_client
             from postgrest.exceptions import APIError
 
-            supabase = get_supabase()
+            supabase = get_service_role_client()
             start = time.time()
             resp = supabase.rpc("exec_freshdesk_query", {"sql_query": sql}).execute()
             elapsed = round((time.time() - start) * 1000, 1)

--- a/backend/app/utils/auth_middleware.py
+++ b/backend/app/utils/auth_middleware.py
@@ -27,7 +27,7 @@ from typing import Optional, Dict, Tuple
 
 import jwt
 from flask import request, jsonify, g
-from app.services.integrations.supabase import get_supabase
+from app.services.integrations.supabase import get_auth_verifier_client
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +192,12 @@ def validate_token() -> Optional[str]:
                 if _get_cached_user_id(token):
                     return user_id
                 try:
-                    supabase = get_supabase()
+                    # Dedicated client: keeps gotrue's auth-event listener
+                    # off the data singleton so a SIGNED_IN / TOKEN_REFRESHED
+                    # firing during this verify call can't flip the
+                    # singleton's postgrest Authorization header to a user
+                    # JWT and 42501 every service-role-only RPC after.
+                    supabase = get_auth_verifier_client()
                     response = supabase.auth.get_user(token)
                     if response and response.user:
                         _cache_token(token, user_id)
@@ -240,7 +245,9 @@ def validate_token() -> Optional[str]:
         return cached_user_id
 
     try:
-        supabase = get_supabase()
+        # Same dedicated client as the fast-path slow-confirm above —
+        # keeps the data singleton's identity pinned to service_role.
+        supabase = get_auth_verifier_client()
         user_response = supabase.auth.get_user(token)
 
         if not user_response or not user_response.user:


### PR DESCRIPTION
## Incident
Production agent calls hit `permission denied for function exec_freshdesk_query` (Postgres `42501`) shortly after every sign-in, and stay broken until the backend container restarts. Bundle logs show the failure starts ~2 minutes after a successful `POST /auth/signin` and continues for every subsequent freshdesk RPC.

## Root cause
supabase-py 2.15.0 registers an `on_auth_state_change` listener on the Client:
```python
def _listen_to_auth_events(self, event, session):
    if event in ["SIGNED_IN", "TOKEN_REFRESHED", "SIGNED_OUT"]:
        self._postgrest = None
        access_token = session.access_token if session else self.supabase_key
    self.options.headers["Authorization"] = self._create_auth_header(access_token)
```

Calling `auth.get_user(token)` on the **data singleton** (from `get_supabase()`) can — depending on gotrue's in-memory session state — fire SIGNED_IN / TOKEN_REFRESHED. That resets the singleton's PostgREST client and rewrites its Authorization header to the user JWT. From that point every `.table()` / `.rpc()` from `get_supabase()` runs as `authenticated`.

Migration `00037_database_mcp_connections_rls.sql` revoked EXECUTE on `exec_freshdesk_query` from `authenticated`, so any flip permanently 42501-s the RPC.

Two call sites were leaking gotrue events onto the singleton:
- `app/utils/auth_middleware.py:195, 243` — JWT verification fast/slow paths
- `app/services/auth/rbac.py:182-183` — identity resolution slow path

`auth_service` and `user_service` already use dedicated clients to avoid this — the gap was on the verifier side.

## Fix (belt + suspenders)
1. **`get_auth_verifier_client()`** in `supabase_client.py` — lazy module-level dedicated client used **only** for `auth.get_user(token)` calls. Wired into `auth_middleware.py` (both verify paths) and `rbac.py`. Keeps gotrue events off the data singleton.
2. **`get_service_role_client()`** in `supabase_client.py` — lazy module-level dedicated service-role-pinned client for RPCs the migrations revoked from `authenticated`. Wired into `freshdesk_executor._exec_via_supabase_rpc`. Even if some future code path regresses #1 and leaks gotrue events back onto the singleton, this RPC stays guaranteed-service_role.

Both clients are protected by a `threading.Lock` so the first concurrent requests don't race into two instances.

## Operator note
Existing production processes need a restart to pick this up — the in-memory singleton is already flipped on the running container.

## Test plan
- [ ] Backend pytest green (no tests touch these modules; CI just verifies imports + lint)
- [ ] Smoke after deploy: sign in, then immediately ask a freshdesk-data question. Agent should get successful query results, not `permission denied`.
- [ ] Existing auth flows (sign-in, sign-up, token refresh, sign-out) still work — `auth_service` is unchanged.
- [ ] `auth/me` keeps working — `validate_token` now routes through the verifier client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)