### PR TITLE
feat: end-to-end req-id, typed errors, fix proxy-disconnect mislabel

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -23,10 +23,77 @@ Authentication: A before_request hook on api_bp validates JWT tokens
 for ALL routes except /auth/* endpoints. This protects every endpoint
 without needing @require_auth on each route.
 """
+import logging
+import re
+import time
+import uuid
+
 from flask import Blueprint, request, jsonify, g
 
 # Create the main API blueprint
 api_bp = Blueprint('api', __name__)
+
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Request-ID + timing middleware (§1.4 + §1.5)
+# =============================================================================
+# Every request gets a UUID-shaped correlation ID. The frontend axios client
+# generates one via `crypto.randomUUID()` and sends it as `X-Request-Id`; if
+# absent we mint one server-side. The ID is stamped onto every log record by
+# `_RequestIdFilter` in `app/utils/logger.py` so a frontend bug report
+# (containing the req_id from DevTools) can be grepped directly in
+# backend.log. The ID is also echoed back in the response so the frontend can
+# print it.
+#
+# Run BEFORE `authenticate_request` so even unauthenticated requests (a 401
+# from `before_request` itself) carry a req_id — which is exactly the case we
+# need most often when debugging spontaneous logouts.
+
+_REQ_ID_HEADER = "X-Request-Id"
+# Strict allowlist: hex / alphanumeric / dash / underscore only. Anything
+# else gets rejected and we mint a fresh server-side ID. Without this, a
+# malicious client could pass `abc]: spoofed-log-line [req:fake` and inject
+# fake log content via the format-string interpolation (the M2 finding from
+# code-review). 1..64 chars matches the previous max length.
+_REQ_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+@api_bp.before_request
+def _attach_request_id():
+    """Mint or accept a per-request correlation ID and start the latency timer.
+
+    Registered BEFORE `authenticate_request` so 401 responses still carry the
+    req_id (the most common case we need to correlate).
+    """
+    incoming = request.headers.get(_REQ_ID_HEADER, "").strip()
+    if incoming and _REQ_ID_RE.fullmatch(incoming):
+        g.req_id = incoming
+    else:
+        g.req_id = uuid.uuid4().hex[:16]  # 16 hex chars = 64 bits = plenty
+    g._t0 = time.monotonic()
+
+
+@api_bp.after_request
+def _emit_request_id_and_timing(response):
+    """Echo X-Request-Id back to the client and log slow paths (§1.5)."""
+    req_id = getattr(g, "req_id", None)
+    if req_id:
+        response.headers[_REQ_ID_HEADER] = req_id
+
+    t0 = getattr(g, "_t0", None)
+    if t0 is not None:
+        elapsed = time.monotonic() - t0
+        # 1.0s threshold catches the failure modes we care about (DB connect
+        # timeout, slow Claude calls, GoTrue blips) without flooding the log
+        # with normal sub-second requests.
+        if elapsed > 1.0:
+            logger.warning(
+                "SLOW_REQUEST method=%s path=%s status=%s elapsed=%.2fs",
+                request.method, request.path, response.status_code, elapsed,
+            )
+    return response
+
 
 # =============================================================================
 # Authentication - Protect all routes except /auth/*
@@ -98,6 +165,7 @@ from app.api.brand import brand_bp
 from app.api.share import share_bp
 from app.api.logs import logs_bp
 from app.api.insights import insights_bp
+from app.api.debug import debug_bp
 
 # Register nested blueprints with the main api blueprint
 # No url_prefix needed - routes already have full paths
@@ -115,3 +183,4 @@ api_bp.register_blueprint(brand_bp)
 api_bp.register_blueprint(share_bp)
 api_bp.register_blueprint(logs_bp)
 api_bp.register_blueprint(insights_bp)
+api_bp.register_blueprint(debug_bp)

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -65,7 +65,14 @@ def _attach_request_id():
 
     Registered BEFORE `authenticate_request` so 401 responses still carry the
     req_id (the most common case we need to correlate).
+
+    CORS preflights (OPTIONS) are skipped — they don't carry app-level
+    semantics worth tracing and were producing noisy SLOW_REQUEST lines on
+    cached preflight refreshes. Matches the OPTIONS-skip in
+    `authenticate_request` below.
     """
+    if request.method == 'OPTIONS':
+        return None
     incoming = request.headers.get(_REQ_ID_HEADER, "").strip()
     if incoming and _REQ_ID_RE.fullmatch(incoming):
         g.req_id = incoming

--- a/backend/app/api/debug/__init__.py
+++ b/backend/app/api/debug/__init__.py
@@ -1,0 +1,19 @@
+"""
+Debug API blueprint — admin-only diagnostic endpoints.
+
+Routes (registered under /api/v1):
+  GET  /debug/supabase-state   (admin) — confirms whether the data singleton's
+                                          Authorization header has been flipped
+                                          off service_role (the supabase-py
+                                          2.15.0 listener-pollution bug).
+  GET  /debug/stats             (admin) — in-flight chat count, token cache
+                                          size, background queue depth.
+
+These exist to give operators (and us) a 1-second live look at process state
+during an incident, without `docker exec` access.
+"""
+from flask import Blueprint
+
+debug_bp = Blueprint("debug", __name__)
+
+from app.api.debug import routes  # noqa: F401,E402

--- a/backend/app/api/debug/routes.py
+++ b/backend/app/api/debug/routes.py
@@ -1,0 +1,73 @@
+"""
+Admin-only diagnostic endpoints.
+
+Designed for "is something wrong RIGHT NOW?" checks during a live incident.
+Neither route mutates state; both are admin-gated.
+"""
+from __future__ import annotations
+
+import logging
+
+from flask import jsonify
+
+from app.api.debug import debug_bp
+from app.services.auth.rbac import require_admin
+from app.services.integrations.supabase import check_singleton_identity
+
+logger = logging.getLogger(__name__)
+
+
+@debug_bp.route("/debug/supabase-state", methods=["GET"])
+@require_admin
+def supabase_state():
+    """Return the data singleton's current identity (is it polluted?).
+
+    See `check_singleton_identity()` for the why. Useful when a user reports
+    a spontaneous logout or 42501-class permission error — one curl confirms
+    or rules out the supabase-py 2.15.0 listener-pollution bug.
+    """
+    state = check_singleton_identity()
+    return jsonify({"success": True, **state}), 200
+
+
+@debug_bp.route("/debug/stats", methods=["GET"])
+@require_admin
+def runtime_stats():
+    """Snapshot of in-process counters useful during an incident.
+
+    Reads existing module-level state without mutating anything:
+      - in_flight_chats: number of SSE chat streams currently being served
+      - token_cache_size: entries in the auth_middleware revocation cache
+      - background_executor: queued/active counts for the source-processing
+        ThreadPoolExecutor (best-effort — CPython's executor doesn't expose
+        a public queue length, so we report what we can).
+    """
+    out: dict = {}
+
+    # In-flight chat streams
+    try:
+        from app.api.messages.routes import _in_flight_chats, _in_flight_lock
+        with _in_flight_lock:
+            out["in_flight_chats"] = len(_in_flight_chats)
+    except Exception as exc:  # noqa: BLE001
+        out["in_flight_chats_error"] = f"{type(exc).__name__}: {exc}"
+
+    # Token revocation cache size
+    try:
+        from app.utils.auth_middleware import _token_cache, _cache_lock
+        with _cache_lock:
+            out["token_cache_size"] = len(_token_cache)
+    except Exception as exc:  # noqa: BLE001
+        out["token_cache_size_error"] = f"{type(exc).__name__}: {exc}"
+
+    # Background ThreadPoolExecutor — actively-running futures plus the
+    # in-memory cancelled set
+    try:
+        from app.services.background_services.task_service import task_service
+        out["background_active_futures"] = len(task_service._futures)
+        out["background_cancelled_set_size"] = len(task_service._cancelled_tasks)
+        out["background_max_workers"] = task_service.MAX_WORKERS
+    except Exception as exc:  # noqa: BLE001
+        out["background_executor_error"] = f"{type(exc).__name__}: {exc}"
+
+    return jsonify({"success": True, "stats": out}), 200

--- a/backend/app/api/logs/routes.py
+++ b/backend/app/api/logs/routes.py
@@ -21,13 +21,19 @@ from app.utils import logger as logger_module
 
 logger = logging.getLogger(__name__)
 
-# `2026-05-01 10:23:44 [ERROR] app.services.foo: message` — matches the
-# format string in setup_logging(). Loose enough to skip continuation
-# lines (stack-trace inner lines) which we still want to include verbatim.
+# Two shapes accepted:
+#   - new:  `10:23:44 [ERROR] app.services.foo [req:abc123]: message`
+#   - old:  `10:23:44 [ERROR] app.services.foo: message`        (pre-§1.4 archives)
+# The `[req:...]` group is optional so rotated archives written before the
+# req_id rollout still parse and display correctly in the admin UI.
+# Loose enough to skip continuation lines (stack-trace inner lines) which we
+# still want to include verbatim.
 _LINE_RE = re.compile(
     r"^(?P<ts>\d{2}:\d{2}:\d{2})\s+"
     r"\[(?P<level>[A-Z]+)\]\s+"
-    r"(?P<logger>[\w.\-]+):\s*"
+    r"(?P<logger>[\w.\-]+)"
+    r"(?:\s+\[req:(?P<req_id>[^\]]*)\])?"
+    r":\s*"
     r"(?P<message>.*)$"
 )
 
@@ -60,6 +66,7 @@ def _read_recent_lines(limit: int, levels: set[str]) -> list[dict[str, Any]]:
                         "ts": m.group("ts"),
                         "level": m.group("level"),
                         "logger": m.group("logger"),
+                        "req_id": m.group("req_id") or "",
                         "message": redact_line(m.group("message")),
                     }
                 else:

--- a/backend/app/api/messages/routes.py
+++ b/backend/app/api/messages/routes.py
@@ -34,7 +34,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, List, Tuple, Union
 
-from flask import jsonify, request, current_app, Response, stream_with_context
+from flask import g, jsonify, request, current_app, Response, stream_with_context
 from werkzeug.utils import secure_filename
 from app.api.messages import messages_bp
 from app.services.chat_services import main_chat_service
@@ -310,6 +310,11 @@ def stream_message(project_id, chat_id):
     # inside the worker thread below so Opik traces still get tagged
     # after we leave the Flask request scope.
     user_email = identity.email if identity.is_authenticated else None
+    # Capture the req_id while we're still in the Flask request context.
+    # The worker thread re-stashes it via set_worker_req_id() so that
+    # PROXY_DISCONNECT_PERSIST + other background traces stay grep-able
+    # against the originating frontend request_id.
+    parent_req_id = getattr(g, "req_id", "-")
     app = current_app._get_current_object()
     # Bounded so the worker can't accumulate hundreds of KB of unread events
     # after the client disconnects. 512 is well above the steady-state size
@@ -351,6 +356,13 @@ def stream_message(project_id, chat_id):
         # cross the thread boundary. ContextVars are per-thread, so this
         # only affects this worker.
         set_current_user_email(user_email)
+        # Same shape: re-stash the parent req_id in this thread's
+        # ContextVar so every log line emitted from main_chat_service
+        # below carries the originating request's req_id instead of "-".
+        # Without this the most user-facing trace (PROXY_DISCONNECT_PERSIST)
+        # loses its correlation key precisely when we need it most.
+        from app.utils.request_context import set_worker_req_id
+        set_worker_req_id(parent_req_id)
         # Fire-and-forget: tag the Opik thread with user identity once per
         # chat so the thread list is filterable by user. Deduped in
         # claude_service so repeated sends in the same chat are cheap.
@@ -444,7 +456,7 @@ def stream_message(project_id, chat_id):
             # in-process set we used pre-H2 only worked when workers=1.
             # Freshness check: a stop timestamp from BEFORE this stream
             # started is from a previous message — ignore it (M1 race).
-            user_stopped_at_iso = chat_service.get_user_stopped_at(chat_id)
+            user_stopped_at_iso = chat_service.get_user_stopped_at(project_id, chat_id)
             was_user_stop = False
             if user_stopped_at_iso:
                 try:

--- a/backend/app/api/messages/routes.py
+++ b/backend/app/api/messages/routes.py
@@ -445,6 +445,25 @@ def stream_message(project_id, chat_id):
             #   3. The proxy (Coolify/nginx) gave up on an idle SSE
             #      connection despite our 15s heartbeats.
             #
+            # ORDERING MATTERS: cancel_event.set() FIRST, BEFORE the Supabase
+            # lookup for the user-stop label. The Supabase call can hang for
+            # 30-120s on the OS-default socket timeout if Supabase/Kong is
+            # unreachable — which is exactly the burst-load scenario this PR
+            # targets. With the old ordering (label first, cancel last), the
+            # worker thread kept running Claude tool calls for the entire
+            # hang window, burning tokens and CPU on a request the user has
+            # already abandoned.
+            #
+            # The labeling logic can race the worker (rare — worker is
+            # usually mid-Claude-call for seconds when GeneratorExit fires,
+            # giving the Supabase query plenty of time to finish before the
+            # worker reaches the labeling branch in main_chat_service). On
+            # the rare race, a real user-stop gets labeled as proxy-
+            # disconnect; that's a UX wart, not data loss, and same UX as
+            # pre-PR-283. Acceptable trade-off for guaranteed worker
+            # termination on Supabase outages.
+            cancel_event.set()
+
             # cancel_event is set in all three cases — the worker stops
             # persisting. user_stop_event is set ONLY in case 1, so the
             # final assistant message only gets the "(stopped by user)"
@@ -456,7 +475,20 @@ def stream_message(project_id, chat_id):
             # in-process set we used pre-H2 only worked when workers=1.
             # Freshness check: a stop timestamp from BEFORE this stream
             # started is from a previous message — ignore it (M1 race).
-            user_stopped_at_iso = chat_service.get_user_stopped_at(project_id, chat_id)
+            try:
+                user_stopped_at_iso = chat_service.get_user_stopped_at(project_id, chat_id)
+            except Exception as supabase_exc:
+                # Defensive: get_user_stopped_at already catches everything,
+                # but if it ever raises (e.g. a new exception type after a
+                # supabase-py upgrade), default to proxy_disconnect rather
+                # than crashing the cleanup path. The worker has already
+                # been told to stop above; this is purely for labeling.
+                app.logger.warning(
+                    "SSE_CLOSE_TRACE chat=%s supabase_lookup_failed err=%s:%s "
+                    "— defaulting label to connection_dropped",
+                    chat_id, type(supabase_exc).__name__, str(supabase_exc)[:120],
+                )
+                user_stopped_at_iso = None
             was_user_stop = False
             if user_stopped_at_iso:
                 try:
@@ -478,7 +510,6 @@ def stream_message(project_id, chat_id):
                 now - stream_started_at,
                 now - last_event_at, heartbeat_count,
             )
-            cancel_event.set()
             raise
 
     headers = {

--- a/backend/app/api/messages/routes.py
+++ b/backend/app/api/messages/routes.py
@@ -29,19 +29,23 @@ Routes:
 import json
 import queue
 import threading
+import time
 import uuid
+from datetime import datetime, timezone
 from typing import Any, List, Tuple, Union
 
 from flask import jsonify, request, current_app, Response, stream_with_context
 from werkzeug.utils import secure_filename
 from app.api.messages import messages_bp
 from app.services.chat_services import main_chat_service
+from app.services.data_services.chat_service import chat_service
 from app.services.auth.rbac import get_request_identity
 from app.services.integrations.claude.claude_service import (
     set_current_user_email,
     tag_chat_thread,
 )
 from app.services.integrations.supabase import storage_service
+from app.utils.error_responses import error_response
 
 
 _STREAM_SENTINEL = object()
@@ -55,6 +59,11 @@ _STREAM_SENTINEL = object()
 # fix prevents the rapid-click case; this server-side guard is the
 # defense-in-depth for cross-tab, browser-retry, and any future caller
 # paths that bypass the UI lock.
+#
+# Caveat: this set is per-gunicorn-worker. With workers > 1 the dedup
+# only catches duplicates that happen to hash to the same worker.
+# That's a pre-existing limitation; the §2.1 marker uses Supabase
+# instead precisely to avoid this trap.
 _in_flight_chats: set = set()
 _in_flight_lock = threading.Lock()
 
@@ -264,11 +273,7 @@ def send_message(project_id, chat_id):
             'error': str(e)
         }), 404
     except Exception as e:
-        current_app.logger.error(f"Error sending message: {e}")
-        return jsonify({
-            'success': False,
-            'error': str(e)
-        }), 500
+        return error_response(e, default_log="Error sending message")
 
 
 @messages_bp.route('/projects/<project_id>/chats/<chat_id>/messages/stream', methods=['POST'])
@@ -311,13 +316,22 @@ def stream_message(project_id, chat_id):
     # of an in-flight stream (a few dozen events queued at most), so a normal
     # slow consumer just back-pressures the worker via the blocking put.
     event_queue: "queue.Queue[object]" = queue.Queue(maxsize=512)
-    # Cancel flag — set when the SSE generator is closed (client disconnect /
-    # frontend AbortController). Plumbed into the chat service so the
-    # assistant message isn't persisted after the user clicks Stop. Without
-    # this, Flask's stream_with_context keeps the worker thread running and
-    # we'd write the half-baked response to DB, producing the "two answers
-    # on resend" symptom Neel reported.
+    # Two flags, distinct semantics:
+    #
+    # - cancel_event: short-circuit signal for the agent loop. Set when EITHER
+    #   the user clicked Stop OR the proxy/browser closed the SSE connection.
+    #   In both cases the worker should stop persisting tool calls and final
+    #   text — without this, Flask's stream_with_context keeps the worker
+    #   thread running and we'd write a half-baked response (the "two answers
+    #   on resend" symptom).
+    #
+    # - user_stop_event: labeling signal. Set ONLY when /messages/stop was
+    #   posted (the user explicitly clicked Stop in the UI). Drives the
+    #   "(stopped by user)" suffix in main_chat_service. Without this flag,
+    #   a proxy idle-timeout (Coolify/nginx) silently mislabeled real
+    #   responses as user-stopped — that's Delta's Symptom 9.
     cancel_event = threading.Event()
+    user_stop_event = threading.Event()
 
     def emit(event_name: str, payload: dict) -> None:
         # After the client has disconnected, nothing reads the queue — drop
@@ -349,6 +363,7 @@ def stream_message(project_id, chat_id):
                 user_id=user_id,
                 on_event=emit,
                 cancel_event=cancel_event,
+                user_stop_event=user_stop_event,
             )
         except ValueError as exc:
             emit("error", {"message": str(exc)})
@@ -363,10 +378,30 @@ def stream_message(project_id, chat_id):
             # has already torn down due to GeneratorExit.
             with _in_flight_lock:
                 _in_flight_chats.discard(chat_id)
+            # No explicit clear of chats.user_stopped_at: the freshness
+            # check in GeneratorExit (stop-timestamp > stream-start) means
+            # a stale value from a previous message never triggers a
+            # false positive on the next stream.
             event_queue.put(_STREAM_SENTINEL)
 
     thread = threading.Thread(target=worker, daemon=True)
     thread.start()
+
+    # Tracking state for SSE_CLOSE_TRACE — answers the central question
+    # behind Symptom 9 ("stopped by user when not actually stopped"):
+    # was the disconnect a proxy timeout (elapsed >> 0, heartbeats fired)
+    # or a real user abort (elapsed ~0, no heartbeats needed)?
+    #
+    # `stream_started_wallclock` is the wall-clock anchor we compare
+    # against `chats.user_stopped_at` to decide whether a /stop signal
+    # arrived DURING this stream (real user-stop) or was left over from
+    # a previous message (stale — ignore). monotonic() is used for
+    # latency math because it's immune to clock jumps; wall-clock is
+    # used for the cross-row comparison because that's what the DB has.
+    stream_started_at = time.monotonic()
+    stream_started_wallclock = datetime.now(timezone.utc)
+    last_event_at = stream_started_at
+    heartbeat_count = 0
 
     def generate():
         # Heartbeat keeps the SSE connection alive while long-running tools
@@ -376,20 +411,61 @@ def stream_message(project_id, chat_id):
         # the worker mislabels the response as "(stopped by user)". The colon
         # prefix is an SSE comment — browsers ignore it but the bytes prevent
         # idle-timeout.
+        nonlocal last_event_at, heartbeat_count
         try:
             while True:
                 try:
                     item = event_queue.get(timeout=15)
                 except queue.Empty:
+                    heartbeat_count += 1
                     yield ": heartbeat\n\n"
                     continue
                 if item is _STREAM_SENTINEL:
                     break
+                last_event_at = time.monotonic()
                 yield item
         except GeneratorExit:
-            # Client disconnected (browser navigation, AbortController, etc.).
-            # Tell the worker to stop persisting before re-raising so Flask
-            # can clean up the response.
+            # Connection closed for one of three reasons:
+            #   1. User explicitly clicked Stop in the UI (POST /messages/stop
+            #      wrote chats.user_stopped_at = NOW()).
+            #   2. The user navigated away or closed the tab (browser
+            #      aborts the fetch).
+            #   3. The proxy (Coolify/nginx) gave up on an idle SSE
+            #      connection despite our 15s heartbeats.
+            #
+            # cancel_event is set in all three cases — the worker stops
+            # persisting. user_stop_event is set ONLY in case 1, so the
+            # final assistant message only gets the "(stopped by user)"
+            # label when that's actually what happened.
+            #
+            # Cross-worker correctness: chats.user_stopped_at is in
+            # Supabase, so the POST /messages/stop on worker A and the
+            # SSE worker on worker B see the same source of truth. The
+            # in-process set we used pre-H2 only worked when workers=1.
+            # Freshness check: a stop timestamp from BEFORE this stream
+            # started is from a previous message — ignore it (M1 race).
+            user_stopped_at_iso = chat_service.get_user_stopped_at(chat_id)
+            was_user_stop = False
+            if user_stopped_at_iso:
+                try:
+                    user_stopped_at = datetime.fromisoformat(
+                        user_stopped_at_iso.replace("Z", "+00:00")
+                    )
+                    was_user_stop = user_stopped_at > stream_started_wallclock
+                except (ValueError, TypeError):
+                    # Malformed timestamp — conservative default: not user-stop.
+                    was_user_stop = False
+            if was_user_stop:
+                user_stop_event.set()
+            now = time.monotonic()
+            app.logger.warning(
+                "SSE_CLOSE_TRACE chat=%s reason=%s elapsed_total=%.2fs "
+                "elapsed_since_last_event=%.2fs heartbeats_sent=%d",
+                chat_id,
+                "user_stop" if was_user_stop else "connection_dropped",
+                now - stream_started_at,
+                now - last_event_at, heartbeat_count,
+            )
             cancel_event.set()
             raise
 
@@ -400,3 +476,37 @@ def stream_message(project_id, chat_id):
         "X-Accel-Buffering": "no",
     }
     return Response(stream_with_context(generate()), headers=headers)
+
+
+@messages_bp.route('/projects/<project_id>/chats/<chat_id>/messages/stop', methods=['POST'])
+def stop_message(project_id, chat_id):
+    """
+    Explicit "user clicked Stop" signal.
+
+    Writes `chats.user_stopped_at = NOW()` (scoped to project_id, so a
+    user can't poison another tenant's chat). When the SSE GeneratorExit
+    fires immediately after — because the frontend also aborts the
+    AbortController — the worker reads `user_stopped_at` and compares
+    against its own stream-start wall-clock to decide whether to apply
+    the "(stopped by user)" label.
+
+    The DB is the source of truth because gunicorn workers don't share
+    memory: POST /messages/stop and POST /messages/stream commonly land
+    on different workers. The pre-H2 in-process set worked only when
+    workers=1.
+
+    Idempotent — repeated POSTs just rewrite the timestamp. 404 when the
+    project doesn't own the chat (the SQL WHERE clause filters cross-
+    project writes; mirrors the verify_project_access blueprint hook on
+    messages_bp at the chat level).
+    """
+    try:
+        updated = chat_service.mark_user_stopped(project_id, chat_id)
+    except Exception as e:
+        return error_response(e, default_log=f"Error marking chat {chat_id} as user-stopped")
+    if not updated:
+        return jsonify({
+            "success": False,
+            "error": "Chat not found or not accessible.",
+        }), 404
+    return jsonify({"success": True}), 200

--- a/backend/app/api/settings/databases.py
+++ b/backend/app/api/settings/databases.py
@@ -19,6 +19,7 @@ from app.api.settings import settings_bp
 from app.services.auth.rbac import require_admin
 from app.services.data_services.database_connection_service import database_connection_service, DEFAULT_USER_ID
 from app.services.auth.rbac import get_request_identity
+from app.utils.error_responses import error_response
 
 
 @settings_bp.route("/settings/databases", methods=["GET"])
@@ -34,8 +35,7 @@ def list_databases():
         )
         return jsonify({"success": True, "databases": connections, "count": len(connections)}), 200
     except Exception as e:
-        current_app.logger.error(f"Error listing databases: {e}")
-        return jsonify({"success": False, "error": str(e)}), 500
+        return error_response(e, default_log="Error listing databases")
 
 
 @settings_bp.route("/settings/databases", methods=["POST"])
@@ -75,8 +75,7 @@ def create_database():
     except ValueError as e:
         return jsonify({"success": False, "error": str(e)}), 400
     except Exception as e:
-        current_app.logger.error(f"Error creating database connection: {e}")
-        return jsonify({"success": False, "error": str(e)}), 500
+        return error_response(e, default_log="Error creating database connection")
 
 
 @settings_bp.route("/settings/databases/<connection_id>", methods=["DELETE"])
@@ -90,8 +89,7 @@ def delete_database(connection_id: str):
             return jsonify({"success": False, "error": "Database connection not found"}), 404
         return jsonify({"success": True, "message": "Database connection deleted"}), 200
     except Exception as e:
-        current_app.logger.error(f"Error deleting database connection {connection_id}: {e}")
-        return jsonify({"success": False, "error": str(e)}), 500
+        return error_response(e, default_log=f"Error deleting database connection {connection_id}")
 
 
 @settings_bp.route("/settings/databases/<connection_id>/visibility", methods=["PATCH"])
@@ -112,8 +110,7 @@ def update_database_visibility(connection_id: str):
 
         return jsonify({"success": True, "database": updated}), 200
     except Exception as e:
-        current_app.logger.error(f"Error updating database visibility {connection_id}: {e}")
-        return jsonify({"success": False, "error": str(e)}), 500
+        return error_response(e, default_log=f"Error updating database visibility {connection_id}")
 
 
 @settings_bp.route("/settings/databases/validate", methods=["POST"])

--- a/backend/app/api/sources/uploads.py
+++ b/backend/app/api/sources/uploads.py
@@ -39,6 +39,7 @@ from app.api.sources import sources_bp
 from app.services.source_services import SourceService
 from app.services.auth.rbac import get_request_identity
 from app.services.auth import require_permission
+from app.utils.error_responses import error_response
 
 # Initialize service
 source_service = SourceService()
@@ -324,8 +325,7 @@ def add_database_source(project_id: str):
     except ValueError as e:
         return jsonify({'success': False, 'error': str(e)}), 400
     except Exception as e:
-        current_app.logger.error(f"Error adding database source: {e}")
-        return jsonify({'success': False, 'error': str(e)}), 500
+        return error_response(e, default_log="Error adding database source")
 
 
 @sources_bp.route('/projects/<project_id>/sources/freshdesk', methods=['POST'])

--- a/backend/app/services/background_services/task_service.py
+++ b/backend/app/services/background_services/task_service.py
@@ -49,22 +49,19 @@ class TaskService:
 
     def __init__(self):
         """Initialize the task service."""
-        # Thread pool for executing tasks
-        # Educational Note: ThreadPoolExecutor manages a pool of worker threads
-        # Tasks are queued and executed as threads become available
         self._executor = ThreadPoolExecutor(max_workers=self.MAX_WORKERS)
-
-        # Lock for thread-safe operations
         self._lock = threading.Lock()
-
-        # Track running futures (for potential cancellation)
         self._futures: Dict[str, Future] = {}
-
-        # Track cancelled tasks - workers check this to stop early
         self._cancelled_tasks: set = set()
 
-        # Clean up any stale tasks from previous runs
-        self._cleanup_stale_tasks()
+        # Stale-task cleanup must run exactly ONCE per container boot, not
+        # per gunicorn worker. With multiple workers, a recycling worker
+        # would otherwise mark tasks running on its peers as "failed".
+        # entrypoint.sh runs the cleanup explicitly before gunicorn starts;
+        # workers skip it unless RUN_STALE_TASK_CLEANUP=1 is set.
+        import os
+        if os.getenv("RUN_STALE_TASK_CLEANUP") == "1":
+            self._cleanup_stale_tasks()
 
     def _cleanup_stale_tasks(self) -> None:
         """
@@ -160,8 +157,18 @@ class TaskService:
                 return result
 
             except Exception as e:
-                # Update status to failed
+                # Full traceback for post-mortem.
                 logger.exception("Task %s failed (%s for %s): %s", task_id, task_type, target_id, e)
+                # Structured prefix for the admin Logs viewer + bundle. Without
+                # a req_id (background threads have no Flask request context),
+                # task_id is the correlation key — when a user reports "my
+                # source got stuck in processing", an admin can grep
+                # `BACKGROUND_TASK_FAIL target=<source_id>` and find the
+                # exact failure.
+                logger.warning(
+                    "BACKGROUND_TASK_FAIL task_id=%s task_type=%s target_id=%s err=%s:%s",
+                    task_id, task_type, target_id, type(e).__name__, str(e)[:200],
+                )
                 self._update_task(
                     task_id,
                     status="failed",

--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -802,25 +802,42 @@ class MainChatService:
                 )
                 # No on_event emit — the SSE generator is already closed.
             elif cancelled:
-                # Proxy / connection drop, NOT a user-initiated stop. Persist
-                # the accumulated text as a normal assistant message so the
-                # frontend's recoverChatFromServer surfaces real content
-                # instead of a mislabeled stub.
-                recovered_content = final_text if final_text.strip() else "I've processed your request."
-                logger.warning(
-                    "PROXY_DISCONNECT_PERSIST chat=%s content_len=%d "
-                    "iterations=%d — persisting partial response (proxy "
-                    "or browser closed the SSE connection before "
-                    "assistant_done could fire).",
-                    chat_id, len(recovered_content), iteration,
-                )
-                assistant_msg = message_service.add_assistant_message(
-                    project_id=project_id,
-                    chat_id=chat_id,
-                    content=recovered_content,
-                    model=response.get("model"),
-                    tokens=response.get("usage"),
-                )
+                # Proxy / connection drop, NOT a user-initiated stop.
+                #
+                # If we accumulated real text before the drop, persist it as a
+                # normal assistant message so the frontend's
+                # recoverChatFromServer surfaces real content instead of a
+                # mislabeled stub.
+                #
+                # If we accumulated NOTHING (proxy dropped during the initial
+                # Claude latency, before any deltas streamed), do NOT persist
+                # a bogus "I've processed your request." reply — that would
+                # break the conversation flow with an answer that has nothing
+                # to do with the user's question. Leave the user-side message
+                # without an assistant reply; the user can re-send.
+                if final_text.strip():
+                    logger.warning(
+                        "PROXY_DISCONNECT_PERSIST chat=%s content_len=%d "
+                        "iterations=%d — persisting partial response (proxy "
+                        "or browser closed the SSE connection before "
+                        "assistant_done could fire).",
+                        chat_id, len(final_text), iteration,
+                    )
+                    assistant_msg = message_service.add_assistant_message(
+                        project_id=project_id,
+                        chat_id=chat_id,
+                        content=final_text,
+                        model=response.get("model"),
+                        tokens=response.get("usage"),
+                    )
+                else:
+                    logger.warning(
+                        "PROXY_DISCONNECT_NO_CONTENT chat=%s iterations=%d "
+                        "— skipping persist; no assistant text accumulated "
+                        "before disconnect (user can re-send their question).",
+                        chat_id, iteration,
+                    )
+                    assistant_msg = None
                 # No on_event emit — generator already closed.
             else:
                 assistant_msg = message_service.add_assistant_message(

--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -481,6 +481,7 @@ class MainChatService:
         on_text_delta: Optional[Callable[[str], None]] = None,
         on_event: Optional[Callable[[str, Dict[str, Any]], None]] = None,
         cancel_event: Optional["object"] = None,
+        user_stop_event: Optional["object"] = None,
     ) -> Dict[str, Any]:
         """
         Shared chat runner for both non-streaming and streaming flows.
@@ -771,15 +772,22 @@ class MainChatService:
 
             final_text = "\n\n".join(accumulated_text_parts) if accumulated_text_parts else ""
 
-            # If the user clicked Stop while we were generating, persist a
-            # stub assistant message marked as interrupted instead of the
-            # full response. The chat history then reads as
-            # "question → (stopped) → next question → answer", which is the
-            # intuitive narrative for the user. Without this guard the
-            # half-finished stream still landed in DB and showed up alongside
-            # the user's revised answer (the "2 responses" symptom).
-
-            if cancelled:
+            # Two cancellation flavours, each persisted differently:
+            #
+            # 1. EXPLICIT user-stop (user_stop_event set) — keep the original
+            #    UX: persist a stub marked "(stopped by user)" so the chat
+            #    reads "question → (stopped) → next question → answer". Same
+            #    behaviour as before the §2.1 fix.
+            #
+            # 2. CONNECTION drop (cancel_event set but user_stop_event NOT
+            #    set) — proxy idle-timeout or tab closed. Persist whatever
+            #    text actually accumulated, with a structured log line so an
+            #    admin can audit "are we losing responses to proxy timeouts?"
+            #    The frontend's recoverChatFromServer path picks the message
+            #    up on the next render. Before §2.1 this case was mislabeled
+            #    "(stopped by user)" — Delta's Symptom 9.
+            user_stopped = user_stop_event is not None and user_stop_event.is_set()
+            if cancelled and user_stopped:
                 stopped_content = (
                     final_text + "\n\n_(stopped by user)_"
                     if final_text.strip()
@@ -793,6 +801,27 @@ class MainChatService:
                     tokens=response.get("usage"),
                 )
                 # No on_event emit — the SSE generator is already closed.
+            elif cancelled:
+                # Proxy / connection drop, NOT a user-initiated stop. Persist
+                # the accumulated text as a normal assistant message so the
+                # frontend's recoverChatFromServer surfaces real content
+                # instead of a mislabeled stub.
+                recovered_content = final_text if final_text.strip() else "I've processed your request."
+                logger.warning(
+                    "PROXY_DISCONNECT_PERSIST chat=%s content_len=%d "
+                    "iterations=%d — persisting partial response (proxy "
+                    "or browser closed the SSE connection before "
+                    "assistant_done could fire).",
+                    chat_id, len(recovered_content), iteration,
+                )
+                assistant_msg = message_service.add_assistant_message(
+                    project_id=project_id,
+                    chat_id=chat_id,
+                    content=recovered_content,
+                    model=response.get("model"),
+                    tokens=response.get("usage"),
+                )
+                # No on_event emit — generator already closed.
             else:
                 assistant_msg = message_service.add_assistant_message(
                     project_id=project_id,
@@ -948,8 +977,17 @@ class MainChatService:
         user_id: Optional[str] = None,
         on_event: Optional[Callable[[str, Dict[str, Any]], None]] = None,
         cancel_event: Optional["object"] = None,
+        user_stop_event: Optional["object"] = None,
     ) -> Dict[str, Any]:
-        """Process a user message while streaming assistant text deltas."""
+        """Process a user message while streaming assistant text deltas.
+
+        cancel_event: short-circuit signal for the agent loop. Set on EITHER
+        explicit user-stop or any connection close.
+        user_stop_event: labeling signal. Set ONLY when the user explicitly
+        clicked Stop (POST /messages/stop). Drives the "(stopped by user)"
+        suffix; without it, a proxy idle-timeout was mislabeled the same way
+        as a real user-stop — Delta's Symptom 9.
+        """
         return self._run_message_flow(
             project_id=project_id,
             chat_id=chat_id,
@@ -963,6 +1001,7 @@ class MainChatService:
             ),
             on_event=on_event,
             cancel_event=cancel_event,
+            user_stop_event=user_stop_event,
         )
 
     def _generate_and_update_chat_title(

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -451,19 +451,27 @@ class ChatService:
         )
         return bool(resp.data)
 
-    def get_user_stopped_at(self, chat_id: str) -> Optional[str]:
+    def get_user_stopped_at(self, project_id: str, chat_id: str) -> Optional[str]:
         """Return the ISO timestamp of the last user-stop, or None.
 
         Called from the SSE GeneratorExit handler — must be cheap and
         safe to call from a worker thread. Tolerates network blips by
         returning None (the caller then labels as proxy-disconnect, which
         is the conservative default).
+
+        Scoped by (project_id, chat_id) as defense-in-depth on top of the
+        blueprint-level verify_project_access hook in messages/__init__.py.
+        Without the project_id filter, a tenant could probe another
+        tenant's chat metadata by passing their own project_id + the
+        target chat_id in the URL. Chat IDs are UUIDs (unguessable in
+        practice), but the cost of the extra WHERE clause is zero.
         """
         try:
             resp = (
                 self.supabase.table(self.table)
                 .select("user_stopped_at")
                 .eq("id", chat_id)
+                .eq("project_id", project_id)
                 .execute()
             )
         except Exception:

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -11,7 +11,7 @@ Separation of Concerns:
 - prompt_loader.py: Prompt management
 """
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Dict, List, Any
 
 from app.services.integrations.supabase import get_supabase, is_supabase_enabled
@@ -426,6 +426,51 @@ class ChatService:
         chat["message_count"] = count_response.count or 0
 
         return chat
+
+    def mark_user_stopped(self, project_id: str, chat_id: str) -> bool:
+        """Record that the user just clicked Stop on this chat.
+
+        Backs the §2.1 user-stop-vs-proxy-disconnect distinction. The SSE
+        worker's GeneratorExit handler reads `user_stopped_at` (via
+        `get_user_stopped_at`) and only treats the close as user-initiated
+        when the timestamp is fresher than the stream's start time.
+
+        Returns True if the row was updated (the project owns the chat),
+        False otherwise. The `eq("project_id", project_id)` scoping is
+        what prevents one tenant from poisoning another tenant's chat —
+        the WHERE clause filters out cross-project writes at the SQL
+        layer, defense-in-depth on top of the blueprint-level
+        verify_project_access hook in `app/api/messages/__init__.py`.
+        """
+        resp = (
+            self.supabase.table(self.table)
+            .update({"user_stopped_at": datetime.now(timezone.utc).isoformat()})
+            .eq("id", chat_id)
+            .eq("project_id", project_id)
+            .execute()
+        )
+        return bool(resp.data)
+
+    def get_user_stopped_at(self, chat_id: str) -> Optional[str]:
+        """Return the ISO timestamp of the last user-stop, or None.
+
+        Called from the SSE GeneratorExit handler — must be cheap and
+        safe to call from a worker thread. Tolerates network blips by
+        returning None (the caller then labels as proxy-disconnect, which
+        is the conservative default).
+        """
+        try:
+            resp = (
+                self.supabase.table(self.table)
+                .select("user_stopped_at")
+                .eq("id", chat_id)
+                .execute()
+            )
+        except Exception:
+            return None
+        if not resp.data:
+            return None
+        return resp.data[0].get("user_stopped_at")
 
     def update_chat(
         self,

--- a/backend/app/services/integrations/supabase/__init__.py
+++ b/backend/app/services/integrations/supabase/__init__.py
@@ -12,6 +12,7 @@ from .supabase_client import (
     get_auth_verifier_client,
     get_service_role_client,
     is_supabase_enabled,
+    check_singleton_identity,
     SupabaseClient,
 )
 from .auth_service import auth_service, AuthService
@@ -22,6 +23,7 @@ __all__ = [
     "get_auth_verifier_client",
     "get_service_role_client",
     "is_supabase_enabled",
+    "check_singleton_identity",
     "SupabaseClient",
     "auth_service",
     "AuthService",

--- a/backend/app/services/integrations/supabase/auth_service.py
+++ b/backend/app/services/integrations/supabase/auth_service.py
@@ -183,7 +183,13 @@ class AuthService:
                 "session": self._serialize_session(response.session),
             }
         except Exception as e:
-            logger.error("Token refresh failed: %s", e)
+            # Structured prefix pairs with AUTH_401_TRACE via the per-request
+            # req_id baked into every log record's format string. Together
+            # they answer: did refresh fail AND why? — in one grep.
+            logger.error(
+                "REFRESH_FAIL_TRACE err=%s:%s rt_suffix=%s",
+                type(e).__name__, str(e)[:200], refresh_token[-12:],
+            )
             return {"success": False, "error": "Token refresh failed"}
 
     def reset_password_email(self, email: str) -> Dict[str, Any]:

--- a/backend/app/services/integrations/supabase/supabase_client.py
+++ b/backend/app/services/integrations/supabase/supabase_client.py
@@ -246,3 +246,68 @@ def is_supabase_enabled() -> bool:
     cases where Supabase is not yet configured during initial setup.
     """
     return SupabaseClient.is_configured()
+
+
+def check_singleton_identity() -> dict:
+    """Introspect the data-singleton client's Authorization header.
+
+    Powers `GET /api/v1/debug/supabase-state`. The fad1921 fix isolated
+    the auth verifier so gotrue's on_auth_state_change listener can no
+    longer flip the data singleton's Authorization header — but only
+    after a container restart. This helper lets an operator confirm in
+    one HTTP call whether their running process is still polluted (still
+    needs a restart) without `docker exec`.
+
+    Returns a dict with:
+      - is_polluted: True if the singleton's Authorization header is
+        NOT pinned to SUPABASE_SERVICE_KEY.
+      - auth_header_prefix: first 30 chars of the actual header (for
+        eyeballing — never logs the full token).
+      - expected_prefix: first 30 chars of the expected header.
+      - reason: short human-readable explanation when polluted/unknown.
+    """
+    if SupabaseClient._instance is None:
+        return {
+            "is_polluted": None,
+            "reason": "Singleton not yet initialized.",
+            "auth_header_prefix": "",
+            "expected_prefix": "",
+        }
+
+    service_key = os.getenv("SUPABASE_SERVICE_KEY") or ""
+    if not service_key:
+        return {
+            "is_polluted": None,
+            "reason": "SUPABASE_SERVICE_KEY not set — cannot verify identity.",
+            "auth_header_prefix": "",
+            "expected_prefix": "",
+        }
+
+    expected = f"Bearer {service_key}"
+    try:
+        actual = (
+            SupabaseClient._instance.postgrest.session.headers.get(
+                "Authorization", ""
+            )
+            or ""
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort introspection
+        return {
+            "is_polluted": None,
+            "reason": f"Could not read singleton headers: {type(exc).__name__}",
+            "auth_header_prefix": "",
+            "expected_prefix": expected[:30],
+        }
+
+    return {
+        "is_polluted": actual != expected,
+        "auth_header_prefix": actual[:30],
+        "expected_prefix": expected[:30],
+        "reason": (
+            "Authorization header has been flipped off service_role — "
+            "restart the backend container to clear the pollution "
+            "(see commit fad1921)."
+            if actual != expected
+            else "Singleton identity is pinned to service_role as expected."
+        ),
+    }

--- a/backend/app/utils/auth_middleware.py
+++ b/backend/app/utils/auth_middleware.py
@@ -279,8 +279,15 @@ def validate_token() -> Optional[str]:
         # "log the user out on every GoTrue hiccup", which is strictly worse
         # — the user re-signs-in with the same token immediately.
         try:
+            # algorithms=[...] is required by PyJWT 3.x and emits a deprecation
+            # warning in some 2.x builds when omitted, even with
+            # verify_signature=False (signature isn't actually verified here —
+            # we just need PyJWT to forward-compile cleanly). Both supabase
+            # GoTrue and our own JWT_SECRET use HS256; RS256 is included as
+            # belt-and-braces for any future migration to asymmetric keys.
             unverified = jwt.decode(
                 token,
+                algorithms=["HS256", "RS256"],
                 options={
                     "verify_signature": False,
                     "verify_aud": False,

--- a/backend/app/utils/auth_middleware.py
+++ b/backend/app/utils/auth_middleware.py
@@ -204,7 +204,10 @@ def validate_token() -> Optional[str]:
                         return user_id
                     # GoTrue says no — token has been revoked (sign-out,
                     # password change, admin force-revoke).
-                    logger.info("Token revoked by GoTrue — denying access")
+                    logger.warning(
+                        "AUTH_401_TRACE branch=fast_revoked user_id=%s token_suffix=%s",
+                        user_id, token[-12:],
+                    )
                     return None
                 except Exception as e:
                     # GoTrue itself is unreachable (network blip, GoTrue
@@ -214,9 +217,8 @@ def validate_token() -> Optional[str]:
                     # matches the historical fail-open behaviour of the
                     # cache-hit path.
                     logger.warning(
-                        "Revocation check failed (GoTrue unreachable: %s: %s) — "
-                        "trusting local signature for the next %ds",
-                        type(e).__name__, e, _TOKEN_CACHE_TTL,
+                        "AUTH_401_TRACE branch=fast_failopen err=%s:%s token_suffix=%s ttl=%ds",
+                        type(e).__name__, str(e)[:120], token[-12:], _TOKEN_CACHE_TTL,
                     )
                     _cache_token(token, user_id)
                     return user_id
@@ -239,7 +241,10 @@ def validate_token() -> Optional[str]:
             logger.warning("Local JWT decode raised %s: %s — falling back to Auth", type(e).__name__, e)
 
     # Slow path (no JWT_SECRET configured, or local decode hit an unexpected
-    # exception): cache + Supabase Auth roundtrip. Same behaviour as before.
+    # exception): cache + Supabase Auth roundtrip. Same behaviour as before
+    # for the happy path; the exception path now mirrors the fast-path
+    # fail-open at lines ~209-222 to avoid logging users out on a transient
+    # GoTrue blip (Delta's Symptom 1/2 cascade).
     cached_user_id = _get_cached_user_id(token)
     if cached_user_id:
         return cached_user_id
@@ -251,14 +256,62 @@ def validate_token() -> Optional[str]:
         user_response = supabase.auth.get_user(token)
 
         if not user_response or not user_response.user:
-            logger.warning("Auth get_user returned no user")
+            logger.warning(
+                "AUTH_401_TRACE branch=slow_nouser token_suffix=%s",
+                token[-12:],
+            )
             return None
 
         user_id = str(user_response.user.id)
         _cache_token(token, user_id)
         return user_id
     except Exception as e:
-        logger.warning("Token validation failed: %s: %s", type(e).__name__, e)
+        # GoTrue itself raised (network blip, container restart, rate limit).
+        # Before §2.3, this short-circuited to None → 401 → frontend kicked
+        # the user out. With JWT_SECRET unset (a common self-hosted misconfig
+        # at Delta) the fast-path fail-open isn't available — so we re-create
+        # its effect HERE by decoding the JWT for its `sub` claim WITHOUT
+        # signature verification. Expiry is still enforced so a stale token
+        # can't ride this branch.
+        #
+        # Security note: we only reach this path AFTER auth.get_user(token)
+        # has already failed for non-credential reasons. The alternative is
+        # "log the user out on every GoTrue hiccup", which is strictly worse
+        # — the user re-signs-in with the same token immediately.
+        try:
+            unverified = jwt.decode(
+                token,
+                options={
+                    "verify_signature": False,
+                    "verify_aud": False,
+                    "verify_exp": True,
+                },
+            )
+            user_id_unverified = unverified.get("sub")
+            if user_id_unverified:
+                logger.warning(
+                    "AUTH_401_TRACE branch=slow_failopen err=%s:%s token_suffix=%s ttl=%ds",
+                    type(e).__name__, str(e)[:120], token[-12:], _TOKEN_CACHE_TTL,
+                )
+                user_id_unverified = str(user_id_unverified)
+                _cache_token(token, user_id_unverified)
+                return user_id_unverified
+        except Exception as decode_exc:
+            # Token is structurally invalid OR expired — fall through to the
+            # original "return None" so the user really is asked to sign in.
+            logger.warning(
+                "AUTH_401_TRACE branch=slow_failopen_rejected err=%s:%s decode_err=%s:%s token_suffix=%s",
+                type(e).__name__, str(e)[:80],
+                type(decode_exc).__name__, str(decode_exc)[:80],
+                token[-12:],
+            )
+            return None
+
+        # `sub` was missing despite a clean decode — same fall-through.
+        logger.warning(
+            "AUTH_401_TRACE branch=slow_exception err=%s:%s token_suffix=%s",
+            type(e).__name__, str(e)[:120], token[-12:],
+        )
         return None
 
 

--- a/backend/app/utils/error_responses.py
+++ b/backend/app/utils/error_responses.py
@@ -1,0 +1,143 @@
+"""
+Typed error → HTTP response mapping.
+
+Most route handlers in the codebase use a broad `except Exception` followed by
+`jsonify({"success": False, "error": str(e)}), 500`. That turns every failure
+mode — database unreachable, Claude rate-limit, supabase RPC denied — into
+the same shape: a 500 with whatever stringification the exception happens to
+produce. The frontend then shows "Failed to send message" with no actionable
+detail.
+
+This module classifies common exception types and returns a richer triple:
+  (HTTP status, user-safe message, internal log message)
+
+so that:
+  - The HTTP status reflects what went wrong (502 for upstream, 429 for rate,
+    503 for service-state, 500 for genuinely unknown).
+  - Frontend toasts can show "Database unreachable — check the connection URI"
+    instead of "Failed to X", because the response body carries that string.
+  - Internal logs still get the full exception representation for debugging.
+
+USAGE in a route:
+
+    from app.utils.error_responses import error_response
+
+    try:
+        do_work()
+    except Exception as exc:
+        return error_response(exc, default_log="Error doing work")
+
+The broad `except Exception` is preserved on purpose — this is additive, not
+a replacement for try/except. We don't want to lose any failure path.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Tuple
+
+from flask import Response, current_app, jsonify
+
+logger = logging.getLogger(__name__)
+
+
+# Import the exception types we want to classify, but defensively — if a
+# dependency is missing in a particular environment the classifier still
+# works for the ones that ARE importable.
+try:  # noqa: SIM105
+    import psycopg2  # type: ignore
+    _PSYCOPG2_OPERATIONAL = psycopg2.OperationalError
+except Exception:  # noqa: BLE001
+    _PSYCOPG2_OPERATIONAL = None
+
+try:
+    from pymysql.err import OperationalError as _PYMYSQL_OPERATIONAL  # type: ignore
+except Exception:  # noqa: BLE001
+    _PYMYSQL_OPERATIONAL = None
+
+try:
+    import anthropic  # type: ignore
+    _ANTHROPIC_STATUS_ERROR = getattr(anthropic, "APIStatusError", None)
+    _ANTHROPIC_TIMEOUT = getattr(anthropic, "APITimeoutError", None)
+    _ANTHROPIC_CONNECTION = getattr(anthropic, "APIConnectionError", None)
+    _ANTHROPIC_RATE_LIMIT = getattr(anthropic, "RateLimitError", None)
+except Exception:  # noqa: BLE001
+    _ANTHROPIC_STATUS_ERROR = None
+    _ANTHROPIC_TIMEOUT = None
+    _ANTHROPIC_CONNECTION = None
+    _ANTHROPIC_RATE_LIMIT = None
+
+try:
+    from postgrest.exceptions import APIError as _POSTGREST_API_ERROR  # type: ignore
+except Exception:  # noqa: BLE001
+    _POSTGREST_API_ERROR = None
+
+
+def _is_instance_safe(exc: Exception, cls: Optional[type]) -> bool:
+    return cls is not None and isinstance(exc, cls)
+
+
+def classify(exc: Exception) -> Tuple[int, str]:
+    """Return `(status_code, user_safe_message)` for the given exception.
+
+    Falls back to (500, "Unexpected server error — see logs") for anything
+    not recognised, preserving the historical behaviour.
+    """
+    # External database connection failures (psycopg2 / pymysql).
+    if _is_instance_safe(exc, _PSYCOPG2_OPERATIONAL) or _is_instance_safe(exc, _PYMYSQL_OPERATIONAL):
+        return 502, "Database unreachable — check the connection URI, host, port, and firewall."
+
+    # Anthropic API issues. RateLimitError extends APIStatusError so it must
+    # be checked first.
+    if _is_instance_safe(exc, _ANTHROPIC_RATE_LIMIT):
+        return 429, "Claude rate limit reached — please retry in a moment."
+    if _is_instance_safe(exc, _ANTHROPIC_TIMEOUT) or _is_instance_safe(exc, _ANTHROPIC_CONNECTION):
+        return 502, "Claude API temporarily unavailable — please retry."
+    if _is_instance_safe(exc, _ANTHROPIC_STATUS_ERROR):
+        status = getattr(exc, "status_code", 502) or 502
+        if 500 <= status < 600:
+            return 502, "Claude API returned a server error — please retry."
+        # 4xx from Anthropic is usually our fault (bad request shape), but
+        # surface it as 502 to avoid leaking internals to the user.
+        return 502, "Claude API rejected the request — please retry or contact support."
+
+    # Postgrest auth/permission errors — most notably the 42501 that the
+    # supabase-py listener-pollution bug surfaces post-restart-required.
+    if _is_instance_safe(exc, _POSTGREST_API_ERROR):
+        code = getattr(exc, "code", None) or ""
+        if code == "42501":
+            return 503, (
+                "A backend service auth state needs reset. "
+                "Please contact your admin to restart the server."
+            )
+        return 502, "Database service returned an error — please retry."
+
+    return 500, "Unexpected server error — see logs."
+
+
+def error_response(
+    exc: Exception,
+    *,
+    default_log: str = "Unhandled exception",
+    extra: Optional[dict[str, Any]] = None,
+) -> Tuple[Response, int]:
+    """Build a Flask response from a classified exception.
+
+    The internal log line includes the full exception (type + str + stack)
+    so debugging isn't degraded. The response body carries only the
+    user-safe message.
+    """
+    status, user_message = classify(exc)
+    # Use current_app.logger so the route's normal logging configuration
+    # (handlers, filters, formatters with req_id) is honoured.
+    try:
+        current_app.logger.exception("%s: %s: %s", default_log, type(exc).__name__, exc)
+    except RuntimeError:
+        # Outside an app context — extremely unlikely from a route, but
+        # don't lose the trace if it happens (e.g. background-thread caller
+        # using this helper).
+        logger.exception("%s: %s: %s", default_log, type(exc).__name__, exc)
+
+    body: dict[str, Any] = {"success": False, "error": user_message}
+    if extra:
+        body.update(extra)
+    return jsonify(body), status

--- a/backend/app/utils/logger.py
+++ b/backend/app/utils/logger.py
@@ -16,6 +16,26 @@ LOG_DIR: Path | None = None
 LOG_FILE: Path | None = None
 
 
+class _RequestIdFilter(logging.Filter):
+    """Inject the current request's correlation ID onto every LogRecord.
+
+    Why: without this, a frontend bug report ("logged out at 14:32") has no
+    way to find the corresponding backend log line. The req_id is set by the
+    before_request hook in `app/api/__init__.py`. For records emitted outside
+    Flask request context (startup, background ThreadPoolExecutor workers,
+    CLI helpers) the placeholder "-" is used so the format string still
+    renders cleanly.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not hasattr(record, "req_id"):
+            # Lazy import — logger.py must stay importable without Flask
+            # (some test paths and CLI helpers touch this before app init).
+            from app.utils.request_context import get_request_id
+            record.req_id = get_request_id()
+        return True
+
+
 def setup_logging(log_level: str = "DEBUG") -> None:
     """
     Configure the root logger with a human-readable format.
@@ -33,15 +53,22 @@ def setup_logging(log_level: str = "DEBUG") -> None:
 
     level = getattr(logging, log_level.upper(), logging.DEBUG)
 
+    # The `[req:%(req_id)s]` segment is what makes frontend-↔-backend
+    # correlation possible. The matching parser at
+    # `app/api/logs/routes.py:_LINE_RE` accepts both the new and the old
+    # shape so already-rotated archives still display in the admin UI.
     formatter = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        "%(asctime)s [%(levelname)s] %(name)s [req:%(req_id)s]: %(message)s",
         datefmt="%H:%M:%S",
     )
+
+    req_id_filter = _RequestIdFilter()
 
     handlers: list[logging.Handler] = []
 
     stream_handler = logging.StreamHandler(sys.stdout)
     stream_handler.setFormatter(formatter)
+    stream_handler.addFilter(req_id_filter)
     handlers.append(stream_handler)
 
     # File handler. Imported lazily so logger.py stays importable without
@@ -61,6 +88,7 @@ def setup_logging(log_level: str = "DEBUG") -> None:
             encoding="utf-8",
         )
         file_handler.setFormatter(formatter)
+        file_handler.addFilter(req_id_filter)
         handlers.append(file_handler)
     except Exception as exc:  # noqa: BLE001 — file handler is best-effort
         # Don't crash startup if the volume isn't writable — stdout still

--- a/backend/app/utils/request_context.py
+++ b/backend/app/utils/request_context.py
@@ -7,22 +7,57 @@ with the X-Request-Id middleware in `app/api/__init__.py` and the matching
 header on the frontend axios client, closes that gap. Every log record gets
 stamped with the current request's UUID; structured tracers (AUTH_401_TRACE
 etc.) include it in the message body too.
+
+Background threads (the SSE worker spawned for chat streaming, source-
+processing tasks, etc.) leave Flask's request context — their log records
+default to req_id="-" unless they explicitly opt into propagation via
+`set_worker_req_id()`. The SSE worker in `app/api/messages/routes.py` does
+this so that PROXY_DISCONNECT_PERSIST and other main_chat_service trace
+lines stay grep-able against the originating frontend request_id.
 """
 from __future__ import annotations
+
+import contextvars
+
+# ContextVars are per-thread and per-asyncio-task. The SSE worker thread
+# sets this once at the top of `worker()`; every log call from that
+# thread (including main_chat_service's PROXY_DISCONNECT_PERSIST) then
+# sees the right req_id via `get_request_id()`.
+_worker_req_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "noobbook_worker_req_id", default="-"
+)
+
+
+def set_worker_req_id(req_id: str) -> None:
+    """Stash a req_id in a thread-local ContextVar.
+
+    Call this from the top of any background worker that wants its log
+    lines correlated with the originating HTTP request. The Flask request
+    context doesn't cross thread boundaries; this is the explicit opt-in.
+    """
+    if req_id:
+        _worker_req_id.set(req_id)
 
 
 def get_request_id() -> str:
     """
-    Return the current request's correlation ID, or "-" outside request context.
+    Return the current request's correlation ID, or "-" if neither source
+    is set.
 
-    Safe to call from anywhere — including background ThreadPoolExecutor
-    workers that have no Flask request context. In that case "-" is
-    returned so the format string still renders cleanly.
+    Resolution order:
+      1. Flask request context (`g.req_id`) — covers normal HTTP handlers.
+      2. ContextVar (`_worker_req_id`) — covers background workers that
+         called `set_worker_req_id()`.
+      3. Literal "-" — covers startup / CLI / un-instrumented threads.
+
+    Safe to call from anywhere; never raises.
     """
     try:
         from flask import g, has_request_context
         if has_request_context():
-            return getattr(g, "req_id", "-") or "-"
+            rid = getattr(g, "req_id", None)
+            if rid:
+                return rid
     except Exception:
         pass
-    return "-"
+    return _worker_req_id.get()

--- a/backend/app/utils/request_context.py
+++ b/backend/app/utils/request_context.py
@@ -1,0 +1,28 @@
+"""
+Per-request context helpers — req_id propagation.
+
+Educational Note: There is no way today to take a frontend "I was logged out at
+14:32" report and find the corresponding backend log line. This helper, paired
+with the X-Request-Id middleware in `app/api/__init__.py` and the matching
+header on the frontend axios client, closes that gap. Every log record gets
+stamped with the current request's UUID; structured tracers (AUTH_401_TRACE
+etc.) include it in the message body too.
+"""
+from __future__ import annotations
+
+
+def get_request_id() -> str:
+    """
+    Return the current request's correlation ID, or "-" outside request context.
+
+    Safe to call from anywhere — including background ThreadPoolExecutor
+    workers that have no Flask request context. In that case "-" is
+    returned so the format string still renders cleanly.
+    """
+    try:
+        from flask import g, has_request_context
+        if has_request_context():
+            return getattr(g, "req_id", "-") or "-"
+    except Exception:
+        pass
+    return "-"

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -20,6 +20,14 @@ mkdir -p data/projects data/tasks data/temp
 # Production: use Gunicorn (production WSGI server with gevent for concurrency)
 # Development: use Werkzeug dev server (auto-reload, debug mode)
 if [ "$FLASK_ENV" = "production" ]; then
+    # Mark every "pending"/"running" task left over from the previous
+    # container as failed. Done here (not in TaskService.__init__) so it
+    # runs exactly once per boot, regardless of how many gunicorn workers
+    # we spawn or how often they recycle.
+    echo "Cleaning up stale background tasks..."
+    RUN_STALE_TASK_CLEANUP=1 python -c "from app.services.background_services.task_service import TaskService; TaskService()" \
+      || echo "  (warning: stale-task cleanup failed, continuing)"
+
     echo "Starting Gunicorn (production)..."
     exec gunicorn -c gunicorn.conf.py "run:app"
 else

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -1,32 +1,22 @@
 """
 Gunicorn configuration for NoobBook production deployment.
-
-Educational Note: Gunicorn is a production-grade WSGI server that replaces
-Flask's built-in Werkzeug dev server. Key differences:
-- Werkzeug: single-process, no crash recovery, not designed for real traffic
-- Gunicorn + gevent: handles hundreds of concurrent connections via greenlets
-  (cooperative multitasking), auto-restarts crashed workers, proper timeouts
-
-We use gevent-websocket worker class because Flask-SocketIO needs WebSocket
-support. With gevent, a single worker can handle many concurrent I/O-bound
-requests (Claude API calls, Supabase queries) without blocking.
 """
 import os
 
-# Bind to the configured port (default 5001)
 bind = f"0.0.0.0:{os.getenv('PORT', '5001')}"
 
-# Flask-SocketIO requires exactly 1 worker when not using a message queue
-# (like Redis). This is fine because gevent handles concurrency via greenlets,
-# not OS processes. One gevent worker can serve hundreds of concurrent requests.
-workers = 1
+# Multiple workers so a single blocking job (PDF batch, Playwright launch,
+# ffmpeg, LibreOffice subprocess) cannot wedge the entire backend.
+# Flask-SocketIO is initialized but no @socketio.on / socketio.emit handlers
+# are registered, so cross-worker state coordination isn't required and
+# raising workers above 1 is safe. Override via GUNICORN_WORKERS env var.
+workers = int(os.getenv("GUNICORN_WORKERS", "4"))
 
-# GeventWebSocketWorker supports both regular HTTP and WebSocket connections.
-# It calls monkey.patch_all() automatically in each worker's init_process()
-# before the app is loaded — no manual monkey-patching needed in app code.
-# NOTE: Do NOT set preload_app = True. That would monkey-patch the master
-# process before forking, breaking signal handling and graceful shutdown.
 worker_class = "geventwebsocket.gunicorn.workers.GeventWebSocketWorker"
+
+# Concurrent greenlets per worker. With 4 workers x 200 = 800 concurrent
+# in-flight requests possible.
+worker_connections = int(os.getenv("GUNICORN_WORKER_CONNECTIONS", "200"))
 
 # Request timeout: if a worker doesn't respond within this time, Gunicorn
 # kills and restarts it. 600s gives long Claude tool loops AND gigabyte

--- a/backend/supabase/migrations/00042_chat_user_stopped_at.sql
+++ b/backend/supabase/migrations/00042_chat_user_stopped_at.sql
@@ -1,0 +1,30 @@
+-- Migration: chats.user_stopped_at — durable user-stop signal for SSE streams.
+-- Created: 2026-05-18
+--
+-- Background: §2.1 introduced a way to distinguish "user clicked Stop" from
+-- "proxy idle-timeout closed the connection" so the assistant response no
+-- longer gets the false-positive "(stopped by user)" label. The initial
+-- implementation used an in-process `_user_stopped_chats` set in
+-- `app/api/messages/routes.py`. Code review (H2) flagged that this breaks
+-- the moment gunicorn runs more than one worker — POST /messages/stop and
+-- the SSE GeneratorExit can land on different workers, so the marker is
+-- invisible to the worker that needs to read it. The uncommitted
+-- gunicorn.conf.py change on this branch raises workers to 4, making this
+-- imminent.
+--
+-- This migration replaces the per-process set with a single column on
+-- `chats`. The SSE worker's GeneratorExit handler reads
+-- `user_stopped_at` and only treats the close as a user-initiated stop
+-- when the timestamp is fresher than the stream's start time. That
+-- "freshness window" defeats the M1 race where a late-arriving /stop
+-- POST would otherwise leak its marker into the chat's next message.
+--
+-- Default NULL is required: existing chats stay untouched and the SELECT
+-- on the GeneratorExit path returns NULL → treated as "no user stop"
+-- (matches the pre-feature behaviour exactly).
+
+ALTER TABLE chats
+  ADD COLUMN IF NOT EXISTS user_stopped_at TIMESTAMPTZ DEFAULT NULL;
+
+COMMENT ON COLUMN chats.user_stopped_at IS
+  'Last time the user clicked Stop on this chat (POST /messages/stop). The SSE worker compares this against its own stream-start time on GeneratorExit; a fresher timestamp means the user really did click Stop and the assistant message should be labeled accordingly. Older timestamps are ignored — they refer to a previous message and never apply to the current stream.';

--- a/backend/tests/test_auth_failopen.py
+++ b/backend/tests/test_auth_failopen.py
@@ -1,0 +1,146 @@
+"""
+Regression tests for §2.3 — slow-path fail-open in auth_middleware.
+
+Background:
+  Before §2.3, the slow-path branch (JWT_SECRET unset OR fast-path raised an
+  unexpected exception) had no fail-open: any GoTrue exception → return None
+  → 401 → frontend logout cascade. That's the most plausible mechanism
+  behind Delta's Symptom 1 (logout while 4-5 DBs are processing — burst
+  load on GoTrue surfaces transient errors).
+
+  The fix mirrors the fast-path fail-open: on GoTrue exception, decode the
+  JWT WITHOUT signature verification to extract `sub`. Expiry is still
+  enforced (jwt.decode raises ExpiredSignatureError) so stale tokens can't
+  ride this branch. Successful fail-open caches the result for 60s.
+
+Notes on the fixture strategy:
+  The conftest `app` fixture goes through `create_app("testing")` which
+  pulls in the whole service graph and gets tangled with pytest-flask's
+  autouse `_configure_application` hook in this repo's Python 3.14 venv.
+  We don't need any of that — `validate_token()` only touches Flask's
+  request context for `request.headers` / `request.args`. So we build a
+  minimal Flask app inline and drive test_request_context off it. Fast,
+  no autouse coupling, and orthogonal to the rest of the suite.
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import jwt
+import pytest
+from flask import Flask
+
+from app.utils import auth_middleware
+
+
+@pytest.fixture
+def minimal_app() -> Flask:
+    """A tiny Flask app — just enough to provide request context."""
+    return Flask(__name__)
+
+
+def _make_token(sub: str, expires_in: int = 3600, secret: str = "irrelevant") -> str:
+    """Build a JWT with a given sub and expiry. The signature is signed with
+    a throwaway secret because the fail-open path doesn't verify it."""
+    payload = {
+        "sub": sub,
+        "exp": int(time.time()) + expires_in,
+        "aud": "authenticated",
+        "iat": int(time.time()),
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+@pytest.fixture
+def slow_path_only(monkeypatch):
+    """Force the slow path by unsetting JWT_SECRET in the module.
+
+    The fast-path constant is read once at import time, so we have to
+    patch it on the module rather than via os.environ.
+    """
+    monkeypatch.setattr(auth_middleware, "_JWT_SECRET", "")
+    # Clear the per-process token cache so each test starts fresh.
+    with auth_middleware._cache_lock:
+        auth_middleware._token_cache.clear()
+        auth_middleware._token_locks.clear()
+    yield
+
+
+class TestSlowPathFailOpen:
+
+    def test_failopen_returns_user_id_when_gotrue_raises(self, minimal_app, slow_path_only):
+        token = _make_token("user-42")
+        with minimal_app.test_request_context(
+            "/api/v1/foo",
+            headers={"Authorization": f"Bearer {token}"},
+        ):
+            with patch(
+                "app.utils.auth_middleware.get_auth_verifier_client",
+            ) as mock_client:
+                # Simulate GoTrue blip — auth.get_user raises.
+                mock_client.return_value.auth.get_user.side_effect = (
+                    ConnectionError("GoTrue unreachable")
+                )
+                result = auth_middleware.validate_token()
+        # Before the fix: result would be None (user logged out).
+        # After:           we trust the locally-decoded sub for 60s.
+        assert result == "user-42"
+
+    def test_failopen_caches_result(self, minimal_app, slow_path_only):
+        token = _make_token("user-cache")
+        with minimal_app.test_request_context(
+            "/api/v1/foo",
+            headers={"Authorization": f"Bearer {token}"},
+        ):
+            with patch(
+                "app.utils.auth_middleware.get_auth_verifier_client",
+            ) as mock_client:
+                mock_client.return_value.auth.get_user.side_effect = (
+                    ConnectionError("blip")
+                )
+                # First call: fail-open trusts the locally-decoded sub.
+                assert auth_middleware.validate_token() == "user-cache"
+                # Second call within the cache TTL should NOT hit GoTrue again.
+                assert auth_middleware.validate_token() == "user-cache"
+                # Exactly 1 GoTrue call across both validate_token() calls.
+                assert mock_client.return_value.auth.get_user.call_count == 1
+
+    def test_failopen_rejects_expired_token(self, minimal_app, slow_path_only):
+        """Expiry is still enforced — a stale token can't ride the fail-open."""
+        token = _make_token("user-stale", expires_in=-60)
+        with minimal_app.test_request_context(
+            "/api/v1/foo",
+            headers={"Authorization": f"Bearer {token}"},
+        ):
+            with patch(
+                "app.utils.auth_middleware.get_auth_verifier_client",
+            ) as mock_client:
+                mock_client.return_value.auth.get_user.side_effect = (
+                    ConnectionError("blip")
+                )
+                result = auth_middleware.validate_token()
+        assert result is None, "Expired tokens must not fail-open."
+
+    def test_failopen_rejects_malformed_token(self, minimal_app, slow_path_only):
+        """Garbage in the Authorization header → no auth (fail-open requires
+        a structurally valid JWT)."""
+        with minimal_app.test_request_context(
+            "/api/v1/foo",
+            headers={"Authorization": "Bearer not-a-real-jwt-just-some-string"},
+        ):
+            with patch(
+                "app.utils.auth_middleware.get_auth_verifier_client",
+            ) as mock_client:
+                mock_client.return_value.auth.get_user.side_effect = (
+                    ConnectionError("blip")
+                )
+                result = auth_middleware.validate_token()
+        assert result is None
+
+    def test_no_token_returns_none(self, minimal_app, slow_path_only):
+        """Sanity-check: missing Authorization header still fails (we don't
+        want the fail-open path to be confused with "no auth required")."""
+        with minimal_app.test_request_context("/api/v1/foo"):
+            result = auth_middleware.validate_token()
+        assert result is None

--- a/backend/tests/test_auth_refresh.py
+++ b/backend/tests/test_auth_refresh.py
@@ -1,0 +1,92 @@
+"""
+Backend contract tests for POST /api/v1/auth/refresh.
+
+Pins the response shapes that the frontend's cross-tab refresh-token
+rotation fix branches off:
+  - HTTP 200 + {success: true, session: {access_token, refresh_token}}
+    when the refresh succeeded.
+  - HTTP 401 + {success: false, error: "Token refresh failed"}
+    when supabase-py raised "Invalid Refresh Token: Already Used"
+    (the GoTrue rotation race that the cross-tab fix in
+    frontend/src/lib/api/client.ts depends on).
+
+A future supabase-py upgrade could change the error shape, and the
+frontend's reactive cross-tab branch depends on `status === 401`. Pinning
+that here protects against silent contract drift.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from flask import Flask
+
+from app.api.auth import auth_bp
+
+
+def _app() -> Flask:
+    """Build a minimal Flask app that mounts just the auth blueprint.
+
+    Mirrors the inline-Flask pattern from test_proxy_disconnect.py and
+    test_auth_failopen.py — keeps these tests isolated from the broader
+    `create_app('testing')` fixture issue that pytest-flask exposes in
+    this venv's Python 3.14.
+    """
+    a = Flask(__name__)
+    a.register_blueprint(auth_bp, url_prefix='/api/v1')
+    return a
+
+
+class TestAuthRefreshContract:
+
+    def test_success_returns_200_with_session_body(self):
+        with patch(
+            'app.api.auth.routes.auth_service.refresh_with_token',
+            return_value={
+                'success': True,
+                'session': {
+                    'access_token': 'access-rotated',
+                    'refresh_token': 'refresh-rotated',
+                    'expires_in': 3600,
+                    'token_type': 'bearer',
+                },
+            },
+        ):
+            client = _app().test_client()
+            resp = client.post('/api/v1/auth/refresh', json={'refresh_token': 'r'})
+
+        assert resp.status_code == 200
+        assert resp.json['success'] is True
+        assert resp.json['session']['access_token'] == 'access-rotated'
+        assert resp.json['session']['refresh_token'] == 'refresh-rotated'
+
+    def test_already_used_token_returns_401_matching_frontend_contract(self):
+        """The exact failure mode behind Delta's spontaneous logouts.
+
+        When GoTrue rejects a refresh with refresh_token_already_used (HTTP
+        400 from /token), supabase-py's `refresh_session(rt)` raises and
+        the service wraps it as `{success: False, error: "Token refresh
+        failed"}`. The endpoint must surface this as HTTP 401 so the
+        frontend's `handle401Error` / cross-tab dedup branches see the
+        status they're written against.
+        """
+        with patch(
+            'app.api.auth.routes.auth_service.refresh_with_token',
+            return_value={'success': False, 'error': 'Token refresh failed'},
+        ):
+            client = _app().test_client()
+            resp = client.post('/api/v1/auth/refresh', json={'refresh_token': 'r'})
+
+        assert resp.status_code == 401
+        assert resp.json['success'] is False
+        assert resp.json['error'] == 'Token refresh failed'
+
+    def test_missing_refresh_token_returns_400(self):
+        """Sanity check on the input-validation path — body must include
+        `refresh_token`. Returns 400, not 401, so the frontend doesn't
+        treat a malformed-call as a rotation-race signal."""
+        client = _app().test_client()
+        resp = client.post('/api/v1/auth/refresh', json={})
+
+        assert resp.status_code == 400
+        assert resp.json['success'] is False
+        assert 'refresh_token' in resp.json['error']

--- a/backend/tests/test_proxy_disconnect.py
+++ b/backend/tests/test_proxy_disconnect.py
@@ -1,0 +1,194 @@
+"""
+Regression tests for §2.1 — user-stop vs proxy-disconnect distinction.
+
+Background:
+  Before §2.1 the SSE generator's `except GeneratorExit` always set a single
+  `cancel_event`, and `main_chat_service` then labeled the persisted
+  assistant message "(stopped by user)" regardless of whether the user
+  actually clicked Stop. Proxy idle-timeouts (Coolify/nginx dropping idle
+  SSE connections) produced false positives — that was Delta's Symptom 9.
+
+  The first iteration used an in-process `_user_stopped_chats` set. Code
+  review (H2) flagged that this breaks the moment gunicorn runs more than
+  one worker. The second iteration moves the marker to a `user_stopped_at`
+  TIMESTAMPTZ column on the `chats` table (migration 00042). The SSE
+  worker reads it on GeneratorExit and compares against its own
+  stream-start wall-clock — a fresher timestamp means the user really did
+  click Stop, an older one is leftover from a previous message (the M1
+  race) and is ignored.
+
+These tests verify the routing decisions and the labeling matrix, not the
+Claude tool loop itself.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from flask import Flask
+
+from app.api.messages import routes as messages_routes
+
+
+class TestStopMessageRoute:
+    """The /messages/stop endpoint writes chats.user_stopped_at via
+    chat_service. We call the route function directly inside a Flask test
+    request context — the full app factory has a separate pytest-flask
+    fixture issue (see test_auth_failopen.py)."""
+
+    def _call_stop(self, project_id: str, chat_id: str):
+        """Invoke stop_message inside a request context. Returns
+        (response, status)."""
+        app = Flask(__name__)
+        with app.test_request_context(
+            f"/api/v1/projects/{project_id}/chats/{chat_id}/messages/stop",
+            method="POST",
+        ):
+            return messages_routes.stop_message(project_id, chat_id)
+
+    def test_post_stop_writes_to_db_via_chat_service(self):
+        with patch.object(
+            messages_routes.chat_service, "mark_user_stopped", return_value=True,
+        ) as mock_mark:
+            resp, status = self._call_stop("proj-1", "chat-abc")
+        mock_mark.assert_called_once_with("proj-1", "chat-abc")
+        assert status == 200
+
+    def test_post_stop_404s_when_chat_not_in_project(self):
+        """mark_user_stopped returns False when the chat doesn't belong
+        to the project (the SQL `.eq("project_id", X)` clause filters it
+        out). This is the second-layer defence against cross-tenant
+        stop-injection on top of the verify_project_access blueprint hook."""
+        with patch.object(
+            messages_routes.chat_service, "mark_user_stopped", return_value=False,
+        ):
+            resp, status = self._call_stop("proj-1", "chat-not-mine")
+        assert status == 404
+
+    def test_post_stop_uses_error_response_on_supabase_failure(self):
+        """A blip in the chat_service write returns a typed error, not a
+        bare str(e). Frontend toast will show the user-safe message
+        instead of the internal exception text."""
+        with patch.object(
+            messages_routes.chat_service, "mark_user_stopped",
+            side_effect=RuntimeError("supabase 500"),
+        ), patch(
+            "app.api.messages.routes.error_response",
+        ) as mock_err:
+            mock_err.return_value = ({"success": False}, 500)
+            self._call_stop("proj-1", "chat-abc")
+        mock_err.assert_called_once()
+
+
+class TestGeneratorExitFreshness:
+    """The freshness window is what closes the M1 race: a /stop POST that
+    arrives AFTER the current message has already finished sets a
+    user_stopped_at timestamp that's BEFORE the next stream's start
+    wall-clock, so the next stream's GeneratorExit ignores it."""
+
+    @staticmethod
+    def _is_user_stop(stop_iso: str | None, stream_started: datetime) -> bool:
+        """Mirror the freshness check in routes.py GeneratorExit."""
+        if not stop_iso:
+            return False
+        try:
+            stopped_at = datetime.fromisoformat(stop_iso.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return False
+        return stopped_at > stream_started
+
+    def test_fresh_stop_during_stream_is_user_stop(self):
+        started = datetime.now(timezone.utc) - timedelta(seconds=30)
+        stopped = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
+        assert self._is_user_stop(stopped, started) is True
+
+    def test_stale_stop_from_previous_message_is_ignored(self):
+        """The M1 race regression test. A /stop POSTed yesterday must not
+        retroactively mark today's stream as user-stopped."""
+        started = datetime.now(timezone.utc) - timedelta(seconds=30)
+        stopped = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        assert self._is_user_stop(stopped, started) is False
+
+    def test_null_stop_column_is_not_user_stop(self):
+        """Default state for any new chat. Must NOT trip the user-stop path."""
+        started = datetime.now(timezone.utc)
+        assert self._is_user_stop(None, started) is False
+
+    def test_malformed_timestamp_is_conservative(self):
+        """Unparseable values fall to the conservative default (not
+        user-stop), matching the route-handler exception branch."""
+        started = datetime.now(timezone.utc)
+        assert self._is_user_stop("not-a-real-timestamp", started) is False
+
+    def test_z_suffix_iso_format_parses(self):
+        """Supabase returns timestamps with `+00:00` but other clients
+        sometimes use `Z`. Both must parse cleanly."""
+        started = datetime.now(timezone.utc) - timedelta(seconds=30)
+        stopped_z = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat().replace(
+            "+00:00", "Z"
+        )
+        assert self._is_user_stop(stopped_z, started) is True
+
+
+class TestLabelingBranches:
+    """main_chat_service writes one of three different message contents
+    depending on (cancelled, user_stopped). Exercise the matrix in
+    isolation — same shape as before H2."""
+
+    @staticmethod
+    def _label(cancelled: bool, user_stopped: bool, final_text: str) -> str:
+        if cancelled and user_stopped:
+            return (
+                final_text + "\n\n_(stopped by user)_"
+                if final_text.strip()
+                else "_(stopped by user)_"
+            )
+        if cancelled:
+            return final_text if final_text.strip() else "I've processed your request."
+        return final_text or "I've processed your request."
+
+    def test_user_stop_with_text_appends_marker(self):
+        assert self._label(True, True, "partial answer") == \
+            "partial answer\n\n_(stopped by user)_"
+
+    def test_user_stop_with_empty_text_is_marker_only(self):
+        assert self._label(True, True, "") == "_(stopped by user)_"
+
+    def test_proxy_disconnect_with_text_persists_text_unchanged(self):
+        """The new branch — was the false-positive case before §2.1."""
+        assert self._label(True, False, "partial answer") == "partial answer"
+        assert "stopped by user" not in self._label(True, False, "partial answer")
+
+    def test_proxy_disconnect_with_empty_text_uses_placeholder(self):
+        assert self._label(True, False, "") == "I've processed your request."
+
+    def test_normal_completion_persists_text(self):
+        assert self._label(False, False, "full answer") == "full answer"
+
+
+class TestRequestIdValidation:
+    """M2: malicious X-Request-Id must not slip through into log lines.
+    Mirrors the regex in app/api/__init__.py."""
+
+    def test_strict_alphanumeric_accepted(self):
+        from app.api import _REQ_ID_RE
+        assert _REQ_ID_RE.fullmatch("abc123") is not None
+        assert _REQ_ID_RE.fullmatch("a1b2c3-d4e5_f6") is not None
+
+    def test_log_injection_payload_rejected(self):
+        from app.api import _REQ_ID_RE
+        # The M2 review finding: `]` and `:` allowed by the previous
+        # whitespace-only validation could break the log-parser regex.
+        assert _REQ_ID_RE.fullmatch("abc]: spoofed-log [req:xyz") is None
+        assert _REQ_ID_RE.fullmatch("abc]:fake") is None
+        assert _REQ_ID_RE.fullmatch("abc def") is None
+        assert _REQ_ID_RE.fullmatch("abc;dangerous") is None
+
+    def test_too_long_rejected(self):
+        from app.api import _REQ_ID_RE
+        assert _REQ_ID_RE.fullmatch("a" * 65) is None
+        assert _REQ_ID_RE.fullmatch("a" * 64) is not None  # exactly at the limit
+
+    def test_empty_rejected(self):
+        from app.api import _REQ_ID_RE
+        assert _REQ_ID_RE.fullmatch("") is None

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,12 @@ COPY . .
 # Empty VITE_API_HOST makes the frontend use same-origin requests,
 # which nginx will proxy to the backend container.
 ENV VITE_API_HOST=""
+# Raise Node's heap limit for the build. Default ~2 GB on node:20-alpine
+# isn't enough once mermaid / blocknote / excalidraw / shadcn are in the
+# dep graph — `tsc -b && vite build` OOMs with "Reached heap limit" on
+# fresh installs. 4 GB is plenty and well below what any non-toy host
+# provides; the container still exits before the next stage runs.
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build
 
 # Stage 2: Serve with nginx

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -88,11 +88,13 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "happy-dom": "^20.9.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.18",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.1.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -5432,6 +5434,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -5734,6 +5743,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -5851,6 +5871,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/dom-mediacapture-record": {
       "version": "1.0.22",
@@ -5980,6 +6007,23 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
       "integrity": "sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.47.0",
@@ -6335,6 +6379,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.9.3",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.9.3.tgz",
@@ -6465,6 +6622,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -6745,6 +6912,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -7812,6 +7989,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -8097,6 +8281,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -8120,6 +8314,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -8517,6 +8721,37 @@
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -9621,6 +9856,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-cancellable-promise": {
@@ -11267,6 +11512,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -11429,6 +11685,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
@@ -13007,6 +13270,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
@@ -13060,6 +13330,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -13069,6 +13346,13 @@
       "engines": {
         "node": ">=0.1.14"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -13297,6 +13581,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -13340,6 +13641,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -13995,6 +14306,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -14045,6 +14459,16 @@
       "integrity": "sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==",
       "license": "MIT"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -14060,6 +14484,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -14068,6 +14509,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y-prosemirror": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@blocknote/core": "^0.49.0",
@@ -90,10 +92,12 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "happy-dom": "^20.9.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.18",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.1.6"
   }
 }

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -25,7 +25,7 @@ import { ChatEmptyState } from './ChatEmptyState';
 import { RawMessageView } from './RawMessageView';
 import { exportChatAsPdf } from '@/lib/exportChatPdf';
 import { createLogger } from '@/lib/logger';
-import { API_BASE_URL } from '@/lib/api/client';
+import { API_BASE_URL, extractServerError } from '@/lib/api/client';
 
 const log = createLogger('chat-panel');
 
@@ -915,11 +915,11 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             }
           } catch (fallbackError) {
             log.error({ err: fallbackError }, 'failed to send message via fallback');
-            errorWithLogs('Failed to send message');
+            errorWithLogs(extractServerError(fallbackError, 'Failed to send message'));
           }
         } else if (shouldFallback && hasAttachments) {
           log.warn('stream failed before user_message event with attachments — surfacing error so user can retry');
-          errorWithLogs('Failed to send message — please retry.');
+          errorWithLogs(extractServerError(err, 'Failed to send message — please retry.'));
         } else {
           // Stream errored mid-flight after delivering partial events
           // (canonical user_message and/or assistant_delta). Re-sending
@@ -963,9 +963,19 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   };
 
   /**
-   * Stop the current in-flight chat request
+   * Stop the current in-flight chat request.
+   *
+   * Order matters: signal the server BEFORE aborting the fetch. The server
+   * marker is what makes the difference between "(stopped by user)" and the
+   * generic recovery path on the backend (Symptom 9 fix). If the POST fails
+   * we still abort — the worst case becomes "the message gets persisted as a
+   * normal response instead of labeled stopped", which is fine.
    */
   const handleStop = () => {
+    if (activeChat) {
+      // Fire-and-forget. stopMessage swallows its own errors.
+      void chatsAPI.stopMessage(projectId, activeChat.id);
+    }
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
       abortControllerRef.current = null;

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -965,16 +965,33 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   /**
    * Stop the current in-flight chat request.
    *
-   * Order matters: signal the server BEFORE aborting the fetch. The server
-   * marker is what makes the difference between "(stopped by user)" and the
-   * generic recovery path on the backend (Symptom 9 fix). If the POST fails
-   * we still abort — the worst case becomes "the message gets persisted as a
-   * normal response instead of labeled stopped", which is fine.
+   * Order matters: signal the server BEFORE aborting the fetch, AND **await**
+   * the signal's network round-trip. We can't fire-and-forget here:
+   *
+   *   - `abortControllerRef.current.abort()` closes the SSE TCP connection
+   *     synchronously the next instruction.
+   *   - The backend's `GeneratorExit` handler fires within tens of ms.
+   *   - It reads `chats.user_stopped_at` to decide whether to label the
+   *     persisted assistant message as `(stopped by user)`.
+   *   - If the fire-and-forget `/messages/stop` POST hasn't reached the
+   *     backend yet, `user_stopped_at` is still NULL/stale, and the
+   *     message is mislabeled as `connection_dropped`.
+   *
+   * On localhost (~0.1 ms) the POST wins the race. On production WAN
+   * (~80-200 ms) it loses. Awaiting it costs the user a perceptible
+   * pause on slow connections but guarantees the label is correct.
+   *
+   * If the POST fails (network blip, 5xx) we still call abort() so the
+   * stream stops — the worst case is just a missing label, never a
+   * stuck stream.
    */
-  const handleStop = () => {
+  const handleStop = async () => {
     if (activeChat) {
-      // Fire-and-forget. stopMessage swallows its own errors.
-      void chatsAPI.stopMessage(projectId, activeChat.id);
+      try {
+        await chatsAPI.stopMessage(projectId, activeChat.id);
+      } catch {
+        // stopMessage logs internally; we still want to abort below.
+      }
     }
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();

--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression tests for cross-tab refresh-token rotation race.
+ *
+ * Background: production logs from 2026-05-18 captured the same Supabase
+ * user-id signed into Chrome-Mac + Firefox-Mac + Chrome-Linux concurrently.
+ * Each tab's `refreshPromise` dedup is module-level (per-tab). When the
+ * access token expired, two tabs raced /auth/refresh, GoTrue rotated the
+ * refresh-token chain on the first POST and rejected the second with
+ * `refresh_token_already_used` → HTTP 401 → frontend ran
+ * handlePermanentFailure → user kicked to AuthPage at 19:46:17, re-entered
+ * credentials at 19:46:22.
+ *
+ * These tests pin the three branches that close that gap:
+ *
+ *   1. Proactive: if another tab broadcast `refresh_succeeded` within the
+ *      freshness window, tryRefreshToken returns 'success' WITHOUT firing
+ *      a network call. Saves a round-trip and the wasted "abuse attempt"
+ *      log line on GoTrue.
+ *
+ *   2. Reactive (load-bearing): if /auth/refresh returns 401 AND another
+ *      tab broadcast within the window, tryRefreshToken returns 'success'
+ *      instead of 'permanent'. This is what prevents Delta's symptom.
+ *
+ *   3. Negative control: if /auth/refresh returns 401 with NO recent
+ *      cross-tab signal, the original handlePermanentFailure path stands.
+ *      Prevents the fix from silently masking real auth failures.
+ *
+ * Strategy: tests drive `tryRefreshToken` directly (via the `__test`
+ * export from client.ts) instead of routing through the axios interceptor
+ * chain — that keeps the failure-mode isolated and the asserts crisp.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import axios from 'axios';
+
+// ---- Module mocks ----------------------------------------------------------
+const sessionMocks = {
+  getAccessToken: vi.fn<() => string | null>(() => 'access-current'),
+  getRefreshToken: vi.fn<() => string | null>(() => 'refresh-current'),
+  setSession: vi.fn(),
+  clearSession: vi.fn(),
+};
+vi.mock('@/lib/auth/session', () => sessionMocks);
+
+const adminModeMocks = { notifySessionExpired: vi.fn() };
+vi.mock('@/lib/adminMode', () => adminModeMocks);
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Helper: send a refresh_succeeded broadcast and wait one tick so the
+// listener installed inside client.ts's module init has time to update
+// `lastOtherTabRefreshAt`.
+async function simulateOtherTabRefresh() {
+  const sender = new BroadcastChannel('noobbook-auth');
+  sender.postMessage({ type: 'refresh_succeeded', at: Date.now() });
+  await new Promise((r) => setTimeout(r, 5));
+  sender.close();
+}
+
+// Helper: import client.ts fresh so module-level state (the channel
+// instance, the storage listener, lastOtherTabRefreshAt) starts clean.
+async function freshClient() {
+  vi.resetModules();
+  return await import('@/lib/api/client');
+}
+
+describe('cross-tab refresh-token rotation', () => {
+  beforeEach(() => {
+    sessionMocks.getAccessToken.mockReturnValue('access-current');
+    sessionMocks.getRefreshToken.mockReturnValue('refresh-current');
+    sessionMocks.setSession.mockReset();
+    sessionMocks.clearSession.mockReset();
+    adminModeMocks.notifySessionExpired.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('proactive: skips network call when another tab refreshed recently', async () => {
+    const postSpy = vi.spyOn(axios, 'post');
+    const client = await freshClient();
+    await simulateOtherTabRefresh();
+
+    const outcome = await client.__test.tryRefreshToken();
+
+    expect(outcome).toBe('success');
+    // Load-bearing: zero network calls. Other tab already handled it.
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(sessionMocks.clearSession).not.toHaveBeenCalled();
+    expect(adminModeMocks.notifySessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('reactive: 401 + recent other-tab refresh = success (no logout)', async () => {
+    // Our POST loses the rotation race — GoTrue's refresh_token_already_used
+    // surfaces as a 401 on /auth/refresh (see backend test_auth_refresh.py).
+    const postSpy = vi.spyOn(axios, 'post').mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 401, data: { error: 'Token refresh failed' } },
+    });
+
+    const client = await freshClient();
+    await simulateOtherTabRefresh();
+    // Push the broadcast timestamp into our test window: we want
+    // `anotherTabRefreshedRecently()` true when the catch-branch checks it
+    // AFTER the axios.post rejection above resolves.
+    const outcome = await client.__test.tryRefreshToken();
+
+    expect(postSpy).toHaveBeenCalledTimes(0); // proactive short-circuit also fires here
+    // Either path (proactive or reactive) must land 'success' and leave
+    // the session intact — that's the user-visible win.
+    expect(outcome).toBe('success');
+    expect(sessionMocks.clearSession).not.toHaveBeenCalled();
+    expect(adminModeMocks.notifySessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('reactive (no proactive): 401 fires AFTER broadcast staleness still recovers', async () => {
+    // This case forces the REACTIVE branch by ensuring the broadcast
+    // arrives DURING the in-flight refresh, not before. Approach: start
+    // tryRefreshToken with no prior broadcast, then broadcast partway
+    // through the axios mock, then assert reactive recovery.
+    const client = await freshClient();
+
+    // Park the axios rejection slightly so the broadcast can arrive
+    // during the in-flight window.
+    const postSpy = vi.spyOn(axios, 'post').mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          setTimeout(
+            () =>
+              reject({
+                isAxiosError: true,
+                response: { status: 401, data: { error: 'Token refresh failed' } },
+              }),
+            20,
+          );
+        }),
+    );
+
+    const refreshPromise = client.__test.tryRefreshToken();
+    // After the POST is in flight but before its rejection fires, the
+    // winning tab broadcasts.
+    await new Promise((r) => setTimeout(r, 10));
+    await simulateOtherTabRefresh();
+
+    const outcome = await refreshPromise;
+
+    expect(postSpy).toHaveBeenCalledTimes(1); // POST DID fire (no proactive)
+    expect(outcome).toBe('success'); // reactive branch recovered
+    expect(sessionMocks.clearSession).not.toHaveBeenCalled();
+    expect(adminModeMocks.notifySessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('negative control: 401 + NO recent cross-tab signal = permanent logout', async () => {
+    const postSpy = vi.spyOn(axios, 'post').mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 401, data: { error: 'Token refresh failed' } },
+    });
+
+    const client = await freshClient();
+    // Reset cross-tab state to be safe — no other tab has refreshed.
+    client.__test.resetCrossTabState();
+
+    const outcome = await client.__test.tryRefreshToken();
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(outcome).toBe('permanent');
+    // The historical behaviour MUST be preserved when there's no
+    // cross-tab signal — otherwise we'd silently swallow real auth failures.
+    expect(sessionMocks.clearSession).toHaveBeenCalledTimes(1);
+    expect(adminModeMocks.notifySessionExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('anotherTabRefreshedRecently() is false when no token in storage', async () => {
+    // Guards the case where lastOtherTabRefreshAt is fresh but
+    // localStorage has been cleared by some other code path — we must
+    // NOT trust the broadcast in isolation.
+    const client = await freshClient();
+    await simulateOtherTabRefresh();
+    expect(client.__test.anotherTabRefreshedRecently()).toBe(true);
+
+    sessionMocks.getAccessToken.mockReturnValueOnce(null);
+    expect(client.__test.anotherTabRefreshedRecently()).toBe(false);
+  });
+});

--- a/frontend/src/lib/api/chats.ts
+++ b/frontend/src/lib/api/chats.ts
@@ -528,14 +528,29 @@ class ChatsAPI {
    * Symptom 9. We POST this BEFORE calling abort() on the AbortController
    * so the marker is in the server-side set when GeneratorExit fires.
    *
-   * Idempotent + non-blocking: failures are swallowed so the abort() that
-   * follows still runs (the worst case is the response gets labeled as a
-   * proxy-disconnect — still better than the old behaviour).
+   * Bounded wait: `timeout: 1500ms` is what makes this safe to await from
+   * `ChatPanel.handleStop`. Without it, if Supabase is unreachable (the
+   * exact burst-load scenario this whole PR exists to handle), the
+   * backend's `mark_user_stopped` Supabase write hangs for the OS socket
+   * default (30-120s on Linux). Awaiting that would freeze handleStop
+   * — and the abort() that comes after — for up to two minutes, during
+   * which the SSE stream keeps running and the worker keeps burning
+   * Claude tokens on a request the user has already cancelled.
+   *
+   * 1.5s is a comfortable upper bound for healthy Supabase: production
+   * round-trips are 50-200ms typical. If we exceed 1.5s, the catch
+   * block fires, handleStop's await unblocks, and abort() runs. Worst
+   * case: the assistant message gets labeled "connection_dropped"
+   * instead of "stopped by user" — UX wart, not data loss.
+   *
+   * Idempotent — repeated calls just overwrite chats.user_stopped_at.
    */
   async stopMessage(projectId: string, chatId: string): Promise<void> {
     try {
       await axios.post(
-        `${API_BASE_URL}/projects/${projectId}/chats/${chatId}/messages/stop`
+        `${API_BASE_URL}/projects/${projectId}/chats/${chatId}/messages/stop`,
+        undefined,
+        { timeout: 1500 },
       );
     } catch (error) {
       log.warn({ err: error }, 'failed to signal stop (proceeding with abort)');

--- a/frontend/src/lib/api/chats.ts
+++ b/frontend/src/lib/api/chats.ts
@@ -519,6 +519,30 @@ class ChatsAPI {
   }
 
   /**
+   * Tell the backend that the user explicitly clicked Stop.
+   *
+   * Why this exists: the SSE generator can't distinguish "user clicked Stop"
+   * from "proxy idle-timeout closed the connection" without a side-channel
+   * signal. Both produce a Python GeneratorExit. Before this endpoint,
+   * proxy timeouts mislabeled real responses as "(stopped by user)" — Delta's
+   * Symptom 9. We POST this BEFORE calling abort() on the AbortController
+   * so the marker is in the server-side set when GeneratorExit fires.
+   *
+   * Idempotent + non-blocking: failures are swallowed so the abort() that
+   * follows still runs (the worst case is the response gets labeled as a
+   * proxy-disconnect — still better than the old behaviour).
+   */
+  async stopMessage(projectId: string, chatId: string): Promise<void> {
+    try {
+      await axios.post(
+        `${API_BASE_URL}/projects/${projectId}/chats/${chatId}/messages/stop`
+      );
+    } catch (error) {
+      log.warn({ err: error }, 'failed to signal stop (proceeding with abort)');
+    }
+  }
+
+  /**
    * Get per-chat cost and token breakdown.
    * Educational Note: Mirrors projectsAPI.getCosts but scoped to a single chat.
    */

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -95,6 +95,80 @@ type RefreshOutcome = 'success' | 'transient' | 'permanent';
 
 let refreshPromise: Promise<RefreshOutcome> | null = null;
 
+// ---------- Cross-tab refresh coordination ----------
+// The `refreshPromise` above dedups concurrent refreshes WITHIN a single tab.
+// When the same user is signed into NoobBook from multiple tabs / browsers
+// (production logs from 2026-05-18 captured Chrome-Mac + Firefox-Mac +
+// Chrome-Linux on the same Supabase user-id), each tab's `refreshPromise`
+// is independent. They race each other on the same refresh-token chain,
+// GoTrue rotates on whichever POST arrives first, and the loser gets
+// `refresh_token_already_used` → HTTP 401. Without cross-tab coordination
+// the loser then runs handlePermanentFailure → user kicked to login.
+//
+// Coordination strategy:
+//   - PROACTIVE: before firing /auth/refresh, check whether another tab
+//     just refreshed within `CROSS_TAB_FRESHNESS_MS`. If yes, skip the
+//     POST entirely — localStorage already has fresh tokens.
+//   - REACTIVE (load-bearing): if our /auth/refresh returns 401/403, check
+//     the same window. If yes, the 401 is a rotation-race loss, not a
+//     real auth failure — return 'success' (the winning tab's tokens are
+//     in localStorage) instead of 'permanent' (logout).
+//
+// Transport: BroadcastChannel('noobbook-auth') primary, `storage` event
+// fallback (Safari < 15.4 lacks BroadcastChannel). Both update the same
+// module-level timestamp.
+
+type AuthBroadcastMessage = { type: 'refresh_succeeded'; at: number };
+
+const AUTH_BROADCAST_CHANNEL = 'noobbook-auth';
+// Picked so the window covers: typical /auth/refresh round-trips are
+// 120–150 ms in production; we want comfortable margin for slow
+// connections without trusting hour-old refreshes from hibernated tabs.
+const CROSS_TAB_FRESHNESS_MS = 2_000;
+
+let lastOtherTabRefreshAt = 0;
+
+const authChannel: BroadcastChannel | null =
+  typeof BroadcastChannel !== 'undefined'
+    ? new BroadcastChannel(AUTH_BROADCAST_CHANNEL)
+    : null;
+
+if (authChannel) {
+  authChannel.addEventListener('message', (ev) => {
+    const msg = ev.data as AuthBroadcastMessage | undefined;
+    if (msg?.type === 'refresh_succeeded') {
+      lastOtherTabRefreshAt = msg.at;
+    }
+  });
+}
+
+// Storage-event fallback. Browsers fire `storage` on every tab EXCEPT the
+// one that performed the setItem — exactly the cross-tab notification
+// semantics we want, and the path Safari < 15.4 takes since it lacks
+// BroadcastChannel.
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (ev) => {
+    if (ev.key === 'noobbook.access_token' && ev.newValue) {
+      lastOtherTabRefreshAt = Date.now();
+    }
+  });
+}
+
+function broadcastRefreshSucceeded(): void {
+  if (!authChannel) return;
+  authChannel.postMessage({
+    type: 'refresh_succeeded',
+    at: Date.now(),
+  } satisfies AuthBroadcastMessage);
+}
+
+function anotherTabRefreshedRecently(): boolean {
+  return (
+    Date.now() - lastOtherTabRefreshAt < CROSS_TAB_FRESHNESS_MS &&
+    !!getAccessToken()
+  );
+}
+
 async function tryRefreshToken(): Promise<RefreshOutcome> {
   const refreshToken = getRefreshToken();
   if (!refreshToken) {
@@ -104,12 +178,21 @@ async function tryRefreshToken(): Promise<RefreshOutcome> {
     return 'permanent';
   }
 
+  // Proactive cross-tab dedup. Another tab broadcast a successful refresh
+  // within the last CROSS_TAB_FRESHNESS_MS — trust it and skip the
+  // network call entirely. localStorage already has the new tokens.
+  if (anotherTabRefreshedRecently()) {
+    log.info('refresh: skipping POST — another tab refreshed recently');
+    return 'success';
+  }
+
   try {
     const { data } = await axios.post(`${API_BASE_URL}/auth/refresh`, {
       refresh_token: refreshToken,
     });
     if (data?.success && data.session?.access_token) {
       setSession(data.session.access_token, data.session.refresh_token);
+      broadcastRefreshSucceeded();
       return 'success';
     }
     // 200 OK but no usable session in the body — treat as permanent. The
@@ -121,6 +204,20 @@ async function tryRefreshToken(): Promise<RefreshOutcome> {
   } catch (err) {
     const status = (err as AxiosError).response?.status;
     if (status === 401 || status === 403) {
+      // Reactive cross-tab dedup — the load-bearing fix.
+      // GoTrue's rotation is "first POST wins". If our POST lost to
+      // another tab, the response is 401 with error_code
+      // refresh_token_already_used. But the winning tab has already
+      // written fresh tokens to localStorage, so we are NOT actually
+      // de-authenticated — adopt their tokens instead of bouncing the
+      // user to the login screen.
+      if (anotherTabRefreshedRecently()) {
+        log.warn(
+          { status },
+          'refresh: lost rotation race against another tab — using their tokens',
+        );
+        return 'success';
+      }
       log.warn({ status }, 'refresh token rejected — session expired');
       handlePermanentFailure();
       return 'permanent';
@@ -236,6 +333,19 @@ export { API_BASE_URL };
  * connection URI", "Claude rate limit reached", etc.) when the backend
  * supplies one.
  */
+// Test-only exports. Bundlers tree-shake unused exports in production
+// builds, so leaving this unguarded keeps the test surface stable across
+// dev/test/prod without conditional logic. Only consumed by
+// `src/lib/api/__tests__/client.test.ts`.
+export const __test = {
+  tryRefreshToken,
+  anotherTabRefreshedRecently,
+  resetCrossTabState: () => {
+    lastOtherTabRefreshAt = 0;
+  },
+};
+
+
 export function extractServerError(err: unknown, fallback: string): string {
   if (!err) return fallback;
   // Axios shape

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -30,11 +30,34 @@ export const api = axios.create({
   },
 });
 
+// Per-request correlation ID. The backend stamps every log record with this
+// (see app/utils/logger.py:_RequestIdFilter), and echoes it back in the
+// X-Request-Id response header. When the user reports "I was logged out at
+// 14:32", the req_id printed alongside any failed-request log in DevTools
+// is the single grep key the support engineer needs in backend.log.
+function _newRequestId(): string {
+  // crypto.randomUUID is available in all browsers we ship to; the fallback
+  // covers older WebView environments (e.g. embedded Slack browser) so we
+  // never throw at request time.
+  try {
+    return (globalThis.crypto?.randomUUID?.() || '').replace(/-/g, '').slice(0, 16)
+      || Math.random().toString(36).slice(2, 18);
+  } catch {
+    return Math.random().toString(36).slice(2, 18);
+  }
+}
+
 const attachAuthHeader = (config: InternalAxiosRequestConfig) => {
   const token = getAccessToken();
   if (token) {
     config.headers = config.headers || {};
     config.headers.Authorization = `Bearer ${token}`;
+  }
+  // Attach a fresh req_id per request so every retry / refresh gets its own.
+  // If a caller has already set one (e.g. a tracing wrapper) we honour it.
+  config.headers = config.headers || {};
+  if (!config.headers['X-Request-Id']) {
+    config.headers['X-Request-Id'] = _newRequestId();
   }
   return config;
 };
@@ -155,7 +178,14 @@ async function handle401Error(error: AxiosError, retryWith: typeof api | typeof 
     // normal API-error toast (not a "you're logged out" experience).
   }
 
-  log.error({ status, data: error.response?.data }, 'API response error');
+  // req_id from the response header (or the request header if the server
+  // never replied). With this on the error line, a support engineer can grep
+  // it directly in backend.log via the admin Logs viewer.
+  const reqId =
+    (error.response?.headers as Record<string, string> | undefined)?.['x-request-id']
+    || (originalRequest?.headers?.['X-Request-Id'] as string | undefined)
+    || '-';
+  log.error({ status, reqId, data: error.response?.data }, 'API response error');
   return Promise.reject(error);
 }
 
@@ -192,3 +222,27 @@ export function getAuthUrl(url: string): string {
 }
 
 export { API_BASE_URL };
+
+
+/**
+ * Pull a user-facing message out of an API error, preferring the server's
+ * `error` / `message` field when present. Falls back to the given default.
+ *
+ * Use this at toast call-sites that currently look like
+ *     errorWithLogs('Failed to send message')
+ * — replace with
+ *     errorWithLogs(extractServerError(err, 'Failed to send message'))
+ * so the user sees the actual reason ("Database unreachable — check the
+ * connection URI", "Claude rate limit reached", etc.) when the backend
+ * supplies one.
+ */
+export function extractServerError(err: unknown, fallback: string): string {
+  if (!err) return fallback;
+  // Axios shape
+  const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
+  const fromAxios = axiosErr.response?.data?.error || axiosErr.response?.data?.message;
+  if (typeof fromAxios === 'string' && fromAxios.trim()) return fromAxios.trim();
+  // Fetch / generic Error shape
+  if (err instanceof Error && err.message && err.message !== 'Network Error') return err.message;
+  return fallback;
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -333,17 +333,34 @@ export { API_BASE_URL };
  * connection URI", "Claude rate limit reached", etc.) when the backend
  * supplies one.
  */
-// Test-only exports. Bundlers tree-shake unused exports in production
-// builds, so leaving this unguarded keeps the test surface stable across
-// dev/test/prod without conditional logic. Only consumed by
-// `src/lib/api/__tests__/client.test.ts`.
-export const __test = {
-  tryRefreshToken,
-  anotherTabRefreshedRecently,
-  resetCrossTabState: () => {
-    lastOtherTabRefreshAt = 0;
-  },
-};
+// Test-only exports. Defense-in-depth against accidental imports from
+// production code: in non-test/dev builds the methods are no-ops, so an
+// `import { __test } from '@/lib/api/client'` in app code TypeScript-
+// compiles AND keeps the test type contract, but can't actually mutate
+// production state. Vite still tree-shakes the active branch.
+//
+// `MODE` is set by Vite — `'test'` during vitest, `'production'` for
+// `npm run build`, `'development'` for `npm run dev`. We expose internals
+// in test and development; production gets harmless stubs.
+const _is_test_or_dev =
+  import.meta.env.MODE === 'test' || import.meta.env.MODE === 'development';
+
+export const __test = _is_test_or_dev
+  ? {
+      tryRefreshToken,
+      anotherTabRefreshedRecently,
+      resetCrossTabState: () => {
+        lastOtherTabRefreshAt = 0;
+      },
+    }
+  : {
+      tryRefreshToken: (): Promise<RefreshOutcome> =>
+        Promise.resolve('permanent' as RefreshOutcome),
+      anotherTabRefreshedRecently: () => false,
+      resetCrossTabState: () => {
+        /* no-op in production */
+      },
+    };
 
 
 export function extractServerError(err: unknown, fallback: string): string {

--- a/frontend/src/lib/errorReporter.ts
+++ b/frontend/src/lib/errorReporter.ts
@@ -58,6 +58,21 @@ function handleError(event: ErrorEvent) {
   });
 }
 
+function extractRequestId(reason: unknown): string | undefined {
+  // AxiosError shape — the request-id middleware echoes our X-Request-Id
+  // back as a response header. With this in the rejection report, an admin
+  // can grep the same req_id in backend.log via the Logs viewer and find
+  // the matching server-side trace line.
+  const r = reason as
+    | { response?: { headers?: Record<string, string> }; config?: { headers?: Record<string, string> } }
+    | undefined;
+  const fromResponse = r?.response?.headers?.['x-request-id'];
+  if (typeof fromResponse === 'string' && fromResponse) return fromResponse;
+  const fromRequest = r?.config?.headers?.['X-Request-Id'];
+  if (typeof fromRequest === 'string' && fromRequest) return fromRequest;
+  return undefined;
+}
+
 function handleRejection(event: PromiseRejectionEvent) {
   const reason = event.reason;
   let message = 'unhandledrejection';
@@ -73,6 +88,12 @@ function handleRejection(event: PromiseRejectionEvent) {
     } catch {
       // leave default
     }
+  }
+  const reqId = extractRequestId(reason);
+  if (reqId) {
+    // Tag the message body so the backend log line carries it through
+    // /logs/client without needing a payload-schema change.
+    message = `[req:${reqId}] ${message}`;
   }
   enqueue({ message, stack });
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,23 @@
+/**
+ * Vitest config — extends the existing vite.config.ts so path aliases
+ * (`@/*`), the React plugin, and any future Vite tweaks are honoured by
+ * the test runner too.
+ *
+ * happy-dom is used over jsdom because it's noticeably faster to start
+ * and we don't need any of jsdom's quirkier (mostly Selenium-style) API
+ * coverage. We test browser-API boundaries (BroadcastChannel, localStorage,
+ * window event listeners) so happy-dom's coverage is more than sufficient.
+ */
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'happy-dom',
+      globals: false,
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    },
+  }),
+);


### PR DESCRIPTION
Investigation of customer (Delta) pain points — spontaneous logouts under DB-burst load, 504s cascading into logouts, "(stopped by user)" appearing when the user never clicked Stop — landed three intertwined classes of change: tracing infrastructure so we can confirm the failing path on next repro, the fixes we already had ≥85% confidence on, and small error-handling cleanups so future bugs surface clearly.

Tracing (Phase 1):
- X-Request-Id propagated end-to-end. Backend before_request mints or accepts the header and stamps every log record with [req:<id>] via a logging.Filter. Frontend axios adds the header on outbound, surfaces reqId on error logs, and forwards req_id with unhandledrejection reports to /logs/client. Closes the cross-stack correlation gap that made spontaneous-logout reports unreproducible.
- Structured prefixes (AUTH_401_TRACE, REFRESH_FAIL_TRACE, SSE_CLOSE_TRACE, SLOW_REQUEST, BACKGROUND_TASK_FAIL, PROXY_DISCONNECT_PERSIST) so the admin /logs/recent UI is greppable.
- Admin-only /debug/supabase-state + /debug/stats endpoints — in-process visibility ("is the singleton polluted? how many chats in flight?") without docker exec. /debug/supabase-state directly tests the fad1921 bug class at runtime.

Confirmed fixes (Phase 2):
- Distinguish user-stop from proxy-disconnect. GeneratorExit no longer auto-labels the assistant message "(stopped by user)". New POST /messages/<chat>/stop writes chats.user_stopped_at (migration 00042); the SSE worker reads it on close and only applies the user-stop label when the timestamp is fresher than the stream's start wall-clock. The marker lives in Supabase because gunicorn workers=4 (below) means the /stop POST and the SSE stream commonly land on different workers — an in-process set is invisible across them. Freshness check defeats the late-arriving-/stop-leaks-to-next-message race.
- Typed error responses (app/utils/error_responses.py). psycopg2 OperationalError → 502 "Database unreachable — check the connection URI"; anthropic.RateLimitError → 429; postgrest 42501 → 503 (the service-auth-state-needs-restart case fad1921 documents); etc. Frontend extractServerError() surfaces the server-provided message in toasts instead of generic "Failed to X".
- Slow-path fail-open in auth_middleware. When JWT_SECRET is unset and auth.get_user(token) raises (GoTrue blip under burst load), we now decode the JWT without signature verification to extract sub (expiry still enforced). Mirrors the existing fast-path fail-open. Most plausible direct fix for the logout cascade under burst load — a single transient blip on GoTrue no longer kicks the user out.

Error-handling (Phase 3):
- BACKGROUND_TASK_FAIL structured log so failed source-processing tasks surface in the admin Logs viewer (task_id is the correlation key — background threads have no Flask request context, so req_id is "-").
- errorReporter extracts req_id from rejected axios errors and prefixes the message body, so /logs/client reports carry the same correlation ID that backend.log has on the failing line.

Sibling infrastructure changes already on this branch:
- gunicorn workers 1 → 4 via GUNICORN_WORKERS env. A single blocking job (PDF batch, Playwright launch, ffmpeg, LibreOffice) can no longer wedge the entire backend. Flask-SocketIO has no registered handlers, so cross-worker coordination isn't required.
- Stale-task cleanup runs once per container boot via entrypoint.sh (RUN_STALE_TASK_CLEANUP=1) instead of once per gunicorn worker — with multi-worker, a recycling worker would otherwise mark its peers' running tasks as failed.

Compatibility / rollout notes:
- Log file format gained a `[req:<id>]` segment between logger name and the colon. The existing /logs/recent parser accepts both shapes (optional capture group) so already-rotated archives still display.
- Migration 00042 is additive (ADD COLUMN IF NOT EXISTS … DEFAULT NULL); old code coexists cleanly during deploy.
- Old frontend (without /stop POST) on new backend: Stop button still works via the AbortController, but the response is persisted as a normal partial instead of carrying the "(stopped by user)" tag — transient UX-only regression for cached bundles during the deploy.

Tests: 22 new (test_proxy_disconnect.py, test_auth_failopen.py) covering the labeling matrix, the M1 freshness check that defeats the late-/stop race, X-Request-Id strict validation against log injection, and slow-path fail-open across the valid-token / expired / malformed / no-token cases. Full suite: 333 passed. Frontend tsc --noEmit clean.

Code-review follow-ups (H2/M1/M2 from internal review):
- H2: moved user-stop marker from per-worker set to Supabase chats.user_stopped_at so the §2.1 fix survives gunicorn workers=4.
- M1: freshness check (stop-timestamp > stream-start) instead of explicit clearing — a stale stop from a previous message can no longer mislabel the next stream.
- M2: X-Request-Id input is now strictly [A-Za-z0-9_-]{1,64} (regex fullmatch); blocks log-line injection via ]/:/space characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)