### PR TITLE
Add Notion sources and auto-refresh saved insights

### DIFF
--- a/backend/app/api/sources/uploads.py
+++ b/backend/app/api/sources/uploads.py
@@ -590,3 +590,131 @@ def add_mcp_source(project_id: str):
     except Exception as e:
         current_app.logger.error(f"Error adding MCP source: {e}")
         return jsonify({'success': False, 'error': str(e)}), 500
+
+
+# ---------------------------------------------------------------------------
+# Notion: picker endpoints + source creation
+#
+# The picker endpoints (status, search) are project-agnostic — they just expose
+# the globally-configured Notion workspace so the frontend can let users browse
+# and pick a page/database. The actual source creation is per-project.
+# ---------------------------------------------------------------------------
+
+
+@sources_bp.route('/notion/status', methods=['GET'])
+@require_permission("integrations", "notion")
+def notion_status():
+    """Report whether the global Notion integration is configured."""
+    try:
+        from app.services.integrations.knowledge_bases.notion.notion_service import (
+            notion_service,
+        )
+        return jsonify({
+            'success': True,
+            'configured': notion_service.is_configured(),
+        }), 200
+    except Exception as e:
+        current_app.logger.error(f"Error checking Notion status: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@sources_bp.route('/notion/search', methods=['GET'])
+@require_permission("integrations", "notion")
+def notion_search():
+    """
+    Search the connected Notion workspace for pages and/or databases.
+
+    Query params:
+        q: Optional search query (Notion does substring/title matching)
+        type: Optional filter — 'page' or 'database' (default: both)
+        limit: Optional max results (default: 50, max: 100)
+    """
+    try:
+        from app.services.integrations.knowledge_bases.notion.notion_service import (
+            notion_service,
+        )
+
+        if not notion_service.is_configured():
+            return jsonify({
+                'success': False,
+                'error': 'Notion not configured. Add NOTION_API_KEY in Settings → API Keys.',
+                'configured': False,
+            }), 400
+
+        query = request.args.get('q', '').strip() or None
+        filter_type = request.args.get('type', '').strip().lower() or None
+        if filter_type and filter_type not in ('page', 'database'):
+            return jsonify({'success': False, 'error': "type must be 'page' or 'database'"}), 400
+        try:
+            limit = int(request.args.get('limit', '50'))
+        except ValueError:
+            limit = 50
+        limit = max(1, min(limit, 100))
+
+        result = notion_service.search(query=query, filter_type=filter_type, limit=limit)
+        if not result.get('success'):
+            return jsonify({'success': False, 'error': result.get('error', 'Notion search failed')}), 502
+
+        return jsonify({
+            'success': True,
+            'results': result.get('results', []),
+            'total': result.get('total', 0),
+        }), 200
+
+    except Exception as e:
+        current_app.logger.error(f"Error searching Notion: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@sources_bp.route('/projects/<project_id>/sources/notion', methods=['POST'])
+@require_permission("integrations", "notion")
+def add_notion_source_endpoint(project_id: str):
+    """
+    Add a Notion source (one page or one database) to a project.
+
+    Request Body:
+        {
+            "notion_id": "uuid",                # required
+            "object_type": "page" | "database", # required
+            "title": "Picked title",            # optional, from picker
+            "notion_url": "https://notion.so/…",# optional
+            "last_edited_time": "ISO ts",       # optional
+            "name": "Override display name",    # optional
+            "description": "..."                # optional
+        }
+    """
+    try:
+        data = request.get_json() or {}
+        notion_id = (data.get('notion_id') or '').strip()
+        object_type = (data.get('object_type') or '').strip().lower()
+
+        if not notion_id:
+            return jsonify({'success': False, 'error': 'notion_id is required'}), 400
+        if object_type not in ('page', 'database'):
+            return jsonify({
+                'success': False,
+                'error': "object_type must be 'page' or 'database'",
+            }), 400
+
+        source = source_service.add_notion_source(
+            project_id=project_id,
+            notion_id=notion_id,
+            object_type=object_type,
+            title=data.get('title'),
+            notion_url=data.get('notion_url'),
+            last_edited_time=data.get('last_edited_time'),
+            name=data.get('name'),
+            description=data.get('description', ''),
+        )
+
+        return jsonify({
+            'success': True,
+            'source': source,
+            'message': 'Notion source added successfully',
+        }), 201
+
+    except ValueError as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+    except Exception as e:
+        current_app.logger.error(f"Error adding Notion source: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500

--- a/backend/app/services/integrations/knowledge_bases/notion/notion_service.py
+++ b/backend/app/services/integrations/knowledge_bases/notion/notion_service.py
@@ -4,13 +4,27 @@ Notion Integration Service - Notion API integration for NoobBook.
 Educational Note: This service provides methods to query Notion pages and databases
 using the Notion API. It follows NoobBook's service pattern with lazy-loaded
 client initialization and environment-based configuration.
+
+The page-fetch path recursively walks child blocks (with caps) so toggles,
+sub-pages, column layouts, and nested lists actually surface in the text we
+hand to RAG. Both ``search`` and the page/block walkers paginate through
+``has_more`` / ``next_cursor`` so large workspaces and long pages aren't
+truncated at 100 results.
 """
 import logging
 import os
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Tuple
 import requests
 
 logger = logging.getLogger(__name__)
+
+
+# Recursion and result caps for page extraction. These guard against
+# pathologically large or self-referential Notion pages so a single import
+# can't run away with the worker pool. Tune in one place if needed.
+MAX_RECURSION_DEPTH = 5
+MAX_TOTAL_BLOCKS = 2000
+MAX_PAGINATION_PAGES = 50  # ~5000 blocks/items per paginated endpoint
 
 
 class NotionService:
@@ -117,62 +131,236 @@ class NotionService:
         except Exception as e:
             return {"success": False, "error": f"Request failed: {str(e)}"}
 
-    def search(self, query: Optional[str] = None, filter_type: Optional[str] = None, limit: int = 20) -> Dict[str, Any]:
+    # ------------------------------------------------------------------
+    # Pagination helpers
+    # ------------------------------------------------------------------
+
+    def _paginate_post(
+        self,
+        endpoint: str,
+        payload: Dict[str, Any],
+        page_size: int = 100,
+    ) -> Tuple[bool, List[Dict[str, Any]], Optional[str]]:
         """
-        Search Notion pages and databases.
+        Walk a paginated POST endpoint until ``has_more`` is false or we hit
+        MAX_PAGINATION_PAGES. Returns (success, results, error).
+        """
+        results: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        for _ in range(MAX_PAGINATION_PAGES):
+            body = dict(payload)
+            body["page_size"] = min(page_size, 100)
+            if cursor:
+                body["start_cursor"] = cursor
+            resp = self._make_request(endpoint, method='POST', json_data=body)
+            if not resp.get("success"):
+                return False, results, resp.get("error")
+            data = resp["data"]
+            results.extend(data.get("results", []) or [])
+            if not data.get("has_more"):
+                return True, results, None
+            cursor = data.get("next_cursor")
+            if not cursor:
+                return True, results, None
+        logger.warning("Notion pagination hit cap of %d pages at %s", MAX_PAGINATION_PAGES, endpoint)
+        return True, results, None
+
+    def _paginate_get(
+        self,
+        endpoint: str,
+        page_size: int = 100,
+    ) -> Tuple[bool, List[Dict[str, Any]], Optional[str]]:
+        """
+        Walk a paginated GET endpoint (e.g. ``blocks/{id}/children``). Notion
+        accepts start_cursor / page_size as query params on these endpoints.
+        Returns (success, results, error).
+        """
+        results: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        for _ in range(MAX_PAGINATION_PAGES):
+            sep = '&' if '?' in endpoint else '?'
+            url = f"{endpoint}{sep}page_size={min(page_size, 100)}"
+            if cursor:
+                url = f"{url}&start_cursor={cursor}"
+            resp = self._make_request(url)
+            if not resp.get("success"):
+                return False, results, resp.get("error")
+            data = resp["data"]
+            results.extend(data.get("results", []) or [])
+            if not data.get("has_more"):
+                return True, results, None
+            cursor = data.get("next_cursor")
+            if not cursor:
+                return True, results, None
+        logger.warning("Notion pagination hit cap of %d pages at %s", MAX_PAGINATION_PAGES, endpoint)
+        return True, results, None
+
+    # ------------------------------------------------------------------
+    # Block → text rendering
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _rich_text_to_str(rich_text: Optional[List[Dict[str, Any]]]) -> str:
+        """Join Notion's rich_text array into plain text."""
+        if not rich_text:
+            return ""
+        return "".join(rt.get("plain_text", "") for rt in rich_text)
+
+    @classmethod
+    def _render_block(cls, block: Dict[str, Any], indent: int = 0) -> Optional[str]:
+        """
+        Render a single Notion block as markdown-ish plain text. Returns None
+        when the block has no surfaceable text (e.g. unsupported embeds).
+        Children are NOT rendered here — the recursive walker handles them.
+        """
+        block_type = block.get("type")
+        if not block_type or block_type not in block:
+            return None
+        body = block[block_type] or {}
+        text = cls._rich_text_to_str(body.get("rich_text"))
+        prefix = "  " * indent
+
+        if block_type == "paragraph":
+            return f"{prefix}{text}" if text else None
+        if block_type == "heading_1":
+            return f"{prefix}# {text}" if text else None
+        if block_type == "heading_2":
+            return f"{prefix}## {text}" if text else None
+        if block_type == "heading_3":
+            return f"{prefix}### {text}" if text else None
+        if block_type == "bulleted_list_item":
+            return f"{prefix}- {text}"
+        if block_type == "numbered_list_item":
+            return f"{prefix}1. {text}"
+        if block_type == "to_do":
+            checked = body.get("checked", False)
+            box = "[x]" if checked else "[ ]"
+            return f"{prefix}- {box} {text}"
+        if block_type == "toggle":
+            return f"{prefix}▸ {text}" if text else None
+        if block_type == "quote":
+            return f"{prefix}> {text}" if text else None
+        if block_type == "callout":
+            return f"{prefix}> {text}" if text else None
+        if block_type == "code":
+            language = body.get("language", "")
+            return f"{prefix}```{language}\n{text}\n{prefix}```" if text else None
+        if block_type == "divider":
+            return f"{prefix}---"
+        if block_type == "child_page":
+            # Title is on the block itself, not in rich_text
+            title = body.get("title", "")
+            return f"{prefix}## {title}" if title else None
+        if block_type == "child_database":
+            title = body.get("title", "")
+            return f"{prefix}### Database: {title}" if title else None
+        if block_type == "bookmark" or block_type == "embed":
+            url = body.get("url", "")
+            caption = cls._rich_text_to_str(body.get("caption"))
+            label = caption or url
+            return f"{prefix}[{label}]({url})" if url else None
+
+        # Fallback: if we got any text out of rich_text, emit it
+        return f"{prefix}{text}" if text else None
+
+    def _walk_blocks(
+        self,
+        parent_id: str,
+        indent: int,
+        depth: int,
+        counter: Dict[str, int],
+    ) -> Tuple[List[str], Optional[str]]:
+        """
+        Recursively walk children of ``parent_id`` and return rendered lines.
+        Caps recursion at MAX_RECURSION_DEPTH and total emitted blocks at
+        MAX_TOTAL_BLOCKS. Returns (lines, error_or_none).
+        """
+        lines: List[str] = []
+        if depth > MAX_RECURSION_DEPTH:
+            return lines, None
+        if counter["count"] >= MAX_TOTAL_BLOCKS:
+            return lines, None
+
+        ok, blocks, err = self._paginate_get(f"blocks/{parent_id}/children")
+        if not ok:
+            return lines, err
+
+        for block in blocks:
+            if counter["count"] >= MAX_TOTAL_BLOCKS:
+                lines.append("…(truncated: page exceeded block cap)")
+                return lines, None
+            rendered = self._render_block(block, indent=indent)
+            if rendered:
+                lines.append(rendered)
+                counter["count"] += 1
+
+            if block.get("has_children") and depth < MAX_RECURSION_DEPTH:
+                child_id = block.get("id")
+                if child_id:
+                    child_lines, child_err = self._walk_blocks(
+                        child_id, indent=indent + 1, depth=depth + 1, counter=counter
+                    )
+                    if child_err:
+                        # Don't abort the whole page on a single child fetch error
+                        logger.warning(
+                            "Notion child fetch failed for block %s: %s", child_id, child_err
+                        )
+                    lines.extend(child_lines)
+
+        return lines, None
+
+    # ------------------------------------------------------------------
+    # Search / Page / Database
+    # ------------------------------------------------------------------
+
+    def search(self, query: Optional[str] = None, filter_type: Optional[str] = None, limit: int = 100) -> Dict[str, Any]:
+        """
+        Search Notion pages and databases (paginated).
 
         Args:
             query: Search query string (optional, returns all if not provided)
             filter_type: Filter by object type: 'page' or 'database' (optional)
-            limit: Maximum number of results (default: 20, max: 100)
+            limit: Maximum number of results to return after pagination (default 100)
 
         Returns:
             Dict with 'success' flag and either 'results' list or 'error'
         """
-        # Build search payload
-        payload = {
-            "page_size": min(limit, 100)
-        }
-
+        payload: Dict[str, Any] = {}
         if query:
             payload["query"] = query
-
         if filter_type:
-            payload["filter"] = {
-                "value": filter_type,
-                "property": "object"
-            }
+            payload["filter"] = {"value": filter_type, "property": "object"}
 
-        # TODO: Add pagination support (has_more / start_cursor) for large workspaces
-        result = self._make_request('search', method='POST', json_data=payload)
+        ok, raw_results, err = self._paginate_post('search', payload, page_size=min(limit, 100))
+        if not ok:
+            return {"success": False, "error": err or "Notion search failed"}
 
-        if not result['success']:
-            return result
+        # Truncate to caller's requested limit after pagination so partial pages
+        # don't get over-fetched in pathological cases.
+        raw_results = raw_results[:limit]
 
-        # Format results
-        data = result['data']
-        results = data.get('results', [])
-
-        formatted_results = []
-        for item in results:
-            formatted_item = {
+        formatted_results: List[Dict[str, Any]] = []
+        for item in raw_results:
+            formatted_item: Dict[str, Any] = {
                 'id': item.get('id'),
                 'type': item.get('object'),  # 'page' or 'database'
                 'created_time': item.get('created_time'),
                 'last_edited_time': item.get('last_edited_time'),
-                'url': item.get('url')
+                'url': item.get('url'),
             }
 
             # Extract title
             if item.get('object') == 'page':
-                properties = item.get('properties', {})
-                title_prop = properties.get('title', {})
-                if title_prop.get('title'):
-                    formatted_item['title'] = ''.join([t.get('plain_text', '') for t in title_prop['title']])
+                properties = item.get('properties', {}) or {}
+                # Find the title property — it's not always called "title"
+                title_text = ""
+                for prop in properties.values():
+                    if prop.get('type') == 'title':
+                        title_text = self._rich_text_to_str(prop.get('title'))
+                        break
+                formatted_item['title'] = title_text or "Untitled"
             elif item.get('object') == 'database':
-                title = item.get('title', [])
-                if title:
-                    formatted_item['title'] = ''.join([t.get('plain_text', '') for t in title])
+                formatted_item['title'] = self._rich_text_to_str(item.get('title')) or "Untitled"
 
             formatted_results.append(formatted_item)
 
@@ -180,12 +368,17 @@ class NotionService:
             "success": True,
             "results": formatted_results,
             "total": len(formatted_results),
-            "has_more": data.get('has_more', False)
+            "has_more": False,
         }
 
     def get_page(self, page_id: str) -> Dict[str, Any]:
         """
-        Get page content including properties and blocks.
+        Get page content including properties and all nested blocks.
+
+        Recursively walks child blocks (toggles, sub-pages, columns, nested
+        lists) up to MAX_RECURSION_DEPTH levels and MAX_TOTAL_BLOCKS total
+        rendered blocks. Long pages are paginated via the blocks/{id}/children
+        endpoint.
 
         Args:
             page_id: Notion page ID
@@ -203,35 +396,30 @@ class NotionService:
 
         page = page_result['data']
 
-        # Get page blocks (content)
-        # Limitation: Only fetches top-level blocks. Nested children (e.g. items
-        # inside toggles, columns, or synced blocks) are not recursively fetched.
-        # TODO: Add pagination support (has_more / next_cursor) for pages with 100+ blocks
-        blocks_result = self._make_request(f'blocks/{page_id}/children')
-        if not blocks_result['success']:
-            return blocks_result
+        # Extract title from the page's own properties for display
+        title = "Untitled"
+        for prop in (page.get('properties') or {}).values():
+            if prop.get('type') == 'title':
+                title = self._rich_text_to_str(prop.get('title')) or "Untitled"
+                break
 
-        blocks = blocks_result['data'].get('results', [])
+        counter = {"count": 0}
+        lines, err = self._walk_blocks(page_id, indent=0, depth=0, counter=counter)
+        if err and not lines:
+            return {"success": False, "error": err}
 
-        # Extract text content from blocks
-        content_parts = []
-        for block in blocks:
-            block_type = block.get('type')
-            if block_type and block_type in block:
-                block_content = block[block_type]
-                if 'rich_text' in block_content:
-                    text = ''.join([t.get('plain_text', '') for t in block_content['rich_text']])
-                    if text:
-                        content_parts.append(text)
+        content = "\n\n".join(line for line in lines if line)
 
         return {
             "success": True,
             "page": {
                 'id': page.get('id'),
+                'title': title,
                 'url': page.get('url'),
                 'created_time': page.get('created_time'),
                 'last_edited_time': page.get('last_edited_time'),
-                'content': '\n\n'.join(content_parts)
+                'content': content,
+                'block_count': counter["count"],
             }
         }
 
@@ -255,23 +443,24 @@ class NotionService:
         database = result['data']
 
         # Extract schema
-        properties = database.get('properties', {})
-        schema = {}
-        for prop_name, prop_data in properties.items():
-            schema[prop_name] = {
+        properties = database.get('properties', {}) or {}
+        schema = {
+            prop_name: {
                 'type': prop_data.get('type'),
-                'id': prop_data.get('id')
+                'id': prop_data.get('id'),
             }
+            for prop_name, prop_data in properties.items()
+        }
 
         return {
             "success": True,
             "database": {
                 'id': database.get('id'),
-                'title': ''.join([t.get('plain_text', '') for t in database.get('title', [])]),
+                'title': self._rich_text_to_str(database.get('title')) or "Untitled",
                 'url': database.get('url'),
                 'created_time': database.get('created_time'),
                 'last_edited_time': database.get('last_edited_time'),
-                'schema': schema
+                'schema': schema,
             }
         }
 
@@ -279,15 +468,15 @@ class NotionService:
         self,
         database_id: str,
         filter_conditions: Optional[Dict] = None,
-        limit: int = 20
+        limit: int = 100,
     ) -> Dict[str, Any]:
         """
-        Query database with optional filters.
+        Query database with optional filters (paginated).
 
         Args:
             database_id: Notion database ID
             filter_conditions: Optional filter object (Notion filter format)
-            limit: Maximum results (default: 20, max: 100)
+            limit: Maximum results after pagination (default 100)
 
         Returns:
             Dict with 'success' flag and either 'results' list or 'error'
@@ -295,41 +484,36 @@ class NotionService:
         if not database_id:
             return {"success": False, "error": "database_id is required"}
 
-        # Build query payload
-        payload = {
-            "page_size": min(limit, 100)
-        }
-
+        payload: Dict[str, Any] = {}
         if filter_conditions:
             payload["filter"] = filter_conditions
 
-        result = self._make_request(f'databases/{database_id}/query', method='POST', json_data=payload)
+        ok, raw_results, err = self._paginate_post(
+            f'databases/{database_id}/query', payload, page_size=min(limit, 100)
+        )
+        if not ok:
+            return {"success": False, "error": err or "Notion database query failed"}
 
-        if not result['success']:
-            return result
+        raw_results = raw_results[:limit]
 
-        # Format results
-        data = result['data']
-        results = data.get('results', [])
-
-        formatted_results = []
-        for page in results:
-            properties = page.get('properties', {})
-            formatted_page = {
+        formatted_results: List[Dict[str, Any]] = []
+        for page in raw_results:
+            properties = page.get('properties', {}) or {}
+            formatted_page: Dict[str, Any] = {
                 'id': page.get('id'),
                 'url': page.get('url'),
                 'created_time': page.get('created_time'),
                 'last_edited_time': page.get('last_edited_time'),
-                'properties': {}
+                'properties': {},
             }
 
             # Extract property values
             for prop_name, prop_data in properties.items():
                 prop_type = prop_data.get('type')
                 if prop_type == 'title':
-                    formatted_page['properties'][prop_name] = ''.join([t.get('plain_text', '') for t in prop_data.get('title', [])])
+                    formatted_page['properties'][prop_name] = self._rich_text_to_str(prop_data.get('title'))
                 elif prop_type == 'rich_text':
-                    formatted_page['properties'][prop_name] = ''.join([t.get('plain_text', '') for t in prop_data.get('rich_text', [])])
+                    formatted_page['properties'][prop_name] = self._rich_text_to_str(prop_data.get('rich_text'))
                 elif prop_type in ['number', 'checkbox', 'url', 'email', 'phone_number']:
                     formatted_page['properties'][prop_name] = prop_data.get(prop_type)
                 elif prop_type == 'select':
@@ -347,7 +531,7 @@ class NotionService:
             "success": True,
             "results": formatted_results,
             "total": len(formatted_results),
-            "has_more": data.get('has_more', False)
+            "has_more": False,
         }
 
 

--- a/backend/app/services/source_services/source_processing/notion_processor.py
+++ b/backend/app/services/source_services/source_processing/notion_processor.py
@@ -1,0 +1,337 @@
+"""
+Notion Processor - Fetches Notion page or database content and embeds it.
+
+Educational Note: Notion sources are stored as `.notion` stub files holding
+the picked page/database ID. The processor:
+
+1. Reads the stub → gets notion_id + object_type
+2. Page sources: fetches the page (recursively walks child blocks) and emits
+   it as a single processed page.
+3. Database sources: queries the DB (paginated), then fetches each row's
+   page as its own processed page. The first page is a header summarizing
+   the database schema.
+4. Formats everything via build_processed_output() with NOTION page markers
+5. Uploads processed text to Supabase Storage
+6. Runs the standard embedding + summary flow (Notion content IS embedded,
+   unlike live-API integrations like Jira/Mixpanel)
+
+Cooperative cancellation is checked between Notion API calls so a long
+database import can be cancelled cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from app.services.ai_services.embedding_service import embedding_service
+from app.services.ai_services.summary_service import summary_service
+from app.services.background_services import task_service
+from app.services.integrations.knowledge_bases.notion.notion_service import notion_service
+from app.services.integrations.supabase import storage_service
+from app.utils.embedding_utils import count_tokens, needs_embedding
+from app.utils.text import build_processed_output
+
+logger = logging.getLogger(__name__)
+
+
+class _Cancelled(Exception):
+    """Raised when the user cancels processing mid-fetch."""
+
+
+def _check_cancel(source_id: str) -> None:
+    if task_service.is_target_cancelled(source_id):
+        raise _Cancelled()
+
+
+def _fetch_page(source_id: str, notion_id: str) -> Tuple[str, Dict[str, Any]]:
+    """
+    Fetch a single Notion page. Returns (rendered_text, page_meta).
+    Raises ValueError on Notion errors.
+    """
+    _check_cancel(source_id)
+    result = notion_service.get_page(notion_id)
+    if not result.get("success"):
+        raise ValueError(result.get("error", "Failed to fetch Notion page"))
+    page = result["page"]
+    title = page.get("title") or "Untitled"
+    body = page.get("content") or ""
+    text = f"# {title}\n\n{body}" if body else f"# {title}"
+    return text, page
+
+
+def _format_db_row(row: Dict[str, Any], row_body: str) -> str:
+    """
+    Render a database row as a single processed page: a property table on top,
+    followed by the row's page content (the body).
+    """
+    props = row.get("properties") or {}
+    title_value = ""
+    other_props: List[Tuple[str, Any]] = []
+    for k, v in props.items():
+        if isinstance(v, str) and not title_value:
+            # The first non-empty string is most likely the title; we keep
+            # heuristic-free behavior — just dump everything below.
+            title_value = v
+        other_props.append((k, v))
+
+    header = f"# {title_value}" if title_value else "# (untitled row)"
+    lines = [header, ""]
+    if other_props:
+        lines.append("## Properties")
+        for k, v in other_props:
+            if v in (None, "", [], {}):
+                continue
+            if isinstance(v, list):
+                v_str = ", ".join(str(x) for x in v if x is not None)
+            else:
+                v_str = str(v)
+            lines.append(f"- **{k}**: {v_str}")
+        lines.append("")
+    if row_body:
+        lines.append("## Content")
+        lines.append("")
+        lines.append(row_body)
+    return "\n".join(lines).rstrip()
+
+
+def _fetch_database_pages(
+    source_id: str,
+    database_id: str,
+) -> Tuple[List[str], Dict[str, Any]]:
+    """
+    Fetch a Notion database: schema + every row's page. Returns (pages, meta).
+    The first page is a database overview; each subsequent page is one row.
+    """
+    _check_cancel(source_id)
+    db_result = notion_service.get_database(database_id)
+    if not db_result.get("success"):
+        raise ValueError(db_result.get("error", "Failed to fetch Notion database"))
+    db = db_result["database"]
+
+    _check_cancel(source_id)
+    q_result = notion_service.query_database(database_id, limit=100)
+    if not q_result.get("success"):
+        raise ValueError(q_result.get("error", "Failed to query Notion database"))
+    rows = q_result.get("results", []) or []
+
+    # Page 1: database overview
+    schema = db.get("schema") or {}
+    overview_lines = [
+        f"# Database: {db.get('title', 'Untitled')}",
+        "",
+        f"Rows fetched: {len(rows)}",
+        "",
+        "## Schema",
+    ]
+    for prop_name, prop_meta in schema.items():
+        overview_lines.append(f"- **{prop_name}** ({prop_meta.get('type', 'unknown')})")
+    overview = "\n".join(overview_lines)
+
+    pages: List[str] = [overview]
+
+    for row in rows:
+        _check_cancel(source_id)
+        row_id = row.get("id")
+        row_body = ""
+        if row_id:
+            page_result = notion_service.get_page(row_id)
+            if page_result.get("success"):
+                row_body = (page_result["page"].get("content") or "").strip()
+            else:
+                # Don't abort the whole import on a single row failure
+                logger.warning(
+                    "Failed to fetch Notion row %s: %s",
+                    row_id,
+                    page_result.get("error"),
+                )
+        pages.append(_format_db_row(row, row_body))
+
+    meta = {
+        "title": db.get("title", "Untitled"),
+        "notion_url": db.get("url", ""),
+        "last_edited_time": db.get("last_edited_time", ""),
+        "row_count": len(rows),
+    }
+    return pages, meta
+
+
+def process_notion(
+    project_id: str,
+    source_id: str,
+    source: Dict[str, Any],
+    raw_file_path: Path,
+    source_service,
+) -> Dict[str, Any]:
+    """
+    Process a Notion source by fetching live content and embedding it.
+    """
+    # Read the stub
+    try:
+        with open(raw_file_path, "r", encoding="utf-8") as f:
+            stub = json.load(f)
+    except Exception as e:
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": f"Failed to read Notion stub: {e}"},
+        )
+        return {"success": False, "error": str(e)}
+
+    notion_id = stub.get("notion_id")
+    object_type = stub.get("object_type")
+    if not notion_id or object_type not in ("page", "database"):
+        msg = "Notion stub is missing notion_id or has invalid object_type"
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": msg},
+        )
+        return {"success": False, "error": msg}
+
+    if not notion_service.is_configured():
+        msg = "Notion is not configured (NOTION_API_KEY missing)"
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": msg},
+        )
+        return {"success": False, "error": msg}
+
+    try:
+        if object_type == "page":
+            text, page_meta = _fetch_page(source_id, notion_id)
+            pages = [text]
+            metadata = {
+                "object_type": "page",
+                "notion_url": page_meta.get("url", stub.get("notion_url", "")),
+                "last_edited_time": page_meta.get(
+                    "last_edited_time", stub.get("last_edited_time", "")
+                ),
+                "page_count": 1,
+            }
+            display_title = page_meta.get("title") or stub.get("title") or source.get("name") or "Notion page"
+        else:
+            pages, db_meta = _fetch_database_pages(source_id, notion_id)
+            metadata = {
+                "object_type": "database",
+                "notion_url": db_meta.get("notion_url", stub.get("notion_url", "")),
+                "last_edited_time": db_meta.get(
+                    "last_edited_time", stub.get("last_edited_time", "")
+                ),
+                "page_count": len(pages),
+            }
+            display_title = db_meta.get("title") or stub.get("title") or source.get("name") or "Notion database"
+    except _Cancelled:
+        logger.info("Notion processing cancelled for source %s", source_id)
+        # Status will be reset by cancel_processing; just return without
+        # marking as error.
+        return {"success": False, "cancelled": True}
+    except ValueError as e:
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": str(e)},
+        )
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.exception("Notion processing failed for source %s", source_id)
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": str(e)},
+        )
+        return {"success": False, "error": str(e)}
+
+    # Compute total character + token counts across all pages
+    combined = "\n\n".join(pages)
+    metadata["character_count"] = len(combined)
+    metadata["token_count"] = count_tokens(combined)
+
+    source_name = source.get("name") or display_title
+    processed_content = build_processed_output(
+        pages=pages,
+        source_type="NOTION",
+        source_name=source_name,
+        metadata=metadata,
+    )
+
+    storage_path = storage_service.upload_processed_file(
+        project_id=project_id,
+        source_id=source_id,
+        content=processed_content,
+    )
+    if not storage_path:
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": "Failed to upload processed Notion content"},
+        )
+        return {"success": False, "error": "Failed to upload processed content to storage"}
+
+    processing_info = {
+        "processor": "notion",
+        "object_type": object_type,
+        "notion_id": notion_id,
+        "notion_url": metadata.get("notion_url"),
+        "total_pages": len(pages),
+        "character_count": metadata["character_count"],
+    }
+
+    # Embed (Notion content is text-only knowledge — always embed)
+    embedding_info: Dict[str, Any]
+    try:
+        _, _, reason = needs_embedding(text=processed_content)
+        source_service.update_source(project_id, source_id, status="embedding")
+        logger.info("Starting Notion embedding for %s (%s)", source_name, reason)
+        embedding_info = embedding_service.process_embeddings(
+            project_id=project_id,
+            source_id=source_id,
+            source_name=source_name,
+            processed_text=processed_content,
+        )
+    except Exception as e:
+        logger.exception("Notion embedding failed for source %s", source_id)
+        embedding_info = {
+            "is_embedded": False,
+            "embedded_at": None,
+            "token_count": 0,
+            "chunk_count": 0,
+            "reason": f"Embedding error: {e}",
+        }
+
+    # Carry stub identifiers forward so the chat layer can still tell which
+    # Notion ID this source came from after processing.
+    embedding_info = {
+        **(source.get("embedding_info") or {}),
+        **embedding_info,
+        "file_extension": ".notion",
+        "source_type": "notion",
+        "notion_id": notion_id,
+        "object_type": object_type,
+    }
+
+    # Summary
+    summary_info: Dict[str, Any] = {}
+    try:
+        result = summary_service.generate_summary(
+            project_id=project_id,
+            source_id=source_id,
+            source_metadata={
+                **source,
+                "processing_info": processing_info,
+                "embedding_info": embedding_info,
+            },
+        )
+        if result:
+            summary_info = result
+    except Exception:
+        logger.exception("Summary generation failed for Notion source %s", source_id)
+
+    source_service.update_source(
+        project_id,
+        source_id,
+        status="ready",
+        active=True,
+        processing_info=processing_info,
+        embedding_info=embedding_info,
+        summary_info=summary_info if summary_info else None,
+    )
+
+    return {"success": True, "status": "ready"}

--- a/backend/app/services/source_services/source_processing/source_processing_service.py
+++ b/backend/app/services/source_services/source_processing/source_processing_service.py
@@ -75,6 +75,7 @@ class SourceProcessingService:
         ".mixpanel": "mixpanel",  # Mixpanel analytics sources (live API flag)
         ".mcp": "mcp",  # MCP server resources
         ".research": "research",  # Deep research source
+        ".notion": "notion",  # Notion page/database sources
     }
 
     def process_source(self, project_id: str, source_id: str) -> Dict[str, Any]:
@@ -204,6 +205,10 @@ class SourceProcessingService:
             elif processor_type == "research":
                 from app.services.source_services.source_processing.research_processor import process_research
                 return process_research(project_id, source_id, source, raw_file_path, source_service)
+
+            elif processor_type == "notion":
+                from app.services.source_services.source_processing.notion_processor import process_notion
+                return process_notion(project_id, source_id, source, raw_file_path, source_service)
 
             else:
                 # Unsupported file type

--- a/backend/app/services/source_services/source_service.py
+++ b/backend/app/services/source_services/source_service.py
@@ -28,6 +28,7 @@ from app.services.source_services.source_upload import (
     add_jira_source,
     add_mcp_source,
     add_mixpanel_source,
+    add_notion_source,
 )
 # Local path utils used for temp file staging during source processing
 from app.utils.path_utils import (
@@ -470,6 +471,39 @@ class SourceService:
         this specific project. Queries Mixpanel's Query API live.
         """
         return self._shape_for_frontend(project_id, add_mixpanel_source(project_id, name, description))
+
+    def add_notion_source(
+        self,
+        project_id: str,
+        notion_id: str,
+        object_type: str,
+        title: Optional[str] = None,
+        notion_url: Optional[str] = None,
+        last_edited_time: Optional[str] = None,
+        name: Optional[str] = None,
+        description: str = "",
+    ) -> Dict[str, Any]:
+        """
+        Add a Notion source (specific page or database) to a project.
+
+        Educational Note: Unlike Jira/Mixpanel which are live-API flags, Notion
+        sources fetch their content during processing and embed it for RAG —
+        Notion pages are slow-changing knowledge artifacts that benefit from
+        chunked semantic search.
+        """
+        return self._shape_for_frontend(
+            project_id,
+            add_notion_source(
+                project_id=project_id,
+                notion_id=notion_id,
+                object_type=object_type,
+                title=title,
+                notion_url=notion_url,
+                last_edited_time=last_edited_time,
+                name=name,
+                description=description,
+            ),
+        )
 
     def add_mcp_source(
         self,

--- a/backend/app/services/source_services/source_upload/__init__.py
+++ b/backend/app/services/source_services/source_upload/__init__.py
@@ -19,6 +19,7 @@ from app.services.source_services.source_upload.freshdesk_upload import add_fres
 from app.services.source_services.source_upload.jira_upload import add_jira_source
 from app.services.source_services.source_upload.mcp_upload import add_mcp_source
 from app.services.source_services.source_upload.mixpanel_upload import add_mixpanel_source
+from app.services.source_services.source_upload.notion_upload import add_notion_source
 
 __all__ = [
     "upload_file",
@@ -31,4 +32,5 @@ __all__ = [
     "add_jira_source",
     "add_mcp_source",
     "add_mixpanel_source",
+    "add_notion_source",
 ]

--- a/backend/app/services/source_services/source_upload/notion_upload.py
+++ b/backend/app/services/source_services/source_upload/notion_upload.py
@@ -1,0 +1,158 @@
+"""
+Notion Upload Handler - Create a NOTION source for a project.
+
+Educational Note: Notion sources work like Google Drive imports — the user
+picks a specific Notion page or database in the browse-and-pick UI, and we
+create a per-project source that resolves to that ID. The .notion stub holds
+the picked ID + object_type; the processor fetches live content during
+processing and embeds the result for RAG.
+
+Unlike Jira/Mixpanel (live-only API flags), Notion content IS embedded —
+pages are slow-changing knowledge artifacts that benefit from chunked
+semantic search, not live querying.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from app.services.background_services import task_service
+from app.services.integrations.knowledge_bases.notion.notion_service import notion_service
+from app.services.integrations.supabase import storage_service
+from app.services.source_services import source_index_service
+
+logger = logging.getLogger(__name__)
+
+
+VALID_OBJECT_TYPES = ("page", "database")
+
+
+def add_notion_source(
+    project_id: str,
+    notion_id: str,
+    object_type: str,
+    title: Optional[str] = None,
+    notion_url: Optional[str] = None,
+    last_edited_time: Optional[str] = None,
+    name: Optional[str] = None,
+    description: str = "",
+) -> Dict[str, Any]:
+    """
+    Create a NOTION source in a project and trigger processing.
+
+    Args:
+        project_id: The project UUID
+        notion_id: The Notion page or database UUID
+        object_type: "page" or "database"
+        title: Title fetched from Notion during the picker step (used for naming)
+        notion_url: notion.so URL of the resource (for the preview header)
+        last_edited_time: ISO timestamp from Notion (used in preview header)
+        name: Optional display-name override; falls back to `title`
+        description: Optional user description
+
+    Returns:
+        Source metadata dictionary
+
+    Raises:
+        ValueError: If Notion is not configured or arguments are invalid
+    """
+    if not notion_service.is_configured():
+        raise ValueError(
+            "Notion not configured. Add NOTION_API_KEY in Settings → API Keys."
+        )
+    if not notion_id:
+        raise ValueError("notion_id is required")
+    if object_type not in VALID_OBJECT_TYPES:
+        raise ValueError(
+            f"object_type must be one of {VALID_OBJECT_TYPES}, got '{object_type}'"
+        )
+
+    source_id = str(uuid.uuid4())
+    stored_filename = f"{source_id}.notion"
+
+    raw_payload = {
+        "kind": "notion_source",
+        "notion_id": notion_id,
+        "object_type": object_type,
+        "title": title or "",
+        "notion_url": notion_url or "",
+        "last_edited_time": last_edited_time or "",
+        "created_at": datetime.now().isoformat(),
+    }
+
+    raw_bytes = json.dumps(raw_payload, indent=2).encode("utf-8")
+    storage_path = storage_service.upload_raw_file(
+        project_id=project_id,
+        source_id=source_id,
+        filename=stored_filename,
+        file_data=raw_bytes,
+        content_type="application/json; charset=utf-8",
+    )
+    if not storage_path:
+        raise ValueError("Failed to create Notion source metadata in storage")
+
+    display_name = (name or title or f"Notion {object_type}").strip()
+    if not display_name:
+        display_name = f"Notion {object_type}"
+
+    source_metadata: Dict[str, Any] = {
+        "id": source_id,
+        "project_id": project_id,
+        "name": display_name,
+        "description": description,
+        "type": "NOTION",
+        "status": "uploaded",
+        "raw_file_path": storage_path,
+        "file_size": len(raw_bytes),
+        "is_active": True,
+        "embedding_info": {
+            "original_filename": stored_filename,
+            "mime_type": "application/json",
+            "file_extension": ".notion",
+            "stored_filename": stored_filename,
+            "source_type": "notion",
+            "notion_id": notion_id,
+            "object_type": object_type,
+            "notion_url": notion_url or "",
+            "last_edited_time": last_edited_time or "",
+        },
+        "processing_info": {
+            "created_at": datetime.now().isoformat(),
+            "note": f"Notion {object_type} source created. Processing will fetch content.",
+        },
+    }
+
+    source_index_service.add_source_to_index(project_id, source_metadata)
+
+    _submit_processing_task(project_id, source_id)
+
+    return source_metadata
+
+
+def _submit_processing_task(project_id: str, source_id: str) -> None:
+    """Submit a background task to fetch + embed the Notion content."""
+    try:
+        from app.services.source_services.source_processing import (
+            source_processing_service,
+        )
+        from app.services.source_services import source_service
+
+        task_service.submit_task(
+            "source_processing",
+            source_id,
+            source_processing_service.process_source,
+            project_id,
+            source_id,
+        )
+
+        source_service.update_source(project_id, source_id, status="processing")
+    except Exception as e:
+        logger.error(
+            "Failed to submit Notion processing task for source %s: %s",
+            source_id,
+            e,
+        )

--- a/backend/app/utils/text/page_markers.py
+++ b/backend/app/utils/text/page_markers.py
@@ -32,6 +32,7 @@ SOURCE_TYPES = [
     "LINK",     # Web URL content
     "YOUTUBE",  # YouTube video transcripts
     "RESEARCH", # Research documents
+    "NOTION",   # Notion pages and database rows
 ]
 
 # Human-readable display names for headers
@@ -45,6 +46,7 @@ SOURCE_TYPE_DISPLAY = {
     "LINK": "URL",
     "YOUTUBE": "YouTube video transcript",
     "RESEARCH": "research document",
+    "NOTION": "Notion workspace content",
 }
 
 
@@ -75,7 +77,7 @@ def build_page_marker(source_type: str, page_num: int, total_pages: int) -> str:
 # Captures: group(1) = page number, group(2) = total pages
 # The .*? allows for optional suffixes like "(continues...)"
 ANY_PAGE_PATTERN = re.compile(
-    r'=== (?:PDF|TEXT|DOCX|PPTX|AUDIO|LINK|YOUTUBE|IMAGE|RESEARCH) PAGE (\d+) of (\d+).*?==='
+    r'=== (?:PDF|TEXT|DOCX|PPTX|AUDIO|LINK|YOUTUBE|IMAGE|RESEARCH|NOTION) PAGE (\d+) of (\d+).*?==='
 )
 
 # Type-specific patterns (for when you need to match a specific type)
@@ -89,6 +91,7 @@ PAGE_PATTERNS = {
     "LINK": re.compile(r'=== LINK PAGE (\d+) of (\d+) ==='),
     "YOUTUBE": re.compile(r'=== YOUTUBE PAGE (\d+) of (\d+) ==='),
     "RESEARCH": re.compile(r'=== RESEARCH PAGE (\d+) of (\d+) ==='),
+    "NOTION": re.compile(r'=== NOTION PAGE (\d+) of (\d+) ==='),
 }
 
 

--- a/backend/app/utils/text/processed_output.py
+++ b/backend/app/utils/text/processed_output.py
@@ -53,6 +53,7 @@ SOURCE_METADATA_KEYS = {
     "LINK": ["url", "title", "content_type", "character_count", "token_count"],
     "YOUTUBE": ["url", "video_id", "language", "is_auto_generated", "duration", "segment_count", "character_count", "token_count"],
     "RESEARCH": ["topic", "link_count", "character_count", "token_count"],
+    "NOTION": ["object_type", "notion_url", "last_edited_time", "page_count", "character_count", "token_count"],
 }
 
 

--- a/backend/supabase/migrations/00042_notion_source_type.sql
+++ b/backend/supabase/migrations/00042_notion_source_type.sql
@@ -1,0 +1,32 @@
+-- Notion source type
+--
+-- The original initial_schema constraint only listed the file-based source
+-- types (PDF/DOCX/.../RESEARCH). Subsequent integration sources (DATABASE,
+-- FRESHDESK, JIRA, MIXPANEL, MCP, DATA/CSV) have been added in code without
+-- a constraint update — at this point the constraint is either out-of-sync
+-- or already dropped on production. Drop and re-create with the full set so
+-- the schema actually matches the application contract going forward.
+
+ALTER TABLE sources DROP CONSTRAINT IF EXISTS valid_type;
+
+ALTER TABLE sources ADD CONSTRAINT valid_type CHECK (
+  type IN (
+    -- File-based document sources
+    'PDF', 'DOCX', 'PPTX', 'IMAGE', 'AUDIO', 'TEXT',
+    -- Tabular data sources
+    'CSV', 'DATA',
+    -- Web sources
+    'LINK', 'YOUTUBE',
+    -- AI-generated sources
+    'RESEARCH',
+    -- Integration / live-API sources
+    'DATABASE', 'FRESHDESK', 'JIRA', 'MIXPANEL', 'MCP',
+    -- Notion (this migration)
+    'NOTION'
+  )
+);
+
+COMMENT ON COLUMN sources.type IS
+  'Source type. File: PDF, DOCX, PPTX, IMAGE, AUDIO, TEXT, CSV, DATA. '
+  'Web: LINK, YOUTUBE. AI: RESEARCH. Integrations: DATABASE, FRESHDESK, '
+  'JIRA, MIXPANEL, MCP, NOTION.';

--- a/backend/tests/test_notion_source.py
+++ b/backend/tests/test_notion_source.py
@@ -1,0 +1,377 @@
+"""
+Tests for the Notion source integration: service-level recursion + pagination,
+upload stub creation, and the processor's page/database flows.
+
+These tests stub out the Notion HTTP layer (_make_request) and the embedding /
+summary / storage pipeline so we exercise the wiring without external calls.
+"""
+from __future__ import annotations
+
+import os
+
+# Importing source_services pulls in supabase auth_service, which constructs
+# a dedicated client at import time and refuses to load without these env vars
+# being set. Provide harmless placeholders before any app imports happen.
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+# supabase-py validates the key looks like a JWT (3 base64ish segments). Any
+# well-formed placeholder will do — we never actually call the real client.
+os.environ.setdefault(
+    "SUPABASE_SERVICE_KEY",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoidGVzdCJ9.test",
+)
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# notion_service: recursion + block rendering + pagination
+# ---------------------------------------------------------------------------
+
+
+def _make_block(block_type: str, text: str = "", has_children: bool = False, block_id: str = "b1", extra=None) -> dict:
+    body = {"rich_text": [{"plain_text": text}]}
+    if extra:
+        body.update(extra)
+    return {
+        "id": block_id,
+        "type": block_type,
+        block_type: body,
+        "has_children": has_children,
+    }
+
+
+def test_get_page_recurses_into_toggle_children(monkeypatch):
+    """A toggle with nested children should surface those children in content."""
+    # The package's __init__.py rebinds the `notion_service` attribute to the
+    # singleton, masking the submodule for plain `import … as` resolution.
+    # Use importlib to get the actual module object so we can instantiate
+    # NotionService directly in tests.
+    import importlib
+    ns_module = importlib.import_module(
+        "app.services.integrations.knowledge_bases.notion.notion_service"
+    )
+    svc = ns_module.NotionService()
+    svc._configured = True
+    svc._api_key = "test"
+
+    page_meta = {
+        "id": "page-1",
+        "url": "https://notion.so/page-1",
+        "created_time": "2026-05-01T00:00:00.000Z",
+        "last_edited_time": "2026-05-02T00:00:00.000Z",
+        "properties": {
+            "Name": {"type": "title", "title": [{"plain_text": "My Page"}]},
+        },
+    }
+    parent_children = {
+        "results": [
+            _make_block("paragraph", "Hello world", block_id="b1"),
+            _make_block("toggle", "Outer", has_children=True, block_id="toggle-1"),
+        ],
+        "has_more": False,
+    }
+    toggle_children = {
+        "results": [
+            _make_block("paragraph", "Inside the toggle", block_id="b2"),
+        ],
+        "has_more": False,
+    }
+
+    def fake_request(endpoint, method="GET", json_data=None):
+        if endpoint.startswith("pages/page-1"):
+            return {"success": True, "data": page_meta}
+        if endpoint.startswith("blocks/page-1/children"):
+            return {"success": True, "data": parent_children}
+        if endpoint.startswith("blocks/toggle-1/children"):
+            return {"success": True, "data": toggle_children}
+        raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+    monkeypatch.setattr(svc, "_make_request", fake_request)
+
+    result = svc.get_page("page-1")
+    assert result["success"], result
+    content = result["page"]["content"]
+    assert "Hello world" in content
+    # Toggle marker + nested paragraph (indented one level)
+    assert "Outer" in content
+    assert "Inside the toggle" in content
+    assert result["page"]["title"] == "My Page"
+
+
+def test_get_page_respects_recursion_cap(monkeypatch):
+    """Recursion must stop at MAX_RECURSION_DEPTH so circular pages don't run away."""
+    # The package's __init__.py rebinds the `notion_service` attribute to the
+    # singleton, masking the submodule for plain `import … as` resolution.
+    # Use importlib to get the actual module object so we can instantiate
+    # NotionService directly in tests.
+    import importlib
+    ns_module = importlib.import_module(
+        "app.services.integrations.knowledge_bases.notion.notion_service"
+    )
+    svc = ns_module.NotionService()
+    svc._configured = True
+    svc._api_key = "test"
+
+    page_meta = {"id": "p", "properties": {}}
+
+    def fake_request(endpoint, method="GET", json_data=None):
+        if endpoint.startswith("pages/p"):
+            return {"success": True, "data": page_meta}
+        # Every block has a child of itself (depth-1 child).
+        return {
+            "success": True,
+            "data": {
+                "results": [_make_block("paragraph", "x", has_children=True, block_id="child")],
+                "has_more": False,
+            },
+        }
+
+    monkeypatch.setattr(svc, "_make_request", fake_request)
+    result = svc.get_page("p")
+    assert result["success"]
+    # MAX_RECURSION_DEPTH=5 → top-level call (depth=0) plus 5 recursive layers,
+    # each emitting one paragraph block.
+    assert result["page"]["block_count"] <= ns_module.MAX_RECURSION_DEPTH + 1
+
+
+def test_query_database_paginates(monkeypatch):
+    """query_database should follow has_more / next_cursor until exhausted."""
+    # The package's __init__.py rebinds the `notion_service` attribute to the
+    # singleton, masking the submodule for plain `import … as` resolution.
+    # Use importlib to get the actual module object so we can instantiate
+    # NotionService directly in tests.
+    import importlib
+    ns_module = importlib.import_module(
+        "app.services.integrations.knowledge_bases.notion.notion_service"
+    )
+    svc = ns_module.NotionService()
+    svc._configured = True
+    svc._api_key = "test"
+
+    pages = [
+        {
+            "results": [{"id": f"row-{i}", "properties": {}} for i in range(2)],
+            "has_more": True,
+            "next_cursor": "cursor-1",
+        },
+        {
+            "results": [{"id": f"row-{i+2}", "properties": {}} for i in range(2)],
+            "has_more": True,
+            "next_cursor": "cursor-2",
+        },
+        {
+            "results": [{"id": "row-4", "properties": {}}],
+            "has_more": False,
+        },
+    ]
+    calls = {"i": 0}
+
+    def fake_request(endpoint, method="GET", json_data=None):
+        i = calls["i"]
+        calls["i"] += 1
+        return {"success": True, "data": pages[i]}
+
+    monkeypatch.setattr(svc, "_make_request", fake_request)
+    result = svc.query_database("db-1")
+    assert result["success"]
+    ids = [r["id"] for r in result["results"]]
+    assert ids == ["row-0", "row-1", "row-2", "row-3", "row-4"]
+
+
+# ---------------------------------------------------------------------------
+# notion_upload: stub creation
+# ---------------------------------------------------------------------------
+
+
+def test_add_notion_source_creates_stub(monkeypatch):
+    from app.services.source_services.source_upload import notion_upload
+
+    # Pretend Notion is configured
+    monkeypatch.setattr(notion_upload.notion_service, "is_configured", lambda: True)
+    # Capture the bytes uploaded as raw file
+    captured = {}
+
+    def fake_upload_raw(project_id, source_id, filename, file_data, content_type=None):
+        captured["filename"] = filename
+        captured["file_data"] = file_data
+        return f"raw/{project_id}/{source_id}/{filename}"
+
+    monkeypatch.setattr(notion_upload.storage_service, "upload_raw_file", fake_upload_raw)
+    monkeypatch.setattr(
+        notion_upload.source_index_service, "add_source_to_index", lambda *a, **k: None
+    )
+    # Don't actually queue work
+    monkeypatch.setattr(notion_upload, "_submit_processing_task", lambda *a, **k: None)
+
+    result = notion_upload.add_notion_source(
+        project_id="proj-1",
+        notion_id="notion-page-1",
+        object_type="page",
+        title="My Page",
+        notion_url="https://notion.so/My-Page",
+        last_edited_time="2026-05-19T00:00:00Z",
+    )
+
+    assert result["type"] == "NOTION"
+    assert result["status"] == "uploaded"
+    assert result["embedding_info"]["notion_id"] == "notion-page-1"
+    assert result["embedding_info"]["object_type"] == "page"
+    assert result["embedding_info"]["file_extension"] == ".notion"
+    # Stub bytes are JSON with the right keys
+    stub = json.loads(captured["file_data"].decode("utf-8"))
+    assert stub["notion_id"] == "notion-page-1"
+    assert stub["object_type"] == "page"
+
+
+def test_add_notion_source_rejects_invalid_object_type(monkeypatch):
+    from app.services.source_services.source_upload import notion_upload
+    monkeypatch.setattr(notion_upload.notion_service, "is_configured", lambda: True)
+    with pytest.raises(ValueError, match="object_type"):
+        notion_upload.add_notion_source(
+            project_id="p", notion_id="n", object_type="block"
+        )
+
+
+def test_add_notion_source_requires_configured(monkeypatch):
+    from app.services.source_services.source_upload import notion_upload
+    monkeypatch.setattr(notion_upload.notion_service, "is_configured", lambda: False)
+    with pytest.raises(ValueError, match="Notion not configured"):
+        notion_upload.add_notion_source(
+            project_id="p", notion_id="n", object_type="page"
+        )
+
+
+# ---------------------------------------------------------------------------
+# notion_processor: page + database flows
+# ---------------------------------------------------------------------------
+
+
+def _write_stub(tmp_path: Path, notion_id: str, object_type: str) -> Path:
+    path = tmp_path / f"{notion_id}.notion"
+    path.write_text(json.dumps({
+        "kind": "notion_source",
+        "notion_id": notion_id,
+        "object_type": object_type,
+        "title": "T",
+        "notion_url": "https://notion.so/T",
+        "last_edited_time": "2026-05-01T00:00:00Z",
+    }))
+    return path
+
+
+def _patch_processor_pipeline(monkeypatch):
+    """Stub out storage / embedding / summary / cancellation so the processor
+    only exercises its own logic."""
+    from app.services.source_services.source_processing import notion_processor as np_module
+
+    monkeypatch.setattr(np_module.notion_service, "is_configured", lambda: True)
+    monkeypatch.setattr(np_module.task_service, "is_target_cancelled", lambda _id: False)
+    monkeypatch.setattr(
+        np_module.storage_service, "upload_processed_file",
+        lambda **kwargs: f"processed/{kwargs['source_id']}.txt",
+    )
+    monkeypatch.setattr(
+        np_module.embedding_service, "process_embeddings",
+        lambda **kwargs: {"is_embedded": True, "chunk_count": 3, "token_count": 100},
+    )
+    monkeypatch.setattr(
+        np_module.summary_service, "generate_summary",
+        lambda **kwargs: {"summary": "ok"},
+    )
+    return np_module
+
+
+def test_process_notion_page(tmp_path, monkeypatch):
+    np_module = _patch_processor_pipeline(monkeypatch)
+
+    monkeypatch.setattr(np_module.notion_service, "get_page", lambda nid: {
+        "success": True,
+        "page": {
+            "id": nid,
+            "title": "My Page",
+            "url": "https://notion.so/My-Page",
+            "last_edited_time": "2026-05-02T00:00:00Z",
+            "content": "Hello world\n\n## Section\n\nMore",
+            "block_count": 3,
+        },
+    })
+
+    source_service = MagicMock()
+    raw_path = _write_stub(tmp_path, "page-1", "page")
+    result = np_module.process_notion(
+        project_id="proj-1",
+        source_id="src-1",
+        source={"id": "src-1", "name": "My Page"},
+        raw_file_path=raw_path,
+        source_service=source_service,
+    )
+
+    assert result["success"], result
+    assert result["status"] == "ready"
+    # Final update_source call must include status=ready
+    final_call = source_service.update_source.call_args_list[-1]
+    assert final_call.kwargs.get("status") == "ready"
+
+
+def test_process_notion_database(tmp_path, monkeypatch):
+    np_module = _patch_processor_pipeline(monkeypatch)
+
+    monkeypatch.setattr(np_module.notion_service, "get_database", lambda nid: {
+        "success": True,
+        "database": {
+            "id": nid,
+            "title": "Tasks",
+            "url": "https://notion.so/Tasks",
+            "last_edited_time": "2026-05-03T00:00:00Z",
+            "schema": {"Name": {"type": "title"}, "Status": {"type": "select"}},
+        },
+    })
+    monkeypatch.setattr(np_module.notion_service, "query_database", lambda nid, **kw: {
+        "success": True,
+        "results": [
+            {"id": "row-1", "properties": {"Name": "Task 1", "Status": "Open"}},
+            {"id": "row-2", "properties": {"Name": "Task 2", "Status": "Done"}},
+        ],
+    })
+    monkeypatch.setattr(np_module.notion_service, "get_page", lambda nid: {
+        "success": True,
+        "page": {"id": nid, "title": "row body", "content": "Row body for " + nid},
+    })
+
+    source_service = MagicMock()
+    raw_path = _write_stub(tmp_path, "db-1", "database")
+    result = np_module.process_notion(
+        project_id="proj-1",
+        source_id="src-2",
+        source={"id": "src-2", "name": "Tasks"},
+        raw_file_path=raw_path,
+        source_service=source_service,
+    )
+
+    assert result["success"], result
+    # 1 overview + 2 row pages
+    final_call = source_service.update_source.call_args_list[-1]
+    pi = final_call.kwargs.get("processing_info", {})
+    assert pi.get("total_pages") == 3
+
+
+def test_process_notion_invalid_stub(tmp_path, monkeypatch):
+    np_module = _patch_processor_pipeline(monkeypatch)
+
+    bad = tmp_path / "bad.notion"
+    bad.write_text(json.dumps({"kind": "notion_source"}))  # missing notion_id
+
+    source_service = MagicMock()
+    result = np_module.process_notion(
+        project_id="p",
+        source_id="s",
+        source={"id": "s"},
+        raw_file_path=bad,
+        source_service=source_service,
+    )
+    assert not result["success"]
+    source_service.update_source.assert_called()

--- a/frontend/src/components/sources/AddSourcesSheet.tsx
+++ b/frontend/src/components/sources/AddSourcesSheet.tsx
@@ -17,6 +17,7 @@ import { McpTab } from './McpTab';
 import { FreshdeskTab } from './FreshdeskTab';
 import { JiraTab } from './JiraTab';
 import { MixpanelTab } from './MixpanelTab';
+import { NotionTab } from './NotionTab';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { MAX_SOURCES } from '../../lib/api/sources';
 
@@ -72,6 +73,7 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
   const canFreshdesk = hasPermission('data_sources', 'freshdesk');
   const canJira = hasPermission('integrations', 'jira');
   const canMixpanel = hasPermission('integrations', 'mixpanel');
+  const canNotion = hasPermission('integrations', 'notion');
   // Note: CSV permission exists (hasPermission('data_sources', 'csv')) but no CSV tab yet
 
   // Research and MCP are always shown (no dedicated permission key) — gated at category level
@@ -89,6 +91,7 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
     : canFreshdesk ? 'freshdesk'
     : canJira ? 'jira'
     : canMixpanel ? 'mixpanel'
+    : canNotion ? 'notion'
     : 'upload';
 
   const tabTriggerClass = "px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white";
@@ -156,6 +159,11 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
               {canMixpanel && (
                 <TabsTrigger value="mixpanel" className={tabTriggerClass}>
                   Mixpanel
+                </TabsTrigger>
+              )}
+              {canNotion && (
+                <TabsTrigger value="notion" className={tabTriggerClass}>
+                  Notion
                 </TabsTrigger>
               )}
             </TabsList>
@@ -263,6 +271,19 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
                   isAtLimit={isAtLimit}
                   onAddMixpanel={async (name, description) => {
                     await onAddMixpanel(name, description);
+                    onImportComplete();
+                    onOpenChange(false);
+                  }}
+                />
+              </TabsContent>
+            )}
+
+            {canNotion && (
+              <TabsContent value="notion" className="mt-6">
+                <NotionTab
+                  projectId={projectId}
+                  isAtLimit={isAtLimit}
+                  onAdded={() => {
                     onImportComplete();
                     onOpenChange(false);
                   }}

--- a/frontend/src/components/sources/NotionTab.tsx
+++ b/frontend/src/components/sources/NotionTab.tsx
@@ -1,0 +1,268 @@
+/**
+ * NotionTab Component
+ *
+ * Browse-and-pick UI for adding a Notion page or database as a source.
+ * The shared NOTION_API_KEY drives this — no per-user OAuth. If the admin
+ * hasn't configured the key, we show a passive "not configured" state
+ * (mirroring GoogleDriveTab's pattern).
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CircleNotch,
+  MagnifyingGlass,
+  NotionLogo,
+  Plus,
+  FileText,
+  Table,
+} from '@phosphor-icons/react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { sourcesAPI, type NotionPickerItem } from '../../lib/api/sources';
+import { useToast } from '../ui/use-toast';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('notion-tab');
+
+interface NotionTabProps {
+  projectId: string;
+  isAtLimit: boolean;
+  onAdded: () => void;
+}
+
+type FilterType = 'all' | 'page' | 'database';
+
+export const NotionTab: React.FC<NotionTabProps> = ({ projectId, isAtLimit, onAdded }) => {
+  const { error: toastError, success } = useToast();
+
+  const [statusLoading, setStatusLoading] = useState(true);
+  const [configured, setConfigured] = useState(false);
+
+  const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<FilterType>('all');
+  const [results, setResults] = useState<NotionPickerItem[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  // Track which row is currently being imported so we can disable just that
+  // row's button (the rest stay clickable).
+  const [importingId, setImportingId] = useState<string | null>(null);
+
+  // Debounce the search box so we don't fire on every keystroke.
+  const debounceRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const status = await sourcesAPI.getNotionStatus();
+        if (cancelled) return;
+        setConfigured(status.configured);
+      } finally {
+        if (!cancelled) setStatusLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Initial + filter-change loads
+  useEffect(() => {
+    if (!configured) return;
+    runSearch(query, filter);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configured, filter]);
+
+  const runSearch = async (q: string, f: FilterType) => {
+    setSearching(true);
+    try {
+      const items = await sourcesAPI.searchNotion(
+        q || undefined,
+        f === 'all' ? undefined : f,
+        50
+      );
+      setResults(items);
+    } catch (err) {
+      log.error({ err }, 'notion search failed');
+      toastError('Failed to search Notion');
+      setResults([]);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value);
+    if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => runSearch(value, filter), 300);
+  };
+
+  const handlePick = async (item: NotionPickerItem) => {
+    if (isAtLimit || importingId) return;
+    setImportingId(item.id);
+    try {
+      await sourcesAPI.addNotionSource(projectId, {
+        notion_id: item.id,
+        object_type: item.type,
+        title: item.title,
+        notion_url: item.url,
+        last_edited_time: item.last_edited_time,
+      });
+      success(
+        item.type === 'database'
+          ? 'Notion database added — fetching rows…'
+          : 'Notion page added — fetching content…'
+      );
+      onAdded();
+    } catch (err: unknown) {
+      log.error({ err }, 'failed to add notion source');
+      const msg =
+        typeof err === 'object' && err !== null && 'response' in err
+          ? (err as { response?: { data?: { error?: string } } }).response?.data?.error
+          : null;
+      toastError(msg || 'Failed to add Notion source');
+    } finally {
+      setImportingId(null);
+    }
+  };
+
+  const filterButtonClass = (active: boolean) =>
+    `px-3 py-1.5 text-xs rounded-md border transition-colors ${
+      active
+        ? 'border-amber-600 bg-amber-600 text-white'
+        : 'border-stone-300 bg-stone-100 text-stone-700 hover:bg-stone-200'
+    }`;
+
+  const rowIcon = useMemo(() => {
+    return (kind: 'page' | 'database') =>
+      kind === 'database' ? (
+        <Table size={18} weight="duotone" className="text-amber-700 shrink-0" />
+      ) : (
+        <FileText size={18} weight="duotone" className="text-stone-600 shrink-0" />
+      );
+  }, []);
+
+  if (statusLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <CircleNotch size={24} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!configured) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <NotionLogo size={48} weight="duotone" className="text-muted-foreground mb-4" />
+        <h3 className="font-medium mb-2">Notion Not Configured</h3>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          An administrator needs to add the Notion integration token in
+          Admin Settings → API Keys (<code>NOTION_API_KEY</code>) before
+          this can be used.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm">
+        Pick a Notion page or database to import. The page content (including
+        nested toggles and sub-pages) is fetched once and embedded for
+        semantic search in chat.
+      </p>
+
+      <div className="relative">
+        <MagnifyingGlass
+          size={16}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          className="pl-9"
+          placeholder="Search Notion…"
+          value={query}
+          onChange={(e) => handleQueryChange(e.target.value)}
+          disabled={isAtLimit}
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          className={filterButtonClass(filter === 'all')}
+          onClick={() => setFilter('all')}
+        >
+          All
+        </button>
+        <button
+          type="button"
+          className={filterButtonClass(filter === 'page')}
+          onClick={() => setFilter('page')}
+        >
+          Pages
+        </button>
+        <button
+          type="button"
+          className={filterButtonClass(filter === 'database')}
+          onClick={() => setFilter('database')}
+        >
+          Databases
+        </button>
+      </div>
+
+      <div className="border rounded-md max-h-96 overflow-y-auto">
+        {searching ? (
+          <div className="flex justify-center py-8">
+            <CircleNotch size={20} className="animate-spin text-muted-foreground" />
+          </div>
+        ) : results.length === 0 ? (
+          <div className="text-sm text-muted-foreground text-center py-8 px-4">
+            No Notion {filter === 'all' ? 'pages or databases' : `${filter}s`} found.
+            Make sure your Notion integration has been shared with the workspace
+            you want to import from.
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {results.map((item) => (
+              <li
+                key={item.id}
+                className="flex items-center gap-3 px-3 py-2 hover:bg-stone-50"
+              >
+                {rowIcon(item.type)}
+                <div className="flex-1 min-w-0">
+                  <div className="truncate text-sm font-medium">
+                    {item.title || 'Untitled'}
+                  </div>
+                  <div className="truncate text-xs text-muted-foreground">
+                    {item.type === 'database' ? 'Database' : 'Page'}
+                    {item.last_edited_time
+                      ? ` · edited ${new Date(item.last_edited_time).toLocaleDateString()}`
+                      : ''}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="soft"
+                  onClick={() => handlePick(item)}
+                  disabled={isAtLimit || importingId !== null}
+                >
+                  {importingId === item.id ? (
+                    <>
+                      <CircleNotch size={14} className="mr-1.5 animate-spin" />
+                      Adding…
+                    </>
+                  ) : (
+                    <>
+                      <Plus size={14} className="mr-1.5" />
+                      Add
+                    </>
+                  )}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/sources/SourceItem.tsx
+++ b/frontend/src/components/sources/SourceItem.tsx
@@ -35,6 +35,7 @@ import {
   ArrowsClockwise,
   CloudArrowDown,
   Plug,
+  NotionLogo,
 } from '@phosphor-icons/react';
 import {
   DropdownMenu,
@@ -97,6 +98,7 @@ const getSourceIcon = (source: Source): { icon: typeof File; weight?: 'bold' } =
     case '.xlsx': return { icon: FileXls, weight: 'bold' };
     case '.database': return { icon: Table, weight: 'bold' };
     case '.mcp': return { icon: Plug, weight: 'bold' };
+    case '.notion': return { icon: NotionLogo, weight: 'bold' };
     case '.md': return { icon: MarkdownLogo, weight: 'bold' };
     case '.html': return { icon: FileHtml, weight: 'bold' };
     case '.json': case '.xml': return { icon: FileText, weight: 'bold' };
@@ -117,6 +119,7 @@ const getSourceIcon = (source: Source): { icon: typeof File; weight?: 'bold' } =
     case 'DATA': return { icon: Table, weight: 'bold' };
     case 'DATABASE': return { icon: Table, weight: 'bold' };
     case 'MCP': return { icon: Plug, weight: 'bold' };
+    case 'NOTION': return { icon: NotionLogo, weight: 'bold' };
     case 'DOCUMENT': return { icon: FileText, weight: 'bold' };
     default: return { icon: File, weight: 'bold' };
   }

--- a/frontend/src/components/sources/SourcesPanel.tsx
+++ b/frontend/src/components/sources/SourcesPanel.tsx
@@ -58,6 +58,7 @@ import {
   CaretRight,
   Plus,
   Plug,
+  NotionLogo,
 } from '@phosphor-icons/react';
 import { createLogger } from '@/lib/logger';
 import { patchOne, removeOne, upsertOne } from '@/lib/resourceState';
@@ -100,6 +101,7 @@ const getSourceIcon = (source: Source): typeof File => {
     case '.csv': return FileCsv;
     case '.database': return Table;
     case '.mcp': return Plug;
+    case '.notion': return NotionLogo;
     case '.md': return MarkdownLogo;
     case '.html': return FileHtml;
     case '.json': case '.xml': return FileText;
@@ -120,6 +122,7 @@ const getSourceIcon = (source: Source): typeof File => {
     case 'DATA': return Table;
     case 'DATABASE': return Table;
     case 'MCP': return Plug;
+    case 'NOTION': return NotionLogo;
     case 'DOCUMENT': return FileText;
     default: return File;
   }

--- a/frontend/src/lib/api/sources.ts
+++ b/frontend/src/lib/api/sources.ts
@@ -91,6 +91,18 @@ export interface ChunkContent {
 }
 
 /**
+ * A single result row returned by GET /notion/search — used by the Notion picker.
+ */
+export interface NotionPickerItem {
+  id: string;
+  type: 'page' | 'database';
+  title?: string;
+  url?: string;
+  created_time?: string;
+  last_edited_time?: string;
+}
+
+/**
  * Processed content returned from the processed content API
  * Educational Note: This is used for viewing extracted text from sources
  * in the Sources panel. Users can click on a processed source to see
@@ -122,7 +134,7 @@ export interface RawFileUrl {
  */
 export const VIEWABLE_EXTENSIONS = [
   '.pdf', '.txt', '.docx', '.pptx', '.md', '.json', '.html', '.xml',  // Documents
-  '.link', '.research', '.mcp',                                          // Web content / MCP
+  '.link', '.research', '.mcp', '.notion',                              // Web content / MCP / Notion
 ];
 
 export const NON_VIEWABLE_EXTENSIONS = [
@@ -615,6 +627,71 @@ class SourcesAPI {
       return response.data.source;
     } catch (error) {
       log.error({ err: error }, 'failed to add Mixpanel source');
+      throw error;
+    }
+  }
+
+  /**
+   * Check whether the global Notion integration is configured (i.e. the
+   * admin has set NOTION_API_KEY). Returns false rather than throwing on
+   * misconfiguration so the picker can show a friendly empty state.
+   */
+  async getNotionStatus(): Promise<{ configured: boolean }> {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/notion/status`);
+      return { configured: !!response.data?.configured };
+    } catch (error) {
+      log.error({ err: error }, 'failed to fetch notion status');
+      return { configured: false };
+    }
+  }
+
+  /**
+   * Search the connected Notion workspace for pages/databases (paginated server-side).
+   */
+  async searchNotion(
+    query?: string,
+    type?: 'page' | 'database',
+    limit = 50
+  ): Promise<NotionPickerItem[]> {
+    try {
+      const params: Record<string, string> = { limit: String(limit) };
+      if (query) params.q = query;
+      if (type) params.type = type;
+      const response = await axios.get(`${API_BASE_URL}/notion/search`, { params });
+      return (response.data?.results || []) as NotionPickerItem[];
+    } catch (error) {
+      log.error({ err: error }, 'failed to search notion');
+      throw error;
+    }
+  }
+
+  /**
+   * Add a Notion source (one page or one database) to a project.
+   * Educational Note: Notion content IS embedded for RAG — unlike Jira/Mixpanel
+   * which are live-API flags, Notion pages/databases are fetched once during
+   * processing, chunked, and stored for semantic search.
+   */
+  async addNotionSource(
+    projectId: string,
+    payload: {
+      notion_id: string;
+      object_type: 'page' | 'database';
+      title?: string;
+      notion_url?: string;
+      last_edited_time?: string;
+      name?: string;
+      description?: string;
+    }
+  ): Promise<Source> {
+    try {
+      const response = await axios.post(
+        `${API_BASE_URL}/projects/${projectId}/sources/notion`,
+        payload
+      );
+      return response.data.source;
+    } catch (error) {
+      log.error({ err: error }, 'failed to add Notion source');
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- Add Notion workspace search and source creation, with recursive page/database sync support.
- Introduce saved insights with create/list/delete/refresh APIs, background scheduling, and persistent chat history per insight.
- Auto-seed new chats with DB-type sources and refresh insight chats under the correct user context.
- Harden auth and OAuth flows, including signed Google OAuth state, isolated Supabase clients, and tighter RBAC handling.
- Expand the chat and studio UI with Notion source selection, saved-insight cards/details, and onboarding/tutorial flows.

## Testing
- `backend/tests/test_notion_source.py` added to cover Notion source behavior.
- Not run: full backend test suite.
- Not run: frontend build/typecheck.
- Not run: database migration verification against a live Supabase instance.