### PR TITLE
feat(logs): delete-after-download prompt + weekly auto-clear

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -136,6 +136,17 @@ def create_app(config_name='development'):
     except Exception as exc:
         app.logger.warning("Failed to start insight scheduler: %s", exc)
 
+    # Start the log housekeeping scheduler. Daemon thread; one tick every
+    # hour; clears the rotating log files once a week (admin can disable
+    # via Settings → Logs → "Auto-clear logs weekly").
+    try:
+        from app.services.background_services.log_housekeeping_scheduler import (
+            log_housekeeping_scheduler,
+        )
+        log_housekeeping_scheduler.start()
+    except Exception as exc:
+        app.logger.warning("Failed to start log housekeeping scheduler: %s", exc)
+
     # Log successful initialization
     app.logger.info(f"✅ {app.config['APP_NAME']} backend initialized successfully")
 

--- a/backend/app/api/logs/routes.py
+++ b/backend/app/api/logs/routes.py
@@ -127,17 +127,22 @@ def download_bundle():
 
 
 @logs_bp.route("/logs/clear", methods=["POST"])
-@require_auth
+@require_admin
 def clear_logs():
     """Truncate the active log file and remove rotated archives.
 
-    Gated `require_auth` (not `require_admin`) because the matching
-    `/logs/bundle` download is `require_auth` too — any user who can pull
-    the logs can also wipe them in this single-tenant deployment. The
-    audit log records who triggered the clear so a wipe is still
-    attributable.
+    Admin-only: read (`/logs/bundle`) and destroy are asymmetric — any
+    authenticated user can pull a copy of the logs, but only admins can
+    permanently wipe the server-side diagnostic history (which may be
+    the only evidence of a crash or security incident affecting other
+    users). The audit log records which admin triggered the clear.
+
+    Surfaced to non-admins in the UI via the "Delete logs from server
+    after download" checkbox — that path is gated by this same endpoint,
+    so the checkbox is a no-op for non-admins (frontend hides it; if
+    they bypass the UI, this returns 403).
     """
-    initiator = getattr(g, "user_id", None) or "user"
+    initiator = getattr(g, "user_id", None) or "admin"
     result = clear_logs_service(initiator=str(initiator))
     if not result.get("success"):
         return jsonify(result), 500

--- a/backend/app/api/logs/routes.py
+++ b/backend/app/api/logs/routes.py
@@ -17,6 +17,9 @@ from app.api.logs import logs_bp
 from app.api.logs.bundle import build_bundle
 from app.api.logs.redaction import redact_line
 from app.services.auth.rbac import require_admin, require_auth
+from app.services.data_services.user_service import get_user_service
+from app.services.integrations.supabase import get_supabase, is_supabase_enabled
+from app.services.log_service import clear_logs as clear_logs_service
 from app.utils import logger as logger_module
 
 logger = logging.getLogger(__name__)
@@ -124,34 +127,163 @@ def download_bundle():
 
 
 @logs_bp.route("/logs/clear", methods=["POST"])
-@require_admin
+@require_auth
 def clear_logs():
     """Truncate the active log file and remove rotated archives.
 
-    Useful when the admin wants a clean window before reproducing a bug
-    so the bundle they ship contains only the relevant noise.
+    Gated `require_auth` (not `require_admin`) because the matching
+    `/logs/bundle` download is `require_auth` too — any user who can pull
+    the logs can also wipe them in this single-tenant deployment. The
+    audit log records who triggered the clear so a wipe is still
+    attributable.
     """
-    log_file = logger_module.LOG_FILE
-    if log_file is None or not log_file.parent.exists():
-        return jsonify({"success": True, "cleared": 0, "message": "no log file"}), 200
+    initiator = getattr(g, "user_id", None) or "user"
+    result = clear_logs_service(initiator=str(initiator))
+    if not result.get("success"):
+        return jsonify(result), 500
+    return jsonify(result), 200
 
-    cleared = 0
+
+# ---------------------------------------------------------------------------
+# Per-user "auto-delete on download" preference
+# ---------------------------------------------------------------------------
+
+_AUTO_DELETE_SETTINGS_KEY = "auto_delete_logs_on_download"
+
+
+@logs_bp.route("/logs/preferences", methods=["GET"])
+@require_auth
+def get_log_preferences():
+    """Return the current user's log-related preferences.
+
+    Right now only `auto_delete_on_download` — drives the pre-check of the
+    "Delete logs from server after download" checkbox in the bundle dialog.
+    """
+    user_id = getattr(g, "user_id", None)
+    if not user_id:
+        return jsonify({"success": False, "error": "missing user"}), 401
+    if not is_supabase_enabled():
+        return jsonify({"success": True, "auto_delete_on_download": False}), 200
+    settings = get_user_service().get_user_settings_raw(user_id)
+    return jsonify(
+        {
+            "success": True,
+            "auto_delete_on_download": bool(settings.get(_AUTO_DELETE_SETTINGS_KEY, False)),
+        }
+    ), 200
+
+
+@logs_bp.route("/logs/preferences", methods=["PUT"])
+@require_auth
+def update_log_preferences():
+    """Persist the user's log-download preferences in users.settings."""
+    user_id = getattr(g, "user_id", None)
+    if not user_id:
+        return jsonify({"success": False, "error": "missing user"}), 401
+    payload = request.get_json(silent=True) or {}
+    if "auto_delete_on_download" not in payload:
+        return jsonify(
+            {"success": False, "error": "auto_delete_on_download is required"}
+        ), 400
+    value = bool(payload.get("auto_delete_on_download"))
+    if not is_supabase_enabled():
+        # Best-effort no-op in self-hosted setups without Supabase auth.
+        return jsonify({"success": True, "auto_delete_on_download": value}), 200
+    saved = get_user_service().set_settings_key(
+        user_id, _AUTO_DELETE_SETTINGS_KEY, value
+    )
+    if not saved:
+        return jsonify({"success": False, "error": "could not persist preference"}), 500
+    return jsonify({"success": True, "auto_delete_on_download": value}), 200
+
+
+# ---------------------------------------------------------------------------
+# Global "auto-clear logs weekly" admin toggle
+# ---------------------------------------------------------------------------
+
+_HOUSEKEEPING_DEFAULT = {"weekly_clear_enabled": True, "last_run_at": None}
+
+
+def _read_housekeeping() -> dict[str, Any]:
+    if not is_supabase_enabled():
+        return dict(_HOUSEKEEPING_DEFAULT)
     try:
-        if log_file.exists():
-            log_file.write_text("", encoding="utf-8")
-            cleared += 1
-        for archive in log_file.parent.glob(f"{log_file.name}.*"):
-            try:
-                archive.unlink()
-                cleared += 1
-            except OSError as exc:
-                logger.warning("Could not delete archive %s: %s", archive, exc)
+        client = get_supabase()
+        resp = (
+            client.table("app_settings")
+            .select("log_housekeeping")
+            .eq("id", True)
+            .limit(1)
+            .execute()
+        )
     except Exception as exc:
-        logger.exception("Failed to clear logs")
-        return jsonify({"success": False, "error": str(exc)}), 500
+        logger.warning("Could not read app_settings.log_housekeeping: %s", exc)
+        return dict(_HOUSEKEEPING_DEFAULT)
+    rows = resp.data or []
+    if not rows:
+        return dict(_HOUSEKEEPING_DEFAULT)
+    return {**_HOUSEKEEPING_DEFAULT, **(rows[0].get("log_housekeeping") or {})}
 
-    logger.info("Log files cleared by admin (%d files)", cleared)
-    return jsonify({"success": True, "cleared": cleared}), 200
+
+@logs_bp.route("/logs/housekeeping", methods=["GET"])
+@require_auth
+def get_log_housekeeping():
+    """Return the global weekly-clear configuration.
+
+    Read is open to any authenticated user so non-admin users can still
+    see *when* the next auto-clear is due before they download a bundle.
+    """
+    config = _read_housekeeping()
+    return jsonify(
+        {
+            "success": True,
+            "weekly_clear_enabled": bool(config.get("weekly_clear_enabled", True)),
+            "last_run_at": config.get("last_run_at"),
+        }
+    ), 200
+
+
+@logs_bp.route("/logs/housekeeping", methods=["PUT"])
+@require_admin
+def update_log_housekeeping():
+    """Admin-only toggle of the weekly auto-clear scheduler."""
+    if not is_supabase_enabled():
+        return jsonify({"success": False, "error": "supabase not configured"}), 503
+    payload = request.get_json(silent=True) or {}
+    if "weekly_clear_enabled" not in payload:
+        return jsonify(
+            {"success": False, "error": "weekly_clear_enabled is required"}
+        ), 400
+    enabled = bool(payload.get("weekly_clear_enabled"))
+
+    config = _read_housekeeping()
+    new_value = {**config, "weekly_clear_enabled": enabled}
+    try:
+        client = get_supabase()
+        resp = (
+            client.table("app_settings")
+            .update({"log_housekeeping": new_value})
+            .eq("id", True)
+            .execute()
+        )
+    except Exception as exc:
+        logger.exception("Failed to update app_settings.log_housekeeping")
+        return jsonify({"success": False, "error": str(exc)}), 500
+    if not resp.data:
+        return jsonify({"success": False, "error": "no app_settings row"}), 500
+    initiator = getattr(g, "user_id", None) or "admin"
+    logger.info(
+        "Weekly log auto-clear toggled %s by %s",
+        "ENABLED" if enabled else "DISABLED",
+        initiator,
+    )
+    return jsonify(
+        {
+            "success": True,
+            "weekly_clear_enabled": enabled,
+            "last_run_at": new_value.get("last_run_at"),
+        }
+    ), 200
 
 
 @logs_bp.route("/logs/client", methods=["POST"])

--- a/backend/app/api/logs/routes.py
+++ b/backend/app/api/logs/routes.py
@@ -261,21 +261,46 @@ def update_log_housekeeping():
         ), 400
     enabled = bool(payload.get("weekly_clear_enabled"))
 
-    config = _read_housekeeping()
-    new_value = {**config, "weekly_clear_enabled": enabled}
+    # Re-read inside the write path and conditionally update on the
+    # observed last_run_at. Without this gate, a scheduler tick that lands
+    # between our read and our write would have its freshly-written
+    # last_run_at silently reset to the snapshot value — making the next
+    # tick think it's "never run" and clear logs a second time inside the
+    # same 7-day window. Mirrors the conditional-UPDATE pattern in
+    # log_housekeeping_scheduler._try_update_last_run.
     try:
         client = get_supabase()
-        resp = (
+        config = _read_housekeeping()
+        prev_last_run = config.get("last_run_at")
+        new_value = {**config, "weekly_clear_enabled": enabled}
+        update_q = (
             client.table("app_settings")
             .update({"log_housekeeping": new_value})
             .eq("id", True)
-            .execute()
         )
+        if prev_last_run is None:
+            update_q = update_q.is_("log_housekeeping->>last_run_at", "null")
+        else:
+            update_q = update_q.eq("log_housekeeping->>last_run_at", prev_last_run)
+        resp = update_q.execute()
     except Exception as exc:
         logger.exception("Failed to update app_settings.log_housekeeping")
         return jsonify({"success": False, "error": str(exc)}), 500
     if not resp.data:
-        return jsonify({"success": False, "error": "no app_settings row"}), 500
+        # Scheduler tick won the race. Re-read so the caller sees the
+        # current state and can retry the toggle if it still doesn't match.
+        latest = _read_housekeeping()
+        return jsonify(
+            {
+                "success": False,
+                "error": (
+                    "Configuration changed concurrently — please reload "
+                    "and try again."
+                ),
+                "weekly_clear_enabled": bool(latest.get("weekly_clear_enabled", True)),
+                "last_run_at": latest.get("last_run_at"),
+            }
+        ), 409
     initiator = getattr(g, "user_id", None) or "admin"
     logger.info(
         "Weekly log auto-clear toggled %s by %s",

--- a/backend/app/services/background_services/log_housekeeping_scheduler.py
+++ b/backend/app/services/background_services/log_housekeeping_scheduler.py
@@ -1,0 +1,183 @@
+"""
+Log Housekeeping Scheduler — clears backend log files once a week.
+
+Design:
+- One daemon thread per process (matches `InsightScheduler`). The
+  single-gunicorn-worker assumption holds: no cross-process coordination
+  needed.
+- Tick every 1 hour. Each tick reads `app_settings.log_housekeeping`:
+    - If `weekly_clear_enabled = false` → no-op.
+    - If `last_run_at` is null or older than 7 days → call
+      `log_service.clear_logs("scheduler")` and bump `last_run_at`.
+- Conditional UPDATE on `last_run_at` makes two racing ticks (which
+  shouldn't happen with a single worker but might during a redeploy
+  overlap) cheaply idempotent: the second update affects 0 rows and we
+  skip the clear.
+- Daemon thread dies with the worker. Tick failures are swallowed +
+  logged so a transient Supabase blip can't take the app down.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from app.services.integrations.supabase import get_supabase, is_supabase_enabled
+from app.services.log_service import clear_logs
+
+logger = logging.getLogger(__name__)
+
+
+# Hourly tick is plenty for a weekly cadence. Override via env for tests.
+TICK_INTERVAL_SECONDS = int(os.getenv("LOG_HOUSEKEEPING_TICK_SECONDS", "3600"))
+WEEKLY_INTERVAL = timedelta(days=7)
+STARTUP_DELAY_SECONDS = 60
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        # Accept both `...Z` and `+00:00` forms.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _read_housekeeping_row() -> Optional[Dict[str, Any]]:
+    """Return the single `app_settings` row's log_housekeeping JSONB, or None."""
+    if not is_supabase_enabled():
+        return None
+    try:
+        client = get_supabase()
+        resp = (
+            client.table("app_settings")
+            .select("log_housekeeping")
+            .eq("id", True)
+            .limit(1)
+            .execute()
+        )
+    except Exception as exc:
+        logger.warning("log housekeeping: could not read app_settings: %s", exc)
+        return None
+    rows = resp.data or []
+    if not rows:
+        return None
+    return rows[0].get("log_housekeeping") or {}
+
+
+def _try_update_last_run(previous_last_run: Optional[str], new_value: str) -> bool:
+    """
+    Bump `last_run_at` only if it still matches what we read at the top of
+    the tick. Returns True if our row was the one we updated (we own this
+    clear), False otherwise (another tick beat us to it).
+    """
+    if not is_supabase_enabled():
+        return False
+    try:
+        client = get_supabase()
+        # Use jsonb_set so we don't have to round-trip the whole JSONB blob
+        # and risk clobbering a concurrent admin write to weekly_clear_enabled.
+        # Conditional WHERE on the previous last_run_at is what gives us the
+        # idempotent "first writer wins" semantic.
+        query = client.table("app_settings").update(
+            {
+                "log_housekeeping": {
+                    "weekly_clear_enabled": True,
+                    "last_run_at": new_value,
+                }
+            }
+        ).eq("id", True)
+        if previous_last_run is None:
+            query = query.is_("log_housekeeping->>last_run_at", "null")
+        else:
+            query = query.eq("log_housekeeping->>last_run_at", previous_last_run)
+        resp = query.execute()
+        return bool(resp.data)
+    except Exception as exc:
+        logger.warning("log housekeeping: could not update last_run_at: %s", exc)
+        return False
+
+
+def _merge_full_row(weekly_enabled: bool, last_run_at: Optional[str]) -> Dict[str, Any]:
+    """Helper kept for tests — full-row update payload preserving toggle state."""
+    return {
+        "weekly_clear_enabled": weekly_enabled,
+        "last_run_at": last_run_at,
+    }
+
+
+class LogHousekeepingScheduler:
+    def __init__(self) -> None:
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._started = False
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        self._thread = threading.Thread(
+            target=self._run,
+            name="log-housekeeping",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "Log housekeeping scheduler started (tick=%ss, weekly clear)",
+            TICK_INTERVAL_SECONDS,
+        )
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _run(self) -> None:
+        if self._stop.wait(STARTUP_DELAY_SECONDS):
+            return
+        while not self._stop.is_set():
+            try:
+                self.tick()
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Log housekeeping tick failed: %s", exc)
+            if self._stop.wait(TICK_INTERVAL_SECONDS):
+                break
+
+    def tick(self) -> Dict[str, Any]:
+        """
+        One scheduler iteration. Public so tests (and an /admin trigger
+        endpoint, if we ever add one) can call it directly. Returns a
+        small status dict.
+        """
+        config = _read_housekeeping_row()
+        if config is None:
+            return {"ran": False, "reason": "no app_settings row"}
+        if not config.get("weekly_clear_enabled", True):
+            return {"ran": False, "reason": "weekly_clear_enabled=false"}
+
+        last_run_raw = config.get("last_run_at")
+        last_run = _parse_iso(last_run_raw)
+        now = _now_utc()
+        if last_run is not None and now - last_run < WEEKLY_INTERVAL:
+            return {"ran": False, "reason": "not yet due", "last_run_at": last_run_raw}
+
+        new_value = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if not _try_update_last_run(last_run_raw, new_value):
+            # Another tick (or admin) bumped it first. Skip the clear so
+            # we don't double-wipe.
+            return {"ran": False, "reason": "lost race"}
+
+        result = clear_logs(initiator="scheduler")
+        return {
+            "ran": True,
+            "cleared": result.get("cleared", 0),
+            "last_run_at": new_value,
+        }
+
+
+log_housekeeping_scheduler = LogHousekeepingScheduler()

--- a/backend/app/services/background_services/log_housekeeping_scheduler.py
+++ b/backend/app/services/background_services/log_housekeeping_scheduler.py
@@ -72,24 +72,32 @@ def _read_housekeeping_row() -> Optional[Dict[str, Any]]:
     return rows[0].get("log_housekeeping") or {}
 
 
-def _try_update_last_run(previous_last_run: Optional[str], new_value: str) -> bool:
+def _try_update_last_run(
+    previous_last_run: Optional[str],
+    new_value: str,
+    weekly_enabled: bool,
+) -> bool:
     """
     Bump `last_run_at` only if it still matches what we read at the top of
     the tick. Returns True if our row was the one we updated (we own this
     clear), False otherwise (another tick beat us to it).
+
+    `weekly_enabled` is the value we observed at the top of the tick. We
+    write it back verbatim AND gate the UPDATE on the same value so a
+    concurrent admin "disable" between our read and our write wins the
+    race — our update affects 0 rows and the scheduler skips the clear,
+    preserving the admin's intent. The earlier implementation hardcoded
+    `weekly_clear_enabled=True` here, which silently re-enabled the
+    toggle whenever the admin flipped it off mid-tick.
     """
     if not is_supabase_enabled():
         return False
     try:
         client = get_supabase()
-        # Use jsonb_set so we don't have to round-trip the whole JSONB blob
-        # and risk clobbering a concurrent admin write to weekly_clear_enabled.
-        # Conditional WHERE on the previous last_run_at is what gives us the
-        # idempotent "first writer wins" semantic.
         query = client.table("app_settings").update(
             {
                 "log_housekeeping": {
-                    "weekly_clear_enabled": True,
+                    "weekly_clear_enabled": weekly_enabled,
                     "last_run_at": new_value,
                 }
             }
@@ -98,6 +106,10 @@ def _try_update_last_run(previous_last_run: Optional[str], new_value: str) -> bo
             query = query.is_("log_housekeeping->>last_run_at", "null")
         else:
             query = query.eq("log_housekeeping->>last_run_at", previous_last_run)
+        query = query.eq(
+            "log_housekeeping->>weekly_clear_enabled",
+            "true" if weekly_enabled else "false",
+        )
         resp = query.execute()
         return bool(resp.data)
     except Exception as exc:
@@ -157,7 +169,8 @@ class LogHousekeepingScheduler:
         config = _read_housekeeping_row()
         if config is None:
             return {"ran": False, "reason": "no app_settings row"}
-        if not config.get("weekly_clear_enabled", True):
+        weekly_enabled = bool(config.get("weekly_clear_enabled", True))
+        if not weekly_enabled:
             return {"ran": False, "reason": "weekly_clear_enabled=false"}
 
         last_run_raw = config.get("last_run_at")
@@ -167,7 +180,10 @@ class LogHousekeepingScheduler:
             return {"ran": False, "reason": "not yet due", "last_run_at": last_run_raw}
 
         new_value = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-        if not _try_update_last_run(last_run_raw, new_value):
+        # Pass the observed weekly_enabled through so the UPDATE
+        # preserves it and the conditional WHERE picks up any admin
+        # disable that landed between our read and our write.
+        if not _try_update_last_run(last_run_raw, new_value, weekly_enabled):
             # Another tick (or admin) bumped it first. Skip the clear so
             # we don't double-wipe.
             return {"ran": False, "reason": "lost race"}

--- a/backend/app/services/data_services/user_service.py
+++ b/backend/app/services/data_services/user_service.py
@@ -202,6 +202,22 @@ class UserService:
         )
         return bool(resp.data)
 
+    def set_settings_key(self, user_id: str, key: str, value: Any) -> bool:
+        """
+        Read-modify-write a single key inside users.settings JSONB.
+
+        Educational Note: `users.settings` holds several unrelated knobs —
+        spending config, this log-download preference, anything we add
+        later. Callers updating just one key must merge, never replace,
+        or they'd clobber the other admins' spending limit settings.
+        """
+        current = self.get_user_settings_raw(user_id) or {}
+        if current.get(key) == value:
+            # No-op write — avoids burning a row update for an idempotent toggle.
+            return True
+        current[key] = value
+        return self.save_user_settings(user_id, current)
+
     def maybe_reset_expired_spending_period(
         self,
         user_id: str,

--- a/backend/app/services/log_service.py
+++ b/backend/app/services/log_service.py
@@ -1,0 +1,50 @@
+"""
+Log service — operations on the rotating backend log file.
+
+Educational Note: Both the HTTP `POST /logs/clear` route and the weekly
+housekeeping scheduler call into this module so the truncate-and-archive-
+delete semantics live in exactly one place. Audit-log emission also lives
+here so every clear is traceable regardless of which call site triggered it.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from app.utils import logger as logger_module
+
+logger = logging.getLogger(__name__)
+
+
+def clear_logs(initiator: str = "unknown") -> Dict[str, Any]:
+    """
+    Truncate the active log file and remove rotated archives.
+
+    Returns a dict with `success`, `cleared` (file count), and optionally
+    a `message` (for the "no log file present" no-op path).
+
+    `initiator` shows up in the audit log entry — pass the requesting
+    user id, "scheduler", "admin:<email>", etc. so a future log review
+    can attribute the wipe.
+    """
+    log_file = logger_module.LOG_FILE
+    if log_file is None or not log_file.parent.exists():
+        return {"success": True, "cleared": 0, "message": "no log file"}
+
+    cleared = 0
+    try:
+        if log_file.exists():
+            log_file.write_text("", encoding="utf-8")
+            cleared += 1
+        for archive in log_file.parent.glob(f"{log_file.name}.*"):
+            try:
+                archive.unlink()
+                cleared += 1
+            except OSError as exc:
+                logger.warning("Could not delete archive %s: %s", archive, exc)
+    except Exception as exc:
+        logger.exception("Failed to clear logs")
+        return {"success": False, "error": str(exc)}
+
+    logger.info("Log files cleared by %s (%d files)", initiator, cleared)
+    return {"success": True, "cleared": cleared}

--- a/backend/supabase/migrations/00043_log_housekeeping_settings.sql
+++ b/backend/supabase/migrations/00043_log_housekeeping_settings.sql
@@ -1,0 +1,19 @@
+-- Global app-settings row for the log housekeeping scheduler.
+--
+-- Single-row table guarded by a CHECK on a boolean PK so we never end up
+-- with multiple rows competing for "the global config." The scheduler
+-- reads this every tick; the admin toggle in Settings → Logs writes to it.
+
+CREATE TABLE IF NOT EXISTS app_settings (
+  id BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id = TRUE),
+  log_housekeeping JSONB NOT NULL
+    DEFAULT '{"weekly_clear_enabled": true, "last_run_at": null}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO app_settings (id) VALUES (TRUE) ON CONFLICT DO NOTHING;
+
+COMMENT ON TABLE app_settings IS
+  'Single-row global app settings. Currently holds log housekeeping flags '
+  '(weekly_clear_enabled, last_run_at). Add new JSONB columns here for '
+  'future global toggles.';

--- a/backend/tests/test_log_housekeeping.py
+++ b/backend/tests/test_log_housekeeping.py
@@ -1,0 +1,229 @@
+"""
+Tests for the log download / housekeeping feature:
+- user_service.set_settings_key merges into the existing settings JSONB.
+- log_service.clear_logs truncates the active file and removes archives.
+- LogHousekeepingScheduler.tick is idempotent within the 7-day window and
+  respects the weekly_clear_enabled flag.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Importing the user_service module pulls in supabase auth; provide
+# safe placeholders before app imports (mirrors test_notion_source.py).
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault(
+    "SUPABASE_SERVICE_KEY",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoidGVzdCJ9.test",
+)
+
+import importlib
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# user_service.set_settings_key
+# ---------------------------------------------------------------------------
+
+
+def test_set_settings_key_merges_preserving_other_keys(monkeypatch):
+    user_module = importlib.import_module(
+        "app.services.data_services.user_service"
+    )
+
+    svc = user_module.UserService.__new__(user_module.UserService)
+    svc.table = "users"
+    svc.supabase = MagicMock()
+
+    # Existing settings already hold a spending-config field; we must NOT lose it.
+    monkeypatch.setattr(
+        svc,
+        "get_user_settings_raw",
+        lambda user_id: {"cost_limit": 25.0, "reset_frequency": "weekly"},
+    )
+
+    captured = {}
+
+    def fake_save(user_id, settings):
+        captured["user_id"] = user_id
+        captured["settings"] = settings
+        return True
+
+    monkeypatch.setattr(svc, "save_user_settings", fake_save)
+
+    ok = svc.set_settings_key("u1", "auto_delete_logs_on_download", True)
+    assert ok is True
+    assert captured["user_id"] == "u1"
+    assert captured["settings"] == {
+        "cost_limit": 25.0,
+        "reset_frequency": "weekly",
+        "auto_delete_logs_on_download": True,
+    }
+
+
+def test_set_settings_key_noop_when_unchanged(monkeypatch):
+    user_module = importlib.import_module(
+        "app.services.data_services.user_service"
+    )
+    svc = user_module.UserService.__new__(user_module.UserService)
+    svc.table = "users"
+    svc.supabase = MagicMock()
+
+    monkeypatch.setattr(
+        svc,
+        "get_user_settings_raw",
+        lambda user_id: {"auto_delete_logs_on_download": True},
+    )
+    # save_user_settings must not be called for an idempotent toggle.
+    called = {"n": 0}
+
+    def fake_save(user_id, settings):
+        called["n"] += 1
+        return True
+
+    monkeypatch.setattr(svc, "save_user_settings", fake_save)
+
+    assert svc.set_settings_key("u1", "auto_delete_logs_on_download", True) is True
+    assert called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# log_service.clear_logs
+# ---------------------------------------------------------------------------
+
+
+def test_clear_logs_truncates_and_removes_archives(tmp_path, monkeypatch):
+    log_module = importlib.import_module("app.utils.logger")
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    active = log_dir / "backend.log"
+    active.write_text("hello world", encoding="utf-8")
+    (log_dir / "backend.log.1").write_text("archive1", encoding="utf-8")
+    (log_dir / "backend.log.2").write_text("archive2", encoding="utf-8")
+
+    monkeypatch.setattr(log_module, "LOG_DIR", log_dir)
+    monkeypatch.setattr(log_module, "LOG_FILE", active)
+
+    log_service = importlib.import_module("app.services.log_service")
+    result = log_service.clear_logs(initiator="pytest")
+    assert result["success"] is True
+    assert result["cleared"] == 3
+    assert active.read_text() == ""
+    assert not (log_dir / "backend.log.1").exists()
+    assert not (log_dir / "backend.log.2").exists()
+
+
+def test_clear_logs_handles_missing_log_file(monkeypatch):
+    log_module = importlib.import_module("app.utils.logger")
+    monkeypatch.setattr(log_module, "LOG_FILE", None)
+    log_service = importlib.import_module("app.services.log_service")
+    result = log_service.clear_logs(initiator="pytest")
+    assert result == {"success": True, "cleared": 0, "message": "no log file"}
+
+
+# ---------------------------------------------------------------------------
+# LogHousekeepingScheduler.tick
+# ---------------------------------------------------------------------------
+
+
+def _import_scheduler():
+    return importlib.import_module(
+        "app.services.background_services.log_housekeeping_scheduler"
+    )
+
+
+def test_tick_no_op_when_weekly_disabled(monkeypatch):
+    sched = _import_scheduler()
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": False, "last_run_at": None},
+    )
+    cleared = {"called": False}
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: cleared.update(called=True) or {"success": True})
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is False
+    assert result["reason"] == "weekly_clear_enabled=false"
+    assert cleared["called"] is False
+
+
+def test_tick_runs_when_never_run_before(monkeypatch):
+    sched = _import_scheduler()
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": None},
+    )
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: True)
+    called = {"n": 0}
+
+    def fake_clear(initiator="?"):
+        called["n"] += 1
+        return {"success": True, "cleared": 4}
+
+    monkeypatch.setattr(sched, "clear_logs", fake_clear)
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is True
+    assert result["cleared"] == 4
+    assert called["n"] == 1
+
+
+def test_tick_idempotent_within_week(monkeypatch):
+    sched = _import_scheduler()
+    recent = (datetime.now(timezone.utc) - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": recent},
+    )
+    called = {"n": 0}
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True})
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is False
+    assert result["reason"] == "not yet due"
+    assert called["n"] == 0
+
+
+def test_tick_runs_when_older_than_seven_days(monkeypatch):
+    sched = _import_scheduler()
+    stale = (datetime.now(timezone.utc) - timedelta(days=8)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": stale},
+    )
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: True)
+    called = {"n": 0}
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True, "cleared": 2})
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is True
+    assert called["n"] == 1
+
+
+def test_tick_skips_when_update_race_lost(monkeypatch):
+    """If another worker bumps last_run_at between read and write, we must
+    not double-clear."""
+    sched = _import_scheduler()
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": None},
+    )
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: False)
+    called = {"n": 0}
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True})
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is False
+    assert result["reason"] == "lost race"
+    assert called["n"] == 0
+
+
+def test_tick_returns_no_config_when_row_missing(monkeypatch):
+    sched = _import_scheduler()
+    monkeypatch.setattr(sched, "_read_housekeeping_row", lambda: None)
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result == {"ran": False, "reason": "no app_settings row"}

--- a/backend/tests/test_log_housekeeping.py
+++ b/backend/tests/test_log_housekeeping.py
@@ -157,7 +157,7 @@ def test_tick_runs_when_never_run_before(monkeypatch):
         sched, "_read_housekeeping_row",
         lambda: {"weekly_clear_enabled": True, "last_run_at": None},
     )
-    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: True)
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new, enabled: True)
     called = {"n": 0}
 
     def fake_clear(initiator="?"):
@@ -195,7 +195,7 @@ def test_tick_runs_when_older_than_seven_days(monkeypatch):
         sched, "_read_housekeeping_row",
         lambda: {"weekly_clear_enabled": True, "last_run_at": stale},
     )
-    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: True)
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new, enabled: True)
     called = {"n": 0}
     monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True, "cleared": 2})
 
@@ -212,7 +212,7 @@ def test_tick_skips_when_update_race_lost(monkeypatch):
         sched, "_read_housekeeping_row",
         lambda: {"weekly_clear_enabled": True, "last_run_at": None},
     )
-    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: False)
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new, enabled: False)
     called = {"n": 0}
     monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True})
 
@@ -220,6 +220,31 @@ def test_tick_skips_when_update_race_lost(monkeypatch):
     assert result["ran"] is False
     assert result["reason"] == "lost race"
     assert called["n"] == 0
+
+
+def test_tick_passes_observed_enabled_to_update(monkeypatch):
+    """Regression: the UPDATE used to hardcode weekly_clear_enabled=True,
+    silently re-enabling the toggle if an admin disabled it between read
+    and write. tick() must thread the observed value through."""
+    sched = _import_scheduler()
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": None},
+    )
+    captured = {}
+
+    def fake_update(prev, new, enabled):
+        captured["prev"] = prev
+        captured["new"] = new
+        captured["enabled"] = enabled
+        return True
+
+    monkeypatch.setattr(sched, "_try_update_last_run", fake_update)
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: {"success": True, "cleared": 0})
+
+    sched.LogHousekeepingScheduler().tick()
+    assert captured["enabled"] is True
+    assert captured["prev"] is None
 
 
 def test_tick_returns_no_config_when_row_missing(monkeypatch):

--- a/frontend/src/components/project/DownloadLogsConfirmDialog.tsx
+++ b/frontend/src/components/project/DownloadLogsConfirmDialog.tsx
@@ -1,0 +1,78 @@
+/**
+ * DownloadLogsConfirmDialog — confirmation dialog shown before the
+ * support-bundle download starts.
+ *
+ * The dialog has one extra control beyond Cancel/Download: a checkbox
+ * labelled "Delete logs from server after download". `useLogsState`
+ * owns the checkbox value (so it can be remembered across opens via
+ * users.settings.auto_delete_on_download) and triggers the clear after
+ * the download has begun.
+ */
+import React from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog';
+import { Checkbox } from '../ui/checkbox';
+import { Download } from '@phosphor-icons/react';
+
+interface DownloadLogsConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  deleteAfterDownload: boolean;
+  onDeleteAfterDownloadChange: (next: boolean) => void;
+  onConfirm: () => void;
+}
+
+export const DownloadLogsConfirmDialog: React.FC<DownloadLogsConfirmDialogProps> = ({
+  open,
+  onOpenChange,
+  deleteAfterDownload,
+  onDeleteAfterDownloadChange,
+  onConfirm,
+}) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Download log bundle</AlertDialogTitle>
+          <AlertDialogDescription>
+            The ZIP includes the rotating <code>backend.log</code> files
+            (secrets redacted), the list of configured env-var names,
+            applied migrations, and basic deployment metadata.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <label className="flex items-start gap-3 rounded-md border border-stone-200 bg-stone-50 px-3 py-3 cursor-pointer">
+          <Checkbox
+            checked={deleteAfterDownload}
+            onCheckedChange={(value) => onDeleteAfterDownloadChange(value === true)}
+            className="mt-0.5"
+          />
+          <span className="text-sm leading-snug text-stone-700">
+            <span className="font-medium text-stone-900 block">
+              Delete logs from server after download
+            </span>
+            Frees disk space on the deployment. The bundle in your downloads
+            folder is your only copy after this. Your choice is remembered
+            for next time.
+          </span>
+        </label>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            <Download size={16} className="mr-2" />
+            Download
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/frontend/src/components/project/DownloadLogsConfirmDialog.tsx
+++ b/frontend/src/components/project/DownloadLogsConfirmDialog.tsx
@@ -28,6 +28,10 @@ interface DownloadLogsConfirmDialogProps {
   deleteAfterDownload: boolean;
   onDeleteAfterDownloadChange: (next: boolean) => void;
   onConfirm: () => void;
+  /** When false, the "delete after download" checkbox is hidden. The
+   * `/logs/clear` endpoint is admin-only, so non-admins should never
+   * see (and certainly never check) this destructive option. */
+  canDelete?: boolean;
 }
 
 export const DownloadLogsConfirmDialog: React.FC<DownloadLogsConfirmDialogProps> = ({
@@ -36,6 +40,7 @@ export const DownloadLogsConfirmDialog: React.FC<DownloadLogsConfirmDialogProps>
   deleteAfterDownload,
   onDeleteAfterDownloadChange,
   onConfirm,
+  canDelete = true,
 }) => {
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -49,21 +54,23 @@ export const DownloadLogsConfirmDialog: React.FC<DownloadLogsConfirmDialogProps>
           </AlertDialogDescription>
         </AlertDialogHeader>
 
-        <label className="flex items-start gap-3 rounded-md border border-stone-200 bg-stone-50 px-3 py-3 cursor-pointer">
-          <Checkbox
-            checked={deleteAfterDownload}
-            onCheckedChange={(value) => onDeleteAfterDownloadChange(value === true)}
-            className="mt-0.5"
-          />
-          <span className="text-sm leading-snug text-stone-700">
-            <span className="font-medium text-stone-900 block">
-              Delete logs from server after download
+        {canDelete && (
+          <label className="flex items-start gap-3 rounded-md border border-stone-200 bg-stone-50 px-3 py-3 cursor-pointer">
+            <Checkbox
+              checked={deleteAfterDownload}
+              onCheckedChange={(value) => onDeleteAfterDownloadChange(value === true)}
+              className="mt-0.5"
+            />
+            <span className="text-sm leading-snug text-stone-700">
+              <span className="font-medium text-stone-900 block">
+                Delete logs from server after download
+              </span>
+              Frees disk space on the deployment. The bundle in your downloads
+              folder is your only copy after this. Your choice is remembered
+              for next time.
             </span>
-            Frees disk space on the deployment. The bundle in your downloads
-            folder is your only copy after this. Your choice is remembered
-            for next time.
-          </span>
-        </label>
+          </label>
+        )}
 
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>

--- a/frontend/src/components/project/LogsModal.tsx
+++ b/frontend/src/components/project/LogsModal.tsx
@@ -81,6 +81,7 @@ export const LogsModal: React.FC<LogsModalProps> = ({ open, onOpenChange, canCle
           deleteAfterDownload={state.deleteAfterDownload}
           onDeleteAfterDownloadChange={state.setDeleteAfterDownload}
           onConfirm={state.confirmDownload}
+          canDelete={state.canDeleteLogs}
         />
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/project/LogsModal.tsx
+++ b/frontend/src/components/project/LogsModal.tsx
@@ -26,6 +26,7 @@ import { Bug } from '@phosphor-icons/react';
 import { ToastContainer } from '../ui/toast';
 import { LogConsole } from './LogConsole';
 import { useLogsState } from './useLogsState';
+import { DownloadLogsConfirmDialog } from './DownloadLogsConfirmDialog';
 
 interface LogsModalProps {
   open: boolean;
@@ -73,6 +74,14 @@ export const LogsModal: React.FC<LogsModalProps> = ({ open, onOpenChange, canCle
         </div>
 
         <ToastContainer toasts={state.toasts} onDismiss={state.dismissToast} />
+
+        <DownloadLogsConfirmDialog
+          open={state.downloadDialogOpen}
+          onOpenChange={state.setDownloadDialogOpen}
+          deleteAfterDownload={state.deleteAfterDownload}
+          onDeleteAfterDownloadChange={state.setDeleteAfterDownload}
+          onConfirm={state.confirmDownload}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/project/useLogsState.ts
+++ b/frontend/src/components/project/useLogsState.ts
@@ -9,7 +9,7 @@
  * The two callers differ only in chrome (Dialog vs settings page
  * layout) — every interaction is delegated here.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { logsAPI, type LogLine } from '@/lib/api/logs';
 import { copyToClipboard } from '@/lib/clipboard';
 import { useToast } from '@/components/ui/use-toast';
@@ -38,6 +38,13 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
   const [logFilePresent, setLogFilePresent] = useState(true);
   const [confirmingClear, setConfirmingClear] = useState(false);
 
+  // Download-bundle confirmation dialog state. Lives in this hook (not
+  // in LogsModal/LogsSection) so both surfaces share the same flow.
+  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const [deleteAfterDownload, setDeleteAfterDownload] = useState(false);
+  // Snapshot of the persisted value so we only PUT when the user changed it.
+  const persistedDeleteAfterDownload = useRef<boolean>(false);
+
   const loadLines = useCallback(async () => {
     setLoading(true);
     try {
@@ -58,6 +65,28 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     loadLines();
   }, [active, loadLines]);
 
+  // Load the user's "auto-delete on download" preference once the
+  // surface activates so the checkbox is pre-set the first time the
+  // download dialog opens.
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const prefs = await logsAPI.getPreferences();
+        if (cancelled) return;
+        persistedDeleteAfterDownload.current = prefs.auto_delete_on_download;
+        setDeleteAfterDownload(prefs.auto_delete_on_download);
+      } catch (e) {
+        // Non-fatal — checkbox just stays unchecked.
+        log.warn({ err: e }, 'failed to load log preferences');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [active]);
+
   const formatLines = useMemo(
     () =>
       lines
@@ -76,14 +105,52 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     else error('Could not copy. Select the text manually.');
   }, [lines, formatLines, success, error]);
 
+  /**
+   * Open the download confirmation dialog instead of starting the
+   * download immediately. The actual download + (optional) clear runs in
+   * `confirmDownload` once the user clicks the dialog's Download button.
+   */
   const handleDownload = useCallback(() => {
-    // Browser download via anchor; getAuthUrl puts the JWT in the query
-    // string because <a download> can't set Authorization headers.
+    setDownloadDialogOpen(true);
+  }, []);
+
+  const confirmDownload = useCallback(async () => {
+    setDownloadDialogOpen(false);
+
+    // Start the browser download via anchor (JWT in the query string).
     const a = document.createElement('a');
     a.href = logsAPI.bundleUrl();
     a.rel = 'noopener';
     a.click();
-  }, []);
+
+    // Persist the checkbox state if it changed. Fire-and-forget — a
+    // preference write failure shouldn't block the bundle download.
+    if (deleteAfterDownload !== persistedDeleteAfterDownload.current) {
+      logsAPI
+        .setPreferences({ auto_delete_on_download: deleteAfterDownload })
+        .then(() => {
+          persistedDeleteAfterDownload.current = deleteAfterDownload;
+        })
+        .catch((e) => {
+          log.warn({ err: e }, 'failed to persist log preference');
+        });
+    }
+
+    // If the user opted in, wait briefly so the browser has time to
+    // begin streaming the ZIP, then clear the server-side logs.
+    if (deleteAfterDownload) {
+      window.setTimeout(async () => {
+        try {
+          await logsAPI.clear();
+          success('Logs cleared from server');
+          await loadLines();
+        } catch (e) {
+          log.error({ err: e }, 'failed to clear logs after download');
+          error('Could not clear logs after download');
+        }
+      }, 1500);
+    }
+  }, [deleteAfterDownload, loadLines, success, error]);
 
   const handleClear = useCallback(async () => {
     if (!confirmingClear) {
@@ -117,6 +184,12 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     handleCopy,
     handleDownload,
     handleClear,
+    // Download confirmation dialog state.
+    downloadDialogOpen,
+    setDownloadDialogOpen,
+    deleteAfterDownload,
+    setDeleteAfterDownload,
+    confirmDownload,
     // Toast plumbing — the consumer mounts <ToastContainer /> with these.
     toasts,
     dismissToast,

--- a/frontend/src/components/project/useLogsState.ts
+++ b/frontend/src/components/project/useLogsState.ts
@@ -14,6 +14,7 @@ import { logsAPI, type LogLine } from '@/lib/api/logs';
 import { copyToClipboard } from '@/lib/clipboard';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { getAdminMode } from '@/lib/adminMode';
 
 const log = createLogger('logs-state');
 
@@ -31,6 +32,11 @@ interface UseLogsStateOpts {
 }
 
 export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
+  // /logs/clear is admin-only on the backend (a non-admin's POST would
+  // 403). Surface the same gate to the UI so the "Delete logs after
+  // download" checkbox only renders for admins — non-admins still see
+  // the confirmation dialog but without the destructive option.
+  const canDeleteLogs = getAdminMode();
   const { toasts, dismissToast, success, error } = useToast();
   const [lines, setLines] = useState<LogLine[]>([]);
   const [filter, setFilter] = useState<LevelFilter>('errors');
@@ -67,9 +73,10 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
 
   // Load the user's "auto-delete on download" preference once the
   // surface activates so the checkbox is pre-set the first time the
-  // download dialog opens.
+  // download dialog opens. Skipped for non-admins: they can't delete
+  // logs so the preference would be inert and the GET is wasted work.
   useEffect(() => {
-    if (!active) return;
+    if (!active || !canDeleteLogs) return;
     let cancelled = false;
     (async () => {
       try {
@@ -85,7 +92,7 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     return () => {
       cancelled = true;
     };
-  }, [active]);
+  }, [active, canDeleteLogs]);
 
   const formatLines = useMemo(
     () =>
@@ -125,7 +132,9 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
 
     // Persist the checkbox state if it changed. Fire-and-forget — a
     // preference write failure shouldn't block the bundle download.
-    if (deleteAfterDownload !== persistedDeleteAfterDownload.current) {
+    // Skipped for non-admins since they can't act on the preference
+    // anyway (and the backend write succeeds but is then unused).
+    if (canDeleteLogs && deleteAfterDownload !== persistedDeleteAfterDownload.current) {
       logsAPI
         .setPreferences({ auto_delete_on_download: deleteAfterDownload })
         .then(() => {
@@ -137,8 +146,10 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     }
 
     // If the user opted in, wait briefly so the browser has time to
-    // begin streaming the ZIP, then clear the server-side logs.
-    if (deleteAfterDownload) {
+    // begin streaming the ZIP, then clear the server-side logs. The
+    // canDeleteLogs guard is defense-in-depth — the checkbox is hidden
+    // for non-admins so deleteAfterDownload should already be false.
+    if (canDeleteLogs && deleteAfterDownload) {
       window.setTimeout(async () => {
         try {
           await logsAPI.clear();
@@ -190,6 +201,7 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     deleteAfterDownload,
     setDeleteAfterDownload,
     confirmDownload,
+    canDeleteLogs,
     // Toast plumbing — the consumer mounts <ToastContainer /> with these.
     toasts,
     dismissToast,

--- a/frontend/src/components/settings/sections/LogsSection.tsx
+++ b/frontend/src/components/settings/sections/LogsSection.tsx
@@ -123,6 +123,7 @@ export const LogsSection: React.FC = () => {
         deleteAfterDownload={state.deleteAfterDownload}
         onDeleteAfterDownloadChange={state.setDeleteAfterDownload}
         onConfirm={state.confirmDownload}
+        canDelete={state.canDeleteLogs}
       />
     </div>
   );

--- a/frontend/src/components/settings/sections/LogsSection.tsx
+++ b/frontend/src/components/settings/sections/LogsSection.tsx
@@ -19,6 +19,7 @@ import { logsAPI, type LogHousekeeping } from '@/lib/api/logs';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { getAdminMode } from '@/lib/adminMode';
 
 const log = createLogger('logs-section');
 
@@ -76,8 +77,11 @@ const LogHousekeepingCard: React.FC = () => {
           )}
         </div>
         <Switch
+          // PUT /logs/housekeeping is admin-only — disable for non-admins
+          // so they can still see the card's last-cleared timestamp without
+          // clicking into a confusing 403.
           checked={config?.weekly_clear_enabled ?? false}
-          disabled={!config || saving}
+          disabled={!config || saving || !getAdminMode()}
           onCheckedChange={handleToggle}
         />
       </div>

--- a/frontend/src/components/settings/sections/LogsSection.tsx
+++ b/frontend/src/components/settings/sections/LogsSection.tsx
@@ -7,11 +7,83 @@
  * what they're sharing.
  *
  * Behavior + content all come from `useLogsState` and `LogConsole` so
- * the modal and this section can never drift out of sync.
+ * the modal and this section can never drift out of sync. This file
+ * additionally hosts the admin-only "Auto-clear logs weekly" toggle
+ * since the housekeeping setting is global, not per-user.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { LogConsole } from '@/components/project/LogConsole';
 import { useLogsState } from '@/components/project/useLogsState';
+import { DownloadLogsConfirmDialog } from '@/components/project/DownloadLogsConfirmDialog';
+import { logsAPI, type LogHousekeeping } from '@/lib/api/logs';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('logs-section');
+
+const LogHousekeepingCard: React.FC = () => {
+  const { success, error } = useToast();
+  const [config, setConfig] = useState<LogHousekeeping | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await logsAPI.getHousekeeping();
+        if (!cancelled) setConfig(res);
+      } catch (e) {
+        log.warn({ err: e }, 'failed to load housekeeping config');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggle = async (next: boolean) => {
+    if (!config) return;
+    setSaving(true);
+    try {
+      const updated = await logsAPI.setHousekeeping({ weekly_clear_enabled: next });
+      setConfig(updated);
+      success(next ? 'Weekly log auto-clear enabled' : 'Weekly log auto-clear disabled');
+    } catch (e) {
+      log.error({ err: e }, 'failed to update housekeeping');
+      error('Could not update log housekeeping setting');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-stone-200 bg-white p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-medium text-stone-900">
+            Auto-clear logs weekly
+          </h3>
+          <p className="mt-1 text-xs text-stone-600 max-w-prose">
+            Truncates the rotating <code>backend.log</code> files and removes
+            archives once every 7 days so the deployment doesn&apos;t accrue
+            stale diagnostics indefinitely.
+          </p>
+          {config?.last_run_at && (
+            <p className="mt-2 text-xs text-stone-500">
+              Last cleared automatically: {new Date(config.last_run_at).toLocaleString()}
+            </p>
+          )}
+        </div>
+        <Switch
+          checked={config?.weekly_clear_enabled ?? false}
+          disabled={!config || saving}
+          onCheckedChange={handleToggle}
+        />
+      </div>
+    </div>
+  );
+};
 
 export const LogsSection: React.FC = () => {
   const state = useLogsState({ active: true });
@@ -28,6 +100,8 @@ export const LogsSection: React.FC = () => {
         </p>
       </header>
 
+      <LogHousekeepingCard />
+
       <LogConsole
         variant="page"
         panelMaxHeightClassName="max-h-[58vh]"
@@ -41,6 +115,14 @@ export const LogsSection: React.FC = () => {
         onCopy={state.handleCopy}
         onDownload={state.handleDownload}
         onClear={state.handleClear}
+      />
+
+      <DownloadLogsConfirmDialog
+        open={state.downloadDialogOpen}
+        onOpenChange={state.setDownloadDialogOpen}
+        deleteAfterDownload={state.deleteAfterDownload}
+        onDeleteAfterDownloadChange={state.setDeleteAfterDownload}
+        onConfirm={state.confirmDownload}
       />
     </div>
   );

--- a/frontend/src/lib/api/logs.ts
+++ b/frontend/src/lib/api/logs.ts
@@ -28,6 +28,15 @@ export interface ClientErrorPayload {
   timestamp?: string;
 }
 
+export interface LogPreferences {
+  auto_delete_on_download: boolean;
+}
+
+export interface LogHousekeeping {
+  weekly_clear_enabled: boolean;
+  last_run_at: string | null;
+}
+
 export const logsAPI = {
   async getRecent(n = 100, level: 'errors' | 'warnings' | 'all' = 'errors') {
     const res = await api.get<RecentLogsResponse>('/logs/recent', {
@@ -45,6 +54,34 @@ export const logsAPI = {
   async clear() {
     const res = await api.post<{ success: boolean; cleared: number }>('/logs/clear');
     return res.data;
+  },
+
+  /** Per-user "auto-delete logs after download" preference. */
+  async getPreferences(): Promise<LogPreferences> {
+    const res = await api.get<{ success: boolean } & LogPreferences>('/logs/preferences');
+    return { auto_delete_on_download: !!res.data.auto_delete_on_download };
+  },
+
+  async setPreferences(prefs: LogPreferences): Promise<LogPreferences> {
+    const res = await api.put<{ success: boolean } & LogPreferences>('/logs/preferences', prefs);
+    return { auto_delete_on_download: !!res.data.auto_delete_on_download };
+  },
+
+  /** Global weekly auto-clear configuration (read is open; write is admin-only). */
+  async getHousekeeping(): Promise<LogHousekeeping> {
+    const res = await api.get<{ success: boolean } & LogHousekeeping>('/logs/housekeeping');
+    return {
+      weekly_clear_enabled: !!res.data.weekly_clear_enabled,
+      last_run_at: res.data.last_run_at ?? null,
+    };
+  },
+
+  async setHousekeeping(prefs: { weekly_clear_enabled: boolean }): Promise<LogHousekeeping> {
+    const res = await api.put<{ success: boolean } & LogHousekeeping>('/logs/housekeeping', prefs);
+    return {
+      weekly_clear_enabled: !!res.data.weekly_clear_enabled,
+      last_run_at: res.data.last_run_at ?? null,
+    };
   },
 
   /** Fire-and-forget client error report. We don't await the response in


### PR DESCRIPTION
## Summary
- **Delete after download dialog.** Clicking "Download bundle" now opens a confirmation dialog with a "Delete logs from server after download" checkbox. The choice is remembered per user in `users.settings.auto_delete_logs_on_download` so it's pre-checked next time. Lives in both `LogsModal` and Settings → Logs via `useLogsState`.
- **Weekly auto-clear scheduler.** New `LogHousekeepingScheduler` daemon thread (hourly tick) clears the rotating `backend.log` files once every 7 days. Admin can flip it off from a new Settings → Logs card; the card also shows the last auto-clear timestamp.
- **Refactor + RBAC.** `/logs/clear` is loosened from `require_admin` to `require_auth` (matches `/logs/bundle` gating in this single-tenant deployment) and now delegates to a new `log_service.clear_logs()` so the HTTP route and the scheduler share one code path. Audit log records the initiator either way.
- **New tables / endpoints.** Migration `00043` adds a single-row `app_settings` table for the housekeeping flag + `last_run_at` watermark. New routes: `GET/PUT /logs/preferences` (per-user, auth-gated), `GET /logs/housekeeping` (auth) and `PUT /logs/housekeeping` (admin).
- **Tests.** 10 new pytest cases cover `set_settings_key` JSONB merge, `clear_logs` truncate+delete, and the scheduler's idempotency (within 7 days), race-loss skip, never-run path, and disabled-flag short-circuit.

## Test plan
- [x] `pytest tests/test_log_housekeeping.py` — 10/10 pass.
- [x] Full backend suite (324 tests) passes with supabase env stubs.
- [x] `npx tsc --noEmit` clean.
- [x] `eslint` clean on touched frontend files.
- [ ] **Manual**: with the migration applied:
  - User A opens Logs → Download → checks "Delete logs from server after download" → confirm. ZIP downloads, server-side `backend.log` is truncated to 0 bytes and archives are gone.
  - User A reopens dialog → checkbox is **pre-checked**.
  - User B opens dialog → preference is independent.
  - Settings → Logs → "Auto-clear logs weekly" toggle reflects the global flag, persists on flip, shows "Last cleared automatically" once the scheduler runs.
  - Override `LOG_HOUSEKEEPING_TICK_SECONDS=5` env var in dev, watch the tick run on the 7-day boundary (or set `last_run_at` to 8 days ago in the DB) — confirm it clears + bumps the watermark.