### PR TITLE
Sync develop → main: notion source + log housekeeping

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -136,6 +136,17 @@ def create_app(config_name='development'):
     except Exception as exc:
         app.logger.warning("Failed to start insight scheduler: %s", exc)
 
+    # Start the log housekeeping scheduler. Daemon thread; one tick every
+    # hour; clears the rotating log files once a week (admin can disable
+    # via Settings → Logs → "Auto-clear logs weekly").
+    try:
+        from app.services.background_services.log_housekeeping_scheduler import (
+            log_housekeeping_scheduler,
+        )
+        log_housekeeping_scheduler.start()
+    except Exception as exc:
+        app.logger.warning("Failed to start log housekeeping scheduler: %s", exc)
+
     # Log successful initialization
     app.logger.info(f"✅ {app.config['APP_NAME']} backend initialized successfully")
 

--- a/backend/app/api/logs/routes.py
+++ b/backend/app/api/logs/routes.py
@@ -127,17 +127,22 @@ def download_bundle():
 
 
 @logs_bp.route("/logs/clear", methods=["POST"])
-@require_auth
+@require_admin
 def clear_logs():
     """Truncate the active log file and remove rotated archives.
 
-    Gated `require_auth` (not `require_admin`) because the matching
-    `/logs/bundle` download is `require_auth` too — any user who can pull
-    the logs can also wipe them in this single-tenant deployment. The
-    audit log records who triggered the clear so a wipe is still
-    attributable.
+    Admin-only: read (`/logs/bundle`) and destroy are asymmetric — any
+    authenticated user can pull a copy of the logs, but only admins can
+    permanently wipe the server-side diagnostic history (which may be
+    the only evidence of a crash or security incident affecting other
+    users). The audit log records which admin triggered the clear.
+
+    Surfaced to non-admins in the UI via the "Delete logs from server
+    after download" checkbox — that path is gated by this same endpoint,
+    so the checkbox is a no-op for non-admins (frontend hides it; if
+    they bypass the UI, this returns 403).
     """
-    initiator = getattr(g, "user_id", None) or "user"
+    initiator = getattr(g, "user_id", None) or "admin"
     result = clear_logs_service(initiator=str(initiator))
     if not result.get("success"):
         return jsonify(result), 500

--- a/backend/app/api/logs/routes.py
+++ b/backend/app/api/logs/routes.py
@@ -17,6 +17,9 @@ from app.api.logs import logs_bp
 from app.api.logs.bundle import build_bundle
 from app.api.logs.redaction import redact_line
 from app.services.auth.rbac import require_admin, require_auth
+from app.services.data_services.user_service import get_user_service
+from app.services.integrations.supabase import get_supabase, is_supabase_enabled
+from app.services.log_service import clear_logs as clear_logs_service
 from app.utils import logger as logger_module
 
 logger = logging.getLogger(__name__)
@@ -124,34 +127,163 @@ def download_bundle():
 
 
 @logs_bp.route("/logs/clear", methods=["POST"])
-@require_admin
+@require_auth
 def clear_logs():
     """Truncate the active log file and remove rotated archives.
 
-    Useful when the admin wants a clean window before reproducing a bug
-    so the bundle they ship contains only the relevant noise.
+    Gated `require_auth` (not `require_admin`) because the matching
+    `/logs/bundle` download is `require_auth` too — any user who can pull
+    the logs can also wipe them in this single-tenant deployment. The
+    audit log records who triggered the clear so a wipe is still
+    attributable.
     """
-    log_file = logger_module.LOG_FILE
-    if log_file is None or not log_file.parent.exists():
-        return jsonify({"success": True, "cleared": 0, "message": "no log file"}), 200
+    initiator = getattr(g, "user_id", None) or "user"
+    result = clear_logs_service(initiator=str(initiator))
+    if not result.get("success"):
+        return jsonify(result), 500
+    return jsonify(result), 200
 
-    cleared = 0
+
+# ---------------------------------------------------------------------------
+# Per-user "auto-delete on download" preference
+# ---------------------------------------------------------------------------
+
+_AUTO_DELETE_SETTINGS_KEY = "auto_delete_logs_on_download"
+
+
+@logs_bp.route("/logs/preferences", methods=["GET"])
+@require_auth
+def get_log_preferences():
+    """Return the current user's log-related preferences.
+
+    Right now only `auto_delete_on_download` — drives the pre-check of the
+    "Delete logs from server after download" checkbox in the bundle dialog.
+    """
+    user_id = getattr(g, "user_id", None)
+    if not user_id:
+        return jsonify({"success": False, "error": "missing user"}), 401
+    if not is_supabase_enabled():
+        return jsonify({"success": True, "auto_delete_on_download": False}), 200
+    settings = get_user_service().get_user_settings_raw(user_id)
+    return jsonify(
+        {
+            "success": True,
+            "auto_delete_on_download": bool(settings.get(_AUTO_DELETE_SETTINGS_KEY, False)),
+        }
+    ), 200
+
+
+@logs_bp.route("/logs/preferences", methods=["PUT"])
+@require_auth
+def update_log_preferences():
+    """Persist the user's log-download preferences in users.settings."""
+    user_id = getattr(g, "user_id", None)
+    if not user_id:
+        return jsonify({"success": False, "error": "missing user"}), 401
+    payload = request.get_json(silent=True) or {}
+    if "auto_delete_on_download" not in payload:
+        return jsonify(
+            {"success": False, "error": "auto_delete_on_download is required"}
+        ), 400
+    value = bool(payload.get("auto_delete_on_download"))
+    if not is_supabase_enabled():
+        # Best-effort no-op in self-hosted setups without Supabase auth.
+        return jsonify({"success": True, "auto_delete_on_download": value}), 200
+    saved = get_user_service().set_settings_key(
+        user_id, _AUTO_DELETE_SETTINGS_KEY, value
+    )
+    if not saved:
+        return jsonify({"success": False, "error": "could not persist preference"}), 500
+    return jsonify({"success": True, "auto_delete_on_download": value}), 200
+
+
+# ---------------------------------------------------------------------------
+# Global "auto-clear logs weekly" admin toggle
+# ---------------------------------------------------------------------------
+
+_HOUSEKEEPING_DEFAULT = {"weekly_clear_enabled": True, "last_run_at": None}
+
+
+def _read_housekeeping() -> dict[str, Any]:
+    if not is_supabase_enabled():
+        return dict(_HOUSEKEEPING_DEFAULT)
     try:
-        if log_file.exists():
-            log_file.write_text("", encoding="utf-8")
-            cleared += 1
-        for archive in log_file.parent.glob(f"{log_file.name}.*"):
-            try:
-                archive.unlink()
-                cleared += 1
-            except OSError as exc:
-                logger.warning("Could not delete archive %s: %s", archive, exc)
+        client = get_supabase()
+        resp = (
+            client.table("app_settings")
+            .select("log_housekeeping")
+            .eq("id", True)
+            .limit(1)
+            .execute()
+        )
     except Exception as exc:
-        logger.exception("Failed to clear logs")
-        return jsonify({"success": False, "error": str(exc)}), 500
+        logger.warning("Could not read app_settings.log_housekeeping: %s", exc)
+        return dict(_HOUSEKEEPING_DEFAULT)
+    rows = resp.data or []
+    if not rows:
+        return dict(_HOUSEKEEPING_DEFAULT)
+    return {**_HOUSEKEEPING_DEFAULT, **(rows[0].get("log_housekeeping") or {})}
 
-    logger.info("Log files cleared by admin (%d files)", cleared)
-    return jsonify({"success": True, "cleared": cleared}), 200
+
+@logs_bp.route("/logs/housekeeping", methods=["GET"])
+@require_auth
+def get_log_housekeeping():
+    """Return the global weekly-clear configuration.
+
+    Read is open to any authenticated user so non-admin users can still
+    see *when* the next auto-clear is due before they download a bundle.
+    """
+    config = _read_housekeeping()
+    return jsonify(
+        {
+            "success": True,
+            "weekly_clear_enabled": bool(config.get("weekly_clear_enabled", True)),
+            "last_run_at": config.get("last_run_at"),
+        }
+    ), 200
+
+
+@logs_bp.route("/logs/housekeeping", methods=["PUT"])
+@require_admin
+def update_log_housekeeping():
+    """Admin-only toggle of the weekly auto-clear scheduler."""
+    if not is_supabase_enabled():
+        return jsonify({"success": False, "error": "supabase not configured"}), 503
+    payload = request.get_json(silent=True) or {}
+    if "weekly_clear_enabled" not in payload:
+        return jsonify(
+            {"success": False, "error": "weekly_clear_enabled is required"}
+        ), 400
+    enabled = bool(payload.get("weekly_clear_enabled"))
+
+    config = _read_housekeeping()
+    new_value = {**config, "weekly_clear_enabled": enabled}
+    try:
+        client = get_supabase()
+        resp = (
+            client.table("app_settings")
+            .update({"log_housekeeping": new_value})
+            .eq("id", True)
+            .execute()
+        )
+    except Exception as exc:
+        logger.exception("Failed to update app_settings.log_housekeeping")
+        return jsonify({"success": False, "error": str(exc)}), 500
+    if not resp.data:
+        return jsonify({"success": False, "error": "no app_settings row"}), 500
+    initiator = getattr(g, "user_id", None) or "admin"
+    logger.info(
+        "Weekly log auto-clear toggled %s by %s",
+        "ENABLED" if enabled else "DISABLED",
+        initiator,
+    )
+    return jsonify(
+        {
+            "success": True,
+            "weekly_clear_enabled": enabled,
+            "last_run_at": new_value.get("last_run_at"),
+        }
+    ), 200
 
 
 @logs_bp.route("/logs/client", methods=["POST"])

--- a/backend/app/api/logs/routes.py
+++ b/backend/app/api/logs/routes.py
@@ -261,21 +261,46 @@ def update_log_housekeeping():
         ), 400
     enabled = bool(payload.get("weekly_clear_enabled"))
 
-    config = _read_housekeeping()
-    new_value = {**config, "weekly_clear_enabled": enabled}
+    # Re-read inside the write path and conditionally update on the
+    # observed last_run_at. Without this gate, a scheduler tick that lands
+    # between our read and our write would have its freshly-written
+    # last_run_at silently reset to the snapshot value — making the next
+    # tick think it's "never run" and clear logs a second time inside the
+    # same 7-day window. Mirrors the conditional-UPDATE pattern in
+    # log_housekeeping_scheduler._try_update_last_run.
     try:
         client = get_supabase()
-        resp = (
+        config = _read_housekeeping()
+        prev_last_run = config.get("last_run_at")
+        new_value = {**config, "weekly_clear_enabled": enabled}
+        update_q = (
             client.table("app_settings")
             .update({"log_housekeeping": new_value})
             .eq("id", True)
-            .execute()
         )
+        if prev_last_run is None:
+            update_q = update_q.is_("log_housekeeping->>last_run_at", "null")
+        else:
+            update_q = update_q.eq("log_housekeeping->>last_run_at", prev_last_run)
+        resp = update_q.execute()
     except Exception as exc:
         logger.exception("Failed to update app_settings.log_housekeeping")
         return jsonify({"success": False, "error": str(exc)}), 500
     if not resp.data:
-        return jsonify({"success": False, "error": "no app_settings row"}), 500
+        # Scheduler tick won the race. Re-read so the caller sees the
+        # current state and can retry the toggle if it still doesn't match.
+        latest = _read_housekeeping()
+        return jsonify(
+            {
+                "success": False,
+                "error": (
+                    "Configuration changed concurrently — please reload "
+                    "and try again."
+                ),
+                "weekly_clear_enabled": bool(latest.get("weekly_clear_enabled", True)),
+                "last_run_at": latest.get("last_run_at"),
+            }
+        ), 409
     initiator = getattr(g, "user_id", None) or "admin"
     logger.info(
         "Weekly log auto-clear toggled %s by %s",

--- a/backend/app/api/sources/uploads.py
+++ b/backend/app/api/sources/uploads.py
@@ -590,3 +590,131 @@ def add_mcp_source(project_id: str):
     except Exception as e:
         current_app.logger.error(f"Error adding MCP source: {e}")
         return jsonify({'success': False, 'error': str(e)}), 500
+
+
+# ---------------------------------------------------------------------------
+# Notion: picker endpoints + source creation
+#
+# The picker endpoints (status, search) are project-agnostic — they just expose
+# the globally-configured Notion workspace so the frontend can let users browse
+# and pick a page/database. The actual source creation is per-project.
+# ---------------------------------------------------------------------------
+
+
+@sources_bp.route('/notion/status', methods=['GET'])
+@require_permission("integrations", "notion")
+def notion_status():
+    """Report whether the global Notion integration is configured."""
+    try:
+        from app.services.integrations.knowledge_bases.notion.notion_service import (
+            notion_service,
+        )
+        return jsonify({
+            'success': True,
+            'configured': notion_service.is_configured(),
+        }), 200
+    except Exception as e:
+        current_app.logger.error(f"Error checking Notion status: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@sources_bp.route('/notion/search', methods=['GET'])
+@require_permission("integrations", "notion")
+def notion_search():
+    """
+    Search the connected Notion workspace for pages and/or databases.
+
+    Query params:
+        q: Optional search query (Notion does substring/title matching)
+        type: Optional filter — 'page' or 'database' (default: both)
+        limit: Optional max results (default: 50, max: 100)
+    """
+    try:
+        from app.services.integrations.knowledge_bases.notion.notion_service import (
+            notion_service,
+        )
+
+        if not notion_service.is_configured():
+            return jsonify({
+                'success': False,
+                'error': 'Notion not configured. Add NOTION_API_KEY in Settings → API Keys.',
+                'configured': False,
+            }), 400
+
+        query = request.args.get('q', '').strip() or None
+        filter_type = request.args.get('type', '').strip().lower() or None
+        if filter_type and filter_type not in ('page', 'database'):
+            return jsonify({'success': False, 'error': "type must be 'page' or 'database'"}), 400
+        try:
+            limit = int(request.args.get('limit', '50'))
+        except ValueError:
+            limit = 50
+        limit = max(1, min(limit, 100))
+
+        result = notion_service.search(query=query, filter_type=filter_type, limit=limit)
+        if not result.get('success'):
+            return jsonify({'success': False, 'error': result.get('error', 'Notion search failed')}), 502
+
+        return jsonify({
+            'success': True,
+            'results': result.get('results', []),
+            'total': result.get('total', 0),
+        }), 200
+
+    except Exception as e:
+        current_app.logger.error(f"Error searching Notion: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@sources_bp.route('/projects/<project_id>/sources/notion', methods=['POST'])
+@require_permission("integrations", "notion")
+def add_notion_source_endpoint(project_id: str):
+    """
+    Add a Notion source (one page or one database) to a project.
+
+    Request Body:
+        {
+            "notion_id": "uuid",                # required
+            "object_type": "page" | "database", # required
+            "title": "Picked title",            # optional, from picker
+            "notion_url": "https://notion.so/…",# optional
+            "last_edited_time": "ISO ts",       # optional
+            "name": "Override display name",    # optional
+            "description": "..."                # optional
+        }
+    """
+    try:
+        data = request.get_json() or {}
+        notion_id = (data.get('notion_id') or '').strip()
+        object_type = (data.get('object_type') or '').strip().lower()
+
+        if not notion_id:
+            return jsonify({'success': False, 'error': 'notion_id is required'}), 400
+        if object_type not in ('page', 'database'):
+            return jsonify({
+                'success': False,
+                'error': "object_type must be 'page' or 'database'",
+            }), 400
+
+        source = source_service.add_notion_source(
+            project_id=project_id,
+            notion_id=notion_id,
+            object_type=object_type,
+            title=data.get('title'),
+            notion_url=data.get('notion_url'),
+            last_edited_time=data.get('last_edited_time'),
+            name=data.get('name'),
+            description=data.get('description', ''),
+        )
+
+        return jsonify({
+            'success': True,
+            'source': source,
+            'message': 'Notion source added successfully',
+        }), 201
+
+    except ValueError as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+    except Exception as e:
+        current_app.logger.error(f"Error adding Notion source: {e}")
+        return jsonify({'success': False, 'error': str(e)}), 500

--- a/backend/app/services/background_services/log_housekeeping_scheduler.py
+++ b/backend/app/services/background_services/log_housekeeping_scheduler.py
@@ -1,0 +1,183 @@
+"""
+Log Housekeeping Scheduler — clears backend log files once a week.
+
+Design:
+- One daemon thread per process (matches `InsightScheduler`). The
+  single-gunicorn-worker assumption holds: no cross-process coordination
+  needed.
+- Tick every 1 hour. Each tick reads `app_settings.log_housekeeping`:
+    - If `weekly_clear_enabled = false` → no-op.
+    - If `last_run_at` is null or older than 7 days → call
+      `log_service.clear_logs("scheduler")` and bump `last_run_at`.
+- Conditional UPDATE on `last_run_at` makes two racing ticks (which
+  shouldn't happen with a single worker but might during a redeploy
+  overlap) cheaply idempotent: the second update affects 0 rows and we
+  skip the clear.
+- Daemon thread dies with the worker. Tick failures are swallowed +
+  logged so a transient Supabase blip can't take the app down.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from app.services.integrations.supabase import get_supabase, is_supabase_enabled
+from app.services.log_service import clear_logs
+
+logger = logging.getLogger(__name__)
+
+
+# Hourly tick is plenty for a weekly cadence. Override via env for tests.
+TICK_INTERVAL_SECONDS = int(os.getenv("LOG_HOUSEKEEPING_TICK_SECONDS", "3600"))
+WEEKLY_INTERVAL = timedelta(days=7)
+STARTUP_DELAY_SECONDS = 60
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        # Accept both `...Z` and `+00:00` forms.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _read_housekeeping_row() -> Optional[Dict[str, Any]]:
+    """Return the single `app_settings` row's log_housekeeping JSONB, or None."""
+    if not is_supabase_enabled():
+        return None
+    try:
+        client = get_supabase()
+        resp = (
+            client.table("app_settings")
+            .select("log_housekeeping")
+            .eq("id", True)
+            .limit(1)
+            .execute()
+        )
+    except Exception as exc:
+        logger.warning("log housekeeping: could not read app_settings: %s", exc)
+        return None
+    rows = resp.data or []
+    if not rows:
+        return None
+    return rows[0].get("log_housekeeping") or {}
+
+
+def _try_update_last_run(previous_last_run: Optional[str], new_value: str) -> bool:
+    """
+    Bump `last_run_at` only if it still matches what we read at the top of
+    the tick. Returns True if our row was the one we updated (we own this
+    clear), False otherwise (another tick beat us to it).
+    """
+    if not is_supabase_enabled():
+        return False
+    try:
+        client = get_supabase()
+        # Use jsonb_set so we don't have to round-trip the whole JSONB blob
+        # and risk clobbering a concurrent admin write to weekly_clear_enabled.
+        # Conditional WHERE on the previous last_run_at is what gives us the
+        # idempotent "first writer wins" semantic.
+        query = client.table("app_settings").update(
+            {
+                "log_housekeeping": {
+                    "weekly_clear_enabled": True,
+                    "last_run_at": new_value,
+                }
+            }
+        ).eq("id", True)
+        if previous_last_run is None:
+            query = query.is_("log_housekeeping->>last_run_at", "null")
+        else:
+            query = query.eq("log_housekeeping->>last_run_at", previous_last_run)
+        resp = query.execute()
+        return bool(resp.data)
+    except Exception as exc:
+        logger.warning("log housekeeping: could not update last_run_at: %s", exc)
+        return False
+
+
+def _merge_full_row(weekly_enabled: bool, last_run_at: Optional[str]) -> Dict[str, Any]:
+    """Helper kept for tests — full-row update payload preserving toggle state."""
+    return {
+        "weekly_clear_enabled": weekly_enabled,
+        "last_run_at": last_run_at,
+    }
+
+
+class LogHousekeepingScheduler:
+    def __init__(self) -> None:
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._started = False
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        self._thread = threading.Thread(
+            target=self._run,
+            name="log-housekeeping",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "Log housekeeping scheduler started (tick=%ss, weekly clear)",
+            TICK_INTERVAL_SECONDS,
+        )
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _run(self) -> None:
+        if self._stop.wait(STARTUP_DELAY_SECONDS):
+            return
+        while not self._stop.is_set():
+            try:
+                self.tick()
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Log housekeeping tick failed: %s", exc)
+            if self._stop.wait(TICK_INTERVAL_SECONDS):
+                break
+
+    def tick(self) -> Dict[str, Any]:
+        """
+        One scheduler iteration. Public so tests (and an /admin trigger
+        endpoint, if we ever add one) can call it directly. Returns a
+        small status dict.
+        """
+        config = _read_housekeeping_row()
+        if config is None:
+            return {"ran": False, "reason": "no app_settings row"}
+        if not config.get("weekly_clear_enabled", True):
+            return {"ran": False, "reason": "weekly_clear_enabled=false"}
+
+        last_run_raw = config.get("last_run_at")
+        last_run = _parse_iso(last_run_raw)
+        now = _now_utc()
+        if last_run is not None and now - last_run < WEEKLY_INTERVAL:
+            return {"ran": False, "reason": "not yet due", "last_run_at": last_run_raw}
+
+        new_value = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if not _try_update_last_run(last_run_raw, new_value):
+            # Another tick (or admin) bumped it first. Skip the clear so
+            # we don't double-wipe.
+            return {"ran": False, "reason": "lost race"}
+
+        result = clear_logs(initiator="scheduler")
+        return {
+            "ran": True,
+            "cleared": result.get("cleared", 0),
+            "last_run_at": new_value,
+        }
+
+
+log_housekeeping_scheduler = LogHousekeepingScheduler()

--- a/backend/app/services/background_services/log_housekeeping_scheduler.py
+++ b/backend/app/services/background_services/log_housekeeping_scheduler.py
@@ -72,24 +72,32 @@ def _read_housekeeping_row() -> Optional[Dict[str, Any]]:
     return rows[0].get("log_housekeeping") or {}
 
 
-def _try_update_last_run(previous_last_run: Optional[str], new_value: str) -> bool:
+def _try_update_last_run(
+    previous_last_run: Optional[str],
+    new_value: str,
+    weekly_enabled: bool,
+) -> bool:
     """
     Bump `last_run_at` only if it still matches what we read at the top of
     the tick. Returns True if our row was the one we updated (we own this
     clear), False otherwise (another tick beat us to it).
+
+    `weekly_enabled` is the value we observed at the top of the tick. We
+    write it back verbatim AND gate the UPDATE on the same value so a
+    concurrent admin "disable" between our read and our write wins the
+    race — our update affects 0 rows and the scheduler skips the clear,
+    preserving the admin's intent. The earlier implementation hardcoded
+    `weekly_clear_enabled=True` here, which silently re-enabled the
+    toggle whenever the admin flipped it off mid-tick.
     """
     if not is_supabase_enabled():
         return False
     try:
         client = get_supabase()
-        # Use jsonb_set so we don't have to round-trip the whole JSONB blob
-        # and risk clobbering a concurrent admin write to weekly_clear_enabled.
-        # Conditional WHERE on the previous last_run_at is what gives us the
-        # idempotent "first writer wins" semantic.
         query = client.table("app_settings").update(
             {
                 "log_housekeeping": {
-                    "weekly_clear_enabled": True,
+                    "weekly_clear_enabled": weekly_enabled,
                     "last_run_at": new_value,
                 }
             }
@@ -98,6 +106,10 @@ def _try_update_last_run(previous_last_run: Optional[str], new_value: str) -> bo
             query = query.is_("log_housekeeping->>last_run_at", "null")
         else:
             query = query.eq("log_housekeeping->>last_run_at", previous_last_run)
+        query = query.eq(
+            "log_housekeeping->>weekly_clear_enabled",
+            "true" if weekly_enabled else "false",
+        )
         resp = query.execute()
         return bool(resp.data)
     except Exception as exc:
@@ -157,7 +169,8 @@ class LogHousekeepingScheduler:
         config = _read_housekeeping_row()
         if config is None:
             return {"ran": False, "reason": "no app_settings row"}
-        if not config.get("weekly_clear_enabled", True):
+        weekly_enabled = bool(config.get("weekly_clear_enabled", True))
+        if not weekly_enabled:
             return {"ran": False, "reason": "weekly_clear_enabled=false"}
 
         last_run_raw = config.get("last_run_at")
@@ -167,7 +180,10 @@ class LogHousekeepingScheduler:
             return {"ran": False, "reason": "not yet due", "last_run_at": last_run_raw}
 
         new_value = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-        if not _try_update_last_run(last_run_raw, new_value):
+        # Pass the observed weekly_enabled through so the UPDATE
+        # preserves it and the conditional WHERE picks up any admin
+        # disable that landed between our read and our write.
+        if not _try_update_last_run(last_run_raw, new_value, weekly_enabled):
             # Another tick (or admin) bumped it first. Skip the clear so
             # we don't double-wipe.
             return {"ran": False, "reason": "lost race"}

--- a/backend/app/services/data_services/user_service.py
+++ b/backend/app/services/data_services/user_service.py
@@ -202,6 +202,22 @@ class UserService:
         )
         return bool(resp.data)
 
+    def set_settings_key(self, user_id: str, key: str, value: Any) -> bool:
+        """
+        Read-modify-write a single key inside users.settings JSONB.
+
+        Educational Note: `users.settings` holds several unrelated knobs —
+        spending config, this log-download preference, anything we add
+        later. Callers updating just one key must merge, never replace,
+        or they'd clobber the other admins' spending limit settings.
+        """
+        current = self.get_user_settings_raw(user_id) or {}
+        if current.get(key) == value:
+            # No-op write — avoids burning a row update for an idempotent toggle.
+            return True
+        current[key] = value
+        return self.save_user_settings(user_id, current)
+
     def maybe_reset_expired_spending_period(
         self,
         user_id: str,

--- a/backend/app/services/integrations/knowledge_bases/notion/notion_service.py
+++ b/backend/app/services/integrations/knowledge_bases/notion/notion_service.py
@@ -331,12 +331,25 @@ class NotionService:
         if filter_type:
             payload["filter"] = {"value": filter_type, "property": "object"}
 
-        ok, raw_results, err = self._paginate_post('search', payload, page_size=min(limit, 100))
-        if not ok:
-            return {"success": False, "error": err or "Notion search failed"}
-
-        # Truncate to caller's requested limit after pagination so partial pages
-        # don't get over-fetched in pathological cases.
+        # Walk pages but bail as soon as we've collected `limit` results so a
+        # caller asking for 50 rows doesn't pull down 5000 just to discard 4950.
+        raw_results: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        for _ in range(MAX_PAGINATION_PAGES):
+            body: Dict[str, Any] = dict(payload)
+            body["page_size"] = min(limit, 100)
+            if cursor:
+                body["start_cursor"] = cursor
+            resp = self._make_request('search', method='POST', json_data=body)
+            if not resp.get("success"):
+                return {"success": False, "error": resp.get("error") or "Notion search failed"}
+            data = resp["data"]
+            raw_results.extend(data.get("results", []) or [])
+            if len(raw_results) >= limit or not data.get("has_more"):
+                break
+            cursor = data.get("next_cursor")
+            if not cursor:
+                break
         raw_results = raw_results[:limit]
 
         formatted_results: List[Dict[str, Any]] = []

--- a/backend/app/services/integrations/knowledge_bases/notion/notion_service.py
+++ b/backend/app/services/integrations/knowledge_bases/notion/notion_service.py
@@ -501,19 +501,48 @@ class NotionService:
         if filter_conditions:
             payload["filter"] = filter_conditions
 
-        ok, raw_results, err = self._paginate_post(
-            f'databases/{database_id}/query', payload, page_size=min(limit, 100)
-        )
-        if not ok:
-            return {"success": False, "error": err or "Notion database query failed"}
-
+        # Walk pages but bail as soon as we've collected `limit` rows — for a
+        # database with thousands of rows and a small caller-limit, the old
+        # "fetch everything then trim" path would burn API calls and could
+        # tip us over Notion's rate limit and fail the whole import.
+        endpoint = f'databases/{database_id}/query'
+        raw_results: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        for _ in range(MAX_PAGINATION_PAGES):
+            body: Dict[str, Any] = dict(payload)
+            body["page_size"] = min(limit, 100)
+            if cursor:
+                body["start_cursor"] = cursor
+            resp = self._make_request(endpoint, method='POST', json_data=body)
+            if not resp.get("success"):
+                return {"success": False, "error": resp.get("error") or "Notion database query failed"}
+            data = resp["data"]
+            raw_results.extend(data.get("results", []) or [])
+            if len(raw_results) >= limit or not data.get("has_more"):
+                break
+            cursor = data.get("next_cursor")
+            if not cursor:
+                break
         raw_results = raw_results[:limit]
 
         formatted_results: List[Dict[str, Any]] = []
         for page in raw_results:
             properties = page.get('properties', {}) or {}
+            # Resolve the row's display title from the actual title-type property
+            # — we can't rely on a string-value heuristic on the formatted props
+            # because title/rich_text/url/email/phone_number all collapse to
+            # plain strings below, so a row whose first property is a URL would
+            # otherwise get that URL promoted as its heading.
+            row_title = ""
+            for prop_data in properties.values():
+                if prop_data.get('type') == 'title':
+                    row_title = self._rich_text_to_str(prop_data.get('title'))
+                    if row_title:
+                        break
+
             formatted_page: Dict[str, Any] = {
                 'id': page.get('id'),
+                'title': row_title or "Untitled",
                 'url': page.get('url'),
                 'created_time': page.get('created_time'),
                 'last_edited_time': page.get('last_edited_time'),

--- a/backend/app/services/integrations/knowledge_bases/notion/notion_service.py
+++ b/backend/app/services/integrations/knowledge_bases/notion/notion_service.py
@@ -4,13 +4,27 @@ Notion Integration Service - Notion API integration for NoobBook.
 Educational Note: This service provides methods to query Notion pages and databases
 using the Notion API. It follows NoobBook's service pattern with lazy-loaded
 client initialization and environment-based configuration.
+
+The page-fetch path recursively walks child blocks (with caps) so toggles,
+sub-pages, column layouts, and nested lists actually surface in the text we
+hand to RAG. Both ``search`` and the page/block walkers paginate through
+``has_more`` / ``next_cursor`` so large workspaces and long pages aren't
+truncated at 100 results.
 """
 import logging
 import os
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Tuple
 import requests
 
 logger = logging.getLogger(__name__)
+
+
+# Recursion and result caps for page extraction. These guard against
+# pathologically large or self-referential Notion pages so a single import
+# can't run away with the worker pool. Tune in one place if needed.
+MAX_RECURSION_DEPTH = 5
+MAX_TOTAL_BLOCKS = 2000
+MAX_PAGINATION_PAGES = 50  # ~5000 blocks/items per paginated endpoint
 
 
 class NotionService:
@@ -117,62 +131,236 @@ class NotionService:
         except Exception as e:
             return {"success": False, "error": f"Request failed: {str(e)}"}
 
-    def search(self, query: Optional[str] = None, filter_type: Optional[str] = None, limit: int = 20) -> Dict[str, Any]:
+    # ------------------------------------------------------------------
+    # Pagination helpers
+    # ------------------------------------------------------------------
+
+    def _paginate_post(
+        self,
+        endpoint: str,
+        payload: Dict[str, Any],
+        page_size: int = 100,
+    ) -> Tuple[bool, List[Dict[str, Any]], Optional[str]]:
         """
-        Search Notion pages and databases.
+        Walk a paginated POST endpoint until ``has_more`` is false or we hit
+        MAX_PAGINATION_PAGES. Returns (success, results, error).
+        """
+        results: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        for _ in range(MAX_PAGINATION_PAGES):
+            body = dict(payload)
+            body["page_size"] = min(page_size, 100)
+            if cursor:
+                body["start_cursor"] = cursor
+            resp = self._make_request(endpoint, method='POST', json_data=body)
+            if not resp.get("success"):
+                return False, results, resp.get("error")
+            data = resp["data"]
+            results.extend(data.get("results", []) or [])
+            if not data.get("has_more"):
+                return True, results, None
+            cursor = data.get("next_cursor")
+            if not cursor:
+                return True, results, None
+        logger.warning("Notion pagination hit cap of %d pages at %s", MAX_PAGINATION_PAGES, endpoint)
+        return True, results, None
+
+    def _paginate_get(
+        self,
+        endpoint: str,
+        page_size: int = 100,
+    ) -> Tuple[bool, List[Dict[str, Any]], Optional[str]]:
+        """
+        Walk a paginated GET endpoint (e.g. ``blocks/{id}/children``). Notion
+        accepts start_cursor / page_size as query params on these endpoints.
+        Returns (success, results, error).
+        """
+        results: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        for _ in range(MAX_PAGINATION_PAGES):
+            sep = '&' if '?' in endpoint else '?'
+            url = f"{endpoint}{sep}page_size={min(page_size, 100)}"
+            if cursor:
+                url = f"{url}&start_cursor={cursor}"
+            resp = self._make_request(url)
+            if not resp.get("success"):
+                return False, results, resp.get("error")
+            data = resp["data"]
+            results.extend(data.get("results", []) or [])
+            if not data.get("has_more"):
+                return True, results, None
+            cursor = data.get("next_cursor")
+            if not cursor:
+                return True, results, None
+        logger.warning("Notion pagination hit cap of %d pages at %s", MAX_PAGINATION_PAGES, endpoint)
+        return True, results, None
+
+    # ------------------------------------------------------------------
+    # Block → text rendering
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _rich_text_to_str(rich_text: Optional[List[Dict[str, Any]]]) -> str:
+        """Join Notion's rich_text array into plain text."""
+        if not rich_text:
+            return ""
+        return "".join(rt.get("plain_text", "") for rt in rich_text)
+
+    @classmethod
+    def _render_block(cls, block: Dict[str, Any], indent: int = 0) -> Optional[str]:
+        """
+        Render a single Notion block as markdown-ish plain text. Returns None
+        when the block has no surfaceable text (e.g. unsupported embeds).
+        Children are NOT rendered here — the recursive walker handles them.
+        """
+        block_type = block.get("type")
+        if not block_type or block_type not in block:
+            return None
+        body = block[block_type] or {}
+        text = cls._rich_text_to_str(body.get("rich_text"))
+        prefix = "  " * indent
+
+        if block_type == "paragraph":
+            return f"{prefix}{text}" if text else None
+        if block_type == "heading_1":
+            return f"{prefix}# {text}" if text else None
+        if block_type == "heading_2":
+            return f"{prefix}## {text}" if text else None
+        if block_type == "heading_3":
+            return f"{prefix}### {text}" if text else None
+        if block_type == "bulleted_list_item":
+            return f"{prefix}- {text}"
+        if block_type == "numbered_list_item":
+            return f"{prefix}1. {text}"
+        if block_type == "to_do":
+            checked = body.get("checked", False)
+            box = "[x]" if checked else "[ ]"
+            return f"{prefix}- {box} {text}"
+        if block_type == "toggle":
+            return f"{prefix}▸ {text}" if text else None
+        if block_type == "quote":
+            return f"{prefix}> {text}" if text else None
+        if block_type == "callout":
+            return f"{prefix}> {text}" if text else None
+        if block_type == "code":
+            language = body.get("language", "")
+            return f"{prefix}```{language}\n{text}\n{prefix}```" if text else None
+        if block_type == "divider":
+            return f"{prefix}---"
+        if block_type == "child_page":
+            # Title is on the block itself, not in rich_text
+            title = body.get("title", "")
+            return f"{prefix}## {title}" if title else None
+        if block_type == "child_database":
+            title = body.get("title", "")
+            return f"{prefix}### Database: {title}" if title else None
+        if block_type == "bookmark" or block_type == "embed":
+            url = body.get("url", "")
+            caption = cls._rich_text_to_str(body.get("caption"))
+            label = caption or url
+            return f"{prefix}[{label}]({url})" if url else None
+
+        # Fallback: if we got any text out of rich_text, emit it
+        return f"{prefix}{text}" if text else None
+
+    def _walk_blocks(
+        self,
+        parent_id: str,
+        indent: int,
+        depth: int,
+        counter: Dict[str, int],
+    ) -> Tuple[List[str], Optional[str]]:
+        """
+        Recursively walk children of ``parent_id`` and return rendered lines.
+        Caps recursion at MAX_RECURSION_DEPTH and total emitted blocks at
+        MAX_TOTAL_BLOCKS. Returns (lines, error_or_none).
+        """
+        lines: List[str] = []
+        if depth > MAX_RECURSION_DEPTH:
+            return lines, None
+        if counter["count"] >= MAX_TOTAL_BLOCKS:
+            return lines, None
+
+        ok, blocks, err = self._paginate_get(f"blocks/{parent_id}/children")
+        if not ok:
+            return lines, err
+
+        for block in blocks:
+            if counter["count"] >= MAX_TOTAL_BLOCKS:
+                lines.append("…(truncated: page exceeded block cap)")
+                return lines, None
+            rendered = self._render_block(block, indent=indent)
+            if rendered:
+                lines.append(rendered)
+                counter["count"] += 1
+
+            if block.get("has_children") and depth < MAX_RECURSION_DEPTH:
+                child_id = block.get("id")
+                if child_id:
+                    child_lines, child_err = self._walk_blocks(
+                        child_id, indent=indent + 1, depth=depth + 1, counter=counter
+                    )
+                    if child_err:
+                        # Don't abort the whole page on a single child fetch error
+                        logger.warning(
+                            "Notion child fetch failed for block %s: %s", child_id, child_err
+                        )
+                    lines.extend(child_lines)
+
+        return lines, None
+
+    # ------------------------------------------------------------------
+    # Search / Page / Database
+    # ------------------------------------------------------------------
+
+    def search(self, query: Optional[str] = None, filter_type: Optional[str] = None, limit: int = 100) -> Dict[str, Any]:
+        """
+        Search Notion pages and databases (paginated).
 
         Args:
             query: Search query string (optional, returns all if not provided)
             filter_type: Filter by object type: 'page' or 'database' (optional)
-            limit: Maximum number of results (default: 20, max: 100)
+            limit: Maximum number of results to return after pagination (default 100)
 
         Returns:
             Dict with 'success' flag and either 'results' list or 'error'
         """
-        # Build search payload
-        payload = {
-            "page_size": min(limit, 100)
-        }
-
+        payload: Dict[str, Any] = {}
         if query:
             payload["query"] = query
-
         if filter_type:
-            payload["filter"] = {
-                "value": filter_type,
-                "property": "object"
-            }
+            payload["filter"] = {"value": filter_type, "property": "object"}
 
-        # TODO: Add pagination support (has_more / start_cursor) for large workspaces
-        result = self._make_request('search', method='POST', json_data=payload)
+        ok, raw_results, err = self._paginate_post('search', payload, page_size=min(limit, 100))
+        if not ok:
+            return {"success": False, "error": err or "Notion search failed"}
 
-        if not result['success']:
-            return result
+        # Truncate to caller's requested limit after pagination so partial pages
+        # don't get over-fetched in pathological cases.
+        raw_results = raw_results[:limit]
 
-        # Format results
-        data = result['data']
-        results = data.get('results', [])
-
-        formatted_results = []
-        for item in results:
-            formatted_item = {
+        formatted_results: List[Dict[str, Any]] = []
+        for item in raw_results:
+            formatted_item: Dict[str, Any] = {
                 'id': item.get('id'),
                 'type': item.get('object'),  # 'page' or 'database'
                 'created_time': item.get('created_time'),
                 'last_edited_time': item.get('last_edited_time'),
-                'url': item.get('url')
+                'url': item.get('url'),
             }
 
             # Extract title
             if item.get('object') == 'page':
-                properties = item.get('properties', {})
-                title_prop = properties.get('title', {})
-                if title_prop.get('title'):
-                    formatted_item['title'] = ''.join([t.get('plain_text', '') for t in title_prop['title']])
+                properties = item.get('properties', {}) or {}
+                # Find the title property — it's not always called "title"
+                title_text = ""
+                for prop in properties.values():
+                    if prop.get('type') == 'title':
+                        title_text = self._rich_text_to_str(prop.get('title'))
+                        break
+                formatted_item['title'] = title_text or "Untitled"
             elif item.get('object') == 'database':
-                title = item.get('title', [])
-                if title:
-                    formatted_item['title'] = ''.join([t.get('plain_text', '') for t in title])
+                formatted_item['title'] = self._rich_text_to_str(item.get('title')) or "Untitled"
 
             formatted_results.append(formatted_item)
 
@@ -180,12 +368,17 @@ class NotionService:
             "success": True,
             "results": formatted_results,
             "total": len(formatted_results),
-            "has_more": data.get('has_more', False)
+            "has_more": False,
         }
 
     def get_page(self, page_id: str) -> Dict[str, Any]:
         """
-        Get page content including properties and blocks.
+        Get page content including properties and all nested blocks.
+
+        Recursively walks child blocks (toggles, sub-pages, columns, nested
+        lists) up to MAX_RECURSION_DEPTH levels and MAX_TOTAL_BLOCKS total
+        rendered blocks. Long pages are paginated via the blocks/{id}/children
+        endpoint.
 
         Args:
             page_id: Notion page ID
@@ -203,35 +396,30 @@ class NotionService:
 
         page = page_result['data']
 
-        # Get page blocks (content)
-        # Limitation: Only fetches top-level blocks. Nested children (e.g. items
-        # inside toggles, columns, or synced blocks) are not recursively fetched.
-        # TODO: Add pagination support (has_more / next_cursor) for pages with 100+ blocks
-        blocks_result = self._make_request(f'blocks/{page_id}/children')
-        if not blocks_result['success']:
-            return blocks_result
+        # Extract title from the page's own properties for display
+        title = "Untitled"
+        for prop in (page.get('properties') or {}).values():
+            if prop.get('type') == 'title':
+                title = self._rich_text_to_str(prop.get('title')) or "Untitled"
+                break
 
-        blocks = blocks_result['data'].get('results', [])
+        counter = {"count": 0}
+        lines, err = self._walk_blocks(page_id, indent=0, depth=0, counter=counter)
+        if err and not lines:
+            return {"success": False, "error": err}
 
-        # Extract text content from blocks
-        content_parts = []
-        for block in blocks:
-            block_type = block.get('type')
-            if block_type and block_type in block:
-                block_content = block[block_type]
-                if 'rich_text' in block_content:
-                    text = ''.join([t.get('plain_text', '') for t in block_content['rich_text']])
-                    if text:
-                        content_parts.append(text)
+        content = "\n\n".join(line for line in lines if line)
 
         return {
             "success": True,
             "page": {
                 'id': page.get('id'),
+                'title': title,
                 'url': page.get('url'),
                 'created_time': page.get('created_time'),
                 'last_edited_time': page.get('last_edited_time'),
-                'content': '\n\n'.join(content_parts)
+                'content': content,
+                'block_count': counter["count"],
             }
         }
 
@@ -255,23 +443,24 @@ class NotionService:
         database = result['data']
 
         # Extract schema
-        properties = database.get('properties', {})
-        schema = {}
-        for prop_name, prop_data in properties.items():
-            schema[prop_name] = {
+        properties = database.get('properties', {}) or {}
+        schema = {
+            prop_name: {
                 'type': prop_data.get('type'),
-                'id': prop_data.get('id')
+                'id': prop_data.get('id'),
             }
+            for prop_name, prop_data in properties.items()
+        }
 
         return {
             "success": True,
             "database": {
                 'id': database.get('id'),
-                'title': ''.join([t.get('plain_text', '') for t in database.get('title', [])]),
+                'title': self._rich_text_to_str(database.get('title')) or "Untitled",
                 'url': database.get('url'),
                 'created_time': database.get('created_time'),
                 'last_edited_time': database.get('last_edited_time'),
-                'schema': schema
+                'schema': schema,
             }
         }
 
@@ -279,15 +468,15 @@ class NotionService:
         self,
         database_id: str,
         filter_conditions: Optional[Dict] = None,
-        limit: int = 20
+        limit: int = 100,
     ) -> Dict[str, Any]:
         """
-        Query database with optional filters.
+        Query database with optional filters (paginated).
 
         Args:
             database_id: Notion database ID
             filter_conditions: Optional filter object (Notion filter format)
-            limit: Maximum results (default: 20, max: 100)
+            limit: Maximum results after pagination (default 100)
 
         Returns:
             Dict with 'success' flag and either 'results' list or 'error'
@@ -295,41 +484,36 @@ class NotionService:
         if not database_id:
             return {"success": False, "error": "database_id is required"}
 
-        # Build query payload
-        payload = {
-            "page_size": min(limit, 100)
-        }
-
+        payload: Dict[str, Any] = {}
         if filter_conditions:
             payload["filter"] = filter_conditions
 
-        result = self._make_request(f'databases/{database_id}/query', method='POST', json_data=payload)
+        ok, raw_results, err = self._paginate_post(
+            f'databases/{database_id}/query', payload, page_size=min(limit, 100)
+        )
+        if not ok:
+            return {"success": False, "error": err or "Notion database query failed"}
 
-        if not result['success']:
-            return result
+        raw_results = raw_results[:limit]
 
-        # Format results
-        data = result['data']
-        results = data.get('results', [])
-
-        formatted_results = []
-        for page in results:
-            properties = page.get('properties', {})
-            formatted_page = {
+        formatted_results: List[Dict[str, Any]] = []
+        for page in raw_results:
+            properties = page.get('properties', {}) or {}
+            formatted_page: Dict[str, Any] = {
                 'id': page.get('id'),
                 'url': page.get('url'),
                 'created_time': page.get('created_time'),
                 'last_edited_time': page.get('last_edited_time'),
-                'properties': {}
+                'properties': {},
             }
 
             # Extract property values
             for prop_name, prop_data in properties.items():
                 prop_type = prop_data.get('type')
                 if prop_type == 'title':
-                    formatted_page['properties'][prop_name] = ''.join([t.get('plain_text', '') for t in prop_data.get('title', [])])
+                    formatted_page['properties'][prop_name] = self._rich_text_to_str(prop_data.get('title'))
                 elif prop_type == 'rich_text':
-                    formatted_page['properties'][prop_name] = ''.join([t.get('plain_text', '') for t in prop_data.get('rich_text', [])])
+                    formatted_page['properties'][prop_name] = self._rich_text_to_str(prop_data.get('rich_text'))
                 elif prop_type in ['number', 'checkbox', 'url', 'email', 'phone_number']:
                     formatted_page['properties'][prop_name] = prop_data.get(prop_type)
                 elif prop_type == 'select':
@@ -347,7 +531,7 @@ class NotionService:
             "success": True,
             "results": formatted_results,
             "total": len(formatted_results),
-            "has_more": data.get('has_more', False)
+            "has_more": False,
         }
 
 

--- a/backend/app/services/log_service.py
+++ b/backend/app/services/log_service.py
@@ -1,0 +1,50 @@
+"""
+Log service — operations on the rotating backend log file.
+
+Educational Note: Both the HTTP `POST /logs/clear` route and the weekly
+housekeeping scheduler call into this module so the truncate-and-archive-
+delete semantics live in exactly one place. Audit-log emission also lives
+here so every clear is traceable regardless of which call site triggered it.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from app.utils import logger as logger_module
+
+logger = logging.getLogger(__name__)
+
+
+def clear_logs(initiator: str = "unknown") -> Dict[str, Any]:
+    """
+    Truncate the active log file and remove rotated archives.
+
+    Returns a dict with `success`, `cleared` (file count), and optionally
+    a `message` (for the "no log file present" no-op path).
+
+    `initiator` shows up in the audit log entry — pass the requesting
+    user id, "scheduler", "admin:<email>", etc. so a future log review
+    can attribute the wipe.
+    """
+    log_file = logger_module.LOG_FILE
+    if log_file is None or not log_file.parent.exists():
+        return {"success": True, "cleared": 0, "message": "no log file"}
+
+    cleared = 0
+    try:
+        if log_file.exists():
+            log_file.write_text("", encoding="utf-8")
+            cleared += 1
+        for archive in log_file.parent.glob(f"{log_file.name}.*"):
+            try:
+                archive.unlink()
+                cleared += 1
+            except OSError as exc:
+                logger.warning("Could not delete archive %s: %s", archive, exc)
+    except Exception as exc:
+        logger.exception("Failed to clear logs")
+        return {"success": False, "error": str(exc)}
+
+    logger.info("Log files cleared by %s (%d files)", initiator, cleared)
+    return {"success": True, "cleared": cleared}

--- a/backend/app/services/source_services/source_processing/notion_processor.py
+++ b/backend/app/services/source_services/source_processing/notion_processor.py
@@ -64,23 +64,27 @@ def _fetch_page(source_id: str, notion_id: str) -> Tuple[str, Dict[str, Any]]:
 
 def _format_db_row(row: Dict[str, Any], row_body: str) -> str:
     """
-    Render a database row as a single processed page: a property table on top,
-    followed by the row's page content (the body).
+    Render a database row as a single processed page: an H1 from the row's
+    title property, a property table, and then the row's page content.
+
+    The row's title comes from the `title` field that notion_service.query_database
+    extracts directly from the title-type property — we don't guess from
+    formatted property values because `query_database` strips type info, so
+    title/url/email/rich_text columns are all indistinguishable plain strings
+    after that point.
     """
     props = row.get("properties") or {}
-    title_value = ""
-    other_props: List[Tuple[str, Any]] = []
-    for k, v in props.items():
-        if isinstance(v, str) and v and not title_value:
-            # Promote the first non-empty string property to the H1 title
-            # and *skip* re-emitting it in the Properties list below — otherwise
-            # the row's title would appear twice in every embedded page.
-            title_value = v
-            continue
-        other_props.append((k, v))
+    title_value = (row.get("title") or "").strip()
 
     header = f"# {title_value}" if title_value else "# (untitled row)"
     lines = [header, ""]
+
+    # Properties list. Skip whichever property *was* the title so it doesn't
+    # appear twice on the page.
+    other_props: List[Tuple[str, Any]] = [
+        (k, v) for k, v in props.items()
+        if not (isinstance(v, str) and v == title_value)
+    ]
     if other_props:
         lines.append("## Properties")
         for k, v in other_props:

--- a/backend/app/services/source_services/source_processing/notion_processor.py
+++ b/backend/app/services/source_services/source_processing/notion_processor.py
@@ -1,0 +1,337 @@
+"""
+Notion Processor - Fetches Notion page or database content and embeds it.
+
+Educational Note: Notion sources are stored as `.notion` stub files holding
+the picked page/database ID. The processor:
+
+1. Reads the stub → gets notion_id + object_type
+2. Page sources: fetches the page (recursively walks child blocks) and emits
+   it as a single processed page.
+3. Database sources: queries the DB (paginated), then fetches each row's
+   page as its own processed page. The first page is a header summarizing
+   the database schema.
+4. Formats everything via build_processed_output() with NOTION page markers
+5. Uploads processed text to Supabase Storage
+6. Runs the standard embedding + summary flow (Notion content IS embedded,
+   unlike live-API integrations like Jira/Mixpanel)
+
+Cooperative cancellation is checked between Notion API calls so a long
+database import can be cancelled cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from app.services.ai_services.embedding_service import embedding_service
+from app.services.ai_services.summary_service import summary_service
+from app.services.background_services import task_service
+from app.services.integrations.knowledge_bases.notion.notion_service import notion_service
+from app.services.integrations.supabase import storage_service
+from app.utils.embedding_utils import count_tokens, needs_embedding
+from app.utils.text import build_processed_output
+
+logger = logging.getLogger(__name__)
+
+
+class _Cancelled(Exception):
+    """Raised when the user cancels processing mid-fetch."""
+
+
+def _check_cancel(source_id: str) -> None:
+    if task_service.is_target_cancelled(source_id):
+        raise _Cancelled()
+
+
+def _fetch_page(source_id: str, notion_id: str) -> Tuple[str, Dict[str, Any]]:
+    """
+    Fetch a single Notion page. Returns (rendered_text, page_meta).
+    Raises ValueError on Notion errors.
+    """
+    _check_cancel(source_id)
+    result = notion_service.get_page(notion_id)
+    if not result.get("success"):
+        raise ValueError(result.get("error", "Failed to fetch Notion page"))
+    page = result["page"]
+    title = page.get("title") or "Untitled"
+    body = page.get("content") or ""
+    text = f"# {title}\n\n{body}" if body else f"# {title}"
+    return text, page
+
+
+def _format_db_row(row: Dict[str, Any], row_body: str) -> str:
+    """
+    Render a database row as a single processed page: a property table on top,
+    followed by the row's page content (the body).
+    """
+    props = row.get("properties") or {}
+    title_value = ""
+    other_props: List[Tuple[str, Any]] = []
+    for k, v in props.items():
+        if isinstance(v, str) and not title_value:
+            # The first non-empty string is most likely the title; we keep
+            # heuristic-free behavior — just dump everything below.
+            title_value = v
+        other_props.append((k, v))
+
+    header = f"# {title_value}" if title_value else "# (untitled row)"
+    lines = [header, ""]
+    if other_props:
+        lines.append("## Properties")
+        for k, v in other_props:
+            if v in (None, "", [], {}):
+                continue
+            if isinstance(v, list):
+                v_str = ", ".join(str(x) for x in v if x is not None)
+            else:
+                v_str = str(v)
+            lines.append(f"- **{k}**: {v_str}")
+        lines.append("")
+    if row_body:
+        lines.append("## Content")
+        lines.append("")
+        lines.append(row_body)
+    return "\n".join(lines).rstrip()
+
+
+def _fetch_database_pages(
+    source_id: str,
+    database_id: str,
+) -> Tuple[List[str], Dict[str, Any]]:
+    """
+    Fetch a Notion database: schema + every row's page. Returns (pages, meta).
+    The first page is a database overview; each subsequent page is one row.
+    """
+    _check_cancel(source_id)
+    db_result = notion_service.get_database(database_id)
+    if not db_result.get("success"):
+        raise ValueError(db_result.get("error", "Failed to fetch Notion database"))
+    db = db_result["database"]
+
+    _check_cancel(source_id)
+    q_result = notion_service.query_database(database_id, limit=100)
+    if not q_result.get("success"):
+        raise ValueError(q_result.get("error", "Failed to query Notion database"))
+    rows = q_result.get("results", []) or []
+
+    # Page 1: database overview
+    schema = db.get("schema") or {}
+    overview_lines = [
+        f"# Database: {db.get('title', 'Untitled')}",
+        "",
+        f"Rows fetched: {len(rows)}",
+        "",
+        "## Schema",
+    ]
+    for prop_name, prop_meta in schema.items():
+        overview_lines.append(f"- **{prop_name}** ({prop_meta.get('type', 'unknown')})")
+    overview = "\n".join(overview_lines)
+
+    pages: List[str] = [overview]
+
+    for row in rows:
+        _check_cancel(source_id)
+        row_id = row.get("id")
+        row_body = ""
+        if row_id:
+            page_result = notion_service.get_page(row_id)
+            if page_result.get("success"):
+                row_body = (page_result["page"].get("content") or "").strip()
+            else:
+                # Don't abort the whole import on a single row failure
+                logger.warning(
+                    "Failed to fetch Notion row %s: %s",
+                    row_id,
+                    page_result.get("error"),
+                )
+        pages.append(_format_db_row(row, row_body))
+
+    meta = {
+        "title": db.get("title", "Untitled"),
+        "notion_url": db.get("url", ""),
+        "last_edited_time": db.get("last_edited_time", ""),
+        "row_count": len(rows),
+    }
+    return pages, meta
+
+
+def process_notion(
+    project_id: str,
+    source_id: str,
+    source: Dict[str, Any],
+    raw_file_path: Path,
+    source_service,
+) -> Dict[str, Any]:
+    """
+    Process a Notion source by fetching live content and embedding it.
+    """
+    # Read the stub
+    try:
+        with open(raw_file_path, "r", encoding="utf-8") as f:
+            stub = json.load(f)
+    except Exception as e:
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": f"Failed to read Notion stub: {e}"},
+        )
+        return {"success": False, "error": str(e)}
+
+    notion_id = stub.get("notion_id")
+    object_type = stub.get("object_type")
+    if not notion_id or object_type not in ("page", "database"):
+        msg = "Notion stub is missing notion_id or has invalid object_type"
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": msg},
+        )
+        return {"success": False, "error": msg}
+
+    if not notion_service.is_configured():
+        msg = "Notion is not configured (NOTION_API_KEY missing)"
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": msg},
+        )
+        return {"success": False, "error": msg}
+
+    try:
+        if object_type == "page":
+            text, page_meta = _fetch_page(source_id, notion_id)
+            pages = [text]
+            metadata = {
+                "object_type": "page",
+                "notion_url": page_meta.get("url", stub.get("notion_url", "")),
+                "last_edited_time": page_meta.get(
+                    "last_edited_time", stub.get("last_edited_time", "")
+                ),
+                "page_count": 1,
+            }
+            display_title = page_meta.get("title") or stub.get("title") or source.get("name") or "Notion page"
+        else:
+            pages, db_meta = _fetch_database_pages(source_id, notion_id)
+            metadata = {
+                "object_type": "database",
+                "notion_url": db_meta.get("notion_url", stub.get("notion_url", "")),
+                "last_edited_time": db_meta.get(
+                    "last_edited_time", stub.get("last_edited_time", "")
+                ),
+                "page_count": len(pages),
+            }
+            display_title = db_meta.get("title") or stub.get("title") or source.get("name") or "Notion database"
+    except _Cancelled:
+        logger.info("Notion processing cancelled for source %s", source_id)
+        # Status will be reset by cancel_processing; just return without
+        # marking as error.
+        return {"success": False, "cancelled": True}
+    except ValueError as e:
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": str(e)},
+        )
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.exception("Notion processing failed for source %s", source_id)
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": str(e)},
+        )
+        return {"success": False, "error": str(e)}
+
+    # Compute total character + token counts across all pages
+    combined = "\n\n".join(pages)
+    metadata["character_count"] = len(combined)
+    metadata["token_count"] = count_tokens(combined)
+
+    source_name = source.get("name") or display_title
+    processed_content = build_processed_output(
+        pages=pages,
+        source_type="NOTION",
+        source_name=source_name,
+        metadata=metadata,
+    )
+
+    storage_path = storage_service.upload_processed_file(
+        project_id=project_id,
+        source_id=source_id,
+        content=processed_content,
+    )
+    if not storage_path:
+        source_service.update_source(
+            project_id, source_id, status="error",
+            processing_info={"error": "Failed to upload processed Notion content"},
+        )
+        return {"success": False, "error": "Failed to upload processed content to storage"}
+
+    processing_info = {
+        "processor": "notion",
+        "object_type": object_type,
+        "notion_id": notion_id,
+        "notion_url": metadata.get("notion_url"),
+        "total_pages": len(pages),
+        "character_count": metadata["character_count"],
+    }
+
+    # Embed (Notion content is text-only knowledge — always embed)
+    embedding_info: Dict[str, Any]
+    try:
+        _, _, reason = needs_embedding(text=processed_content)
+        source_service.update_source(project_id, source_id, status="embedding")
+        logger.info("Starting Notion embedding for %s (%s)", source_name, reason)
+        embedding_info = embedding_service.process_embeddings(
+            project_id=project_id,
+            source_id=source_id,
+            source_name=source_name,
+            processed_text=processed_content,
+        )
+    except Exception as e:
+        logger.exception("Notion embedding failed for source %s", source_id)
+        embedding_info = {
+            "is_embedded": False,
+            "embedded_at": None,
+            "token_count": 0,
+            "chunk_count": 0,
+            "reason": f"Embedding error: {e}",
+        }
+
+    # Carry stub identifiers forward so the chat layer can still tell which
+    # Notion ID this source came from after processing.
+    embedding_info = {
+        **(source.get("embedding_info") or {}),
+        **embedding_info,
+        "file_extension": ".notion",
+        "source_type": "notion",
+        "notion_id": notion_id,
+        "object_type": object_type,
+    }
+
+    # Summary
+    summary_info: Dict[str, Any] = {}
+    try:
+        result = summary_service.generate_summary(
+            project_id=project_id,
+            source_id=source_id,
+            source_metadata={
+                **source,
+                "processing_info": processing_info,
+                "embedding_info": embedding_info,
+            },
+        )
+        if result:
+            summary_info = result
+    except Exception:
+        logger.exception("Summary generation failed for Notion source %s", source_id)
+
+    source_service.update_source(
+        project_id,
+        source_id,
+        status="ready",
+        active=True,
+        processing_info=processing_info,
+        embedding_info=embedding_info,
+        summary_info=summary_info if summary_info else None,
+    )
+
+    return {"success": True, "status": "ready"}

--- a/backend/app/services/source_services/source_processing/notion_processor.py
+++ b/backend/app/services/source_services/source_processing/notion_processor.py
@@ -71,10 +71,12 @@ def _format_db_row(row: Dict[str, Any], row_body: str) -> str:
     title_value = ""
     other_props: List[Tuple[str, Any]] = []
     for k, v in props.items():
-        if isinstance(v, str) and not title_value:
-            # The first non-empty string is most likely the title; we keep
-            # heuristic-free behavior — just dump everything below.
+        if isinstance(v, str) and v and not title_value:
+            # Promote the first non-empty string property to the H1 title
+            # and *skip* re-emitting it in the Properties list below — otherwise
+            # the row's title would appear twice in every embedded page.
             title_value = v
+            continue
         other_props.append((k, v))
 
     header = f"# {title_value}" if title_value else "# (untitled row)"
@@ -163,7 +165,7 @@ def process_notion(
     source_id: str,
     source: Dict[str, Any],
     raw_file_path: Path,
-    source_service,
+    source_service: Any,
 ) -> Dict[str, Any]:
     """
     Process a Notion source by fetching live content and embedding it.

--- a/backend/app/services/source_services/source_processing/source_processing_service.py
+++ b/backend/app/services/source_services/source_processing/source_processing_service.py
@@ -75,6 +75,7 @@ class SourceProcessingService:
         ".mixpanel": "mixpanel",  # Mixpanel analytics sources (live API flag)
         ".mcp": "mcp",  # MCP server resources
         ".research": "research",  # Deep research source
+        ".notion": "notion",  # Notion page/database sources
     }
 
     def process_source(self, project_id: str, source_id: str) -> Dict[str, Any]:
@@ -204,6 +205,10 @@ class SourceProcessingService:
             elif processor_type == "research":
                 from app.services.source_services.source_processing.research_processor import process_research
                 return process_research(project_id, source_id, source, raw_file_path, source_service)
+
+            elif processor_type == "notion":
+                from app.services.source_services.source_processing.notion_processor import process_notion
+                return process_notion(project_id, source_id, source, raw_file_path, source_service)
 
             else:
                 # Unsupported file type

--- a/backend/app/services/source_services/source_service.py
+++ b/backend/app/services/source_services/source_service.py
@@ -28,6 +28,7 @@ from app.services.source_services.source_upload import (
     add_jira_source,
     add_mcp_source,
     add_mixpanel_source,
+    add_notion_source,
 )
 # Local path utils used for temp file staging during source processing
 from app.utils.path_utils import (
@@ -470,6 +471,39 @@ class SourceService:
         this specific project. Queries Mixpanel's Query API live.
         """
         return self._shape_for_frontend(project_id, add_mixpanel_source(project_id, name, description))
+
+    def add_notion_source(
+        self,
+        project_id: str,
+        notion_id: str,
+        object_type: str,
+        title: Optional[str] = None,
+        notion_url: Optional[str] = None,
+        last_edited_time: Optional[str] = None,
+        name: Optional[str] = None,
+        description: str = "",
+    ) -> Dict[str, Any]:
+        """
+        Add a Notion source (specific page or database) to a project.
+
+        Educational Note: Unlike Jira/Mixpanel which are live-API flags, Notion
+        sources fetch their content during processing and embed it for RAG —
+        Notion pages are slow-changing knowledge artifacts that benefit from
+        chunked semantic search.
+        """
+        return self._shape_for_frontend(
+            project_id,
+            add_notion_source(
+                project_id=project_id,
+                notion_id=notion_id,
+                object_type=object_type,
+                title=title,
+                notion_url=notion_url,
+                last_edited_time=last_edited_time,
+                name=name,
+                description=description,
+            ),
+        )
 
     def add_mcp_source(
         self,

--- a/backend/app/services/source_services/source_upload/__init__.py
+++ b/backend/app/services/source_services/source_upload/__init__.py
@@ -19,6 +19,7 @@ from app.services.source_services.source_upload.freshdesk_upload import add_fres
 from app.services.source_services.source_upload.jira_upload import add_jira_source
 from app.services.source_services.source_upload.mcp_upload import add_mcp_source
 from app.services.source_services.source_upload.mixpanel_upload import add_mixpanel_source
+from app.services.source_services.source_upload.notion_upload import add_notion_source
 
 __all__ = [
     "upload_file",
@@ -31,4 +32,5 @@ __all__ = [
     "add_jira_source",
     "add_mcp_source",
     "add_mixpanel_source",
+    "add_notion_source",
 ]

--- a/backend/app/services/source_services/source_upload/notion_upload.py
+++ b/backend/app/services/source_services/source_upload/notion_upload.py
@@ -1,0 +1,158 @@
+"""
+Notion Upload Handler - Create a NOTION source for a project.
+
+Educational Note: Notion sources work like Google Drive imports — the user
+picks a specific Notion page or database in the browse-and-pick UI, and we
+create a per-project source that resolves to that ID. The .notion stub holds
+the picked ID + object_type; the processor fetches live content during
+processing and embeds the result for RAG.
+
+Unlike Jira/Mixpanel (live-only API flags), Notion content IS embedded —
+pages are slow-changing knowledge artifacts that benefit from chunked
+semantic search, not live querying.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from app.services.background_services import task_service
+from app.services.integrations.knowledge_bases.notion.notion_service import notion_service
+from app.services.integrations.supabase import storage_service
+from app.services.source_services import source_index_service
+
+logger = logging.getLogger(__name__)
+
+
+VALID_OBJECT_TYPES = ("page", "database")
+
+
+def add_notion_source(
+    project_id: str,
+    notion_id: str,
+    object_type: str,
+    title: Optional[str] = None,
+    notion_url: Optional[str] = None,
+    last_edited_time: Optional[str] = None,
+    name: Optional[str] = None,
+    description: str = "",
+) -> Dict[str, Any]:
+    """
+    Create a NOTION source in a project and trigger processing.
+
+    Args:
+        project_id: The project UUID
+        notion_id: The Notion page or database UUID
+        object_type: "page" or "database"
+        title: Title fetched from Notion during the picker step (used for naming)
+        notion_url: notion.so URL of the resource (for the preview header)
+        last_edited_time: ISO timestamp from Notion (used in preview header)
+        name: Optional display-name override; falls back to `title`
+        description: Optional user description
+
+    Returns:
+        Source metadata dictionary
+
+    Raises:
+        ValueError: If Notion is not configured or arguments are invalid
+    """
+    if not notion_service.is_configured():
+        raise ValueError(
+            "Notion not configured. Add NOTION_API_KEY in Settings → API Keys."
+        )
+    if not notion_id:
+        raise ValueError("notion_id is required")
+    if object_type not in VALID_OBJECT_TYPES:
+        raise ValueError(
+            f"object_type must be one of {VALID_OBJECT_TYPES}, got '{object_type}'"
+        )
+
+    source_id = str(uuid.uuid4())
+    stored_filename = f"{source_id}.notion"
+
+    raw_payload = {
+        "kind": "notion_source",
+        "notion_id": notion_id,
+        "object_type": object_type,
+        "title": title or "",
+        "notion_url": notion_url or "",
+        "last_edited_time": last_edited_time or "",
+        "created_at": datetime.now().isoformat(),
+    }
+
+    raw_bytes = json.dumps(raw_payload, indent=2).encode("utf-8")
+    storage_path = storage_service.upload_raw_file(
+        project_id=project_id,
+        source_id=source_id,
+        filename=stored_filename,
+        file_data=raw_bytes,
+        content_type="application/json; charset=utf-8",
+    )
+    if not storage_path:
+        raise ValueError("Failed to create Notion source metadata in storage")
+
+    display_name = (name or title or f"Notion {object_type}").strip()
+    if not display_name:
+        display_name = f"Notion {object_type}"
+
+    source_metadata: Dict[str, Any] = {
+        "id": source_id,
+        "project_id": project_id,
+        "name": display_name,
+        "description": description,
+        "type": "NOTION",
+        "status": "uploaded",
+        "raw_file_path": storage_path,
+        "file_size": len(raw_bytes),
+        "is_active": True,
+        "embedding_info": {
+            "original_filename": stored_filename,
+            "mime_type": "application/json",
+            "file_extension": ".notion",
+            "stored_filename": stored_filename,
+            "source_type": "notion",
+            "notion_id": notion_id,
+            "object_type": object_type,
+            "notion_url": notion_url or "",
+            "last_edited_time": last_edited_time or "",
+        },
+        "processing_info": {
+            "created_at": datetime.now().isoformat(),
+            "note": f"Notion {object_type} source created. Processing will fetch content.",
+        },
+    }
+
+    source_index_service.add_source_to_index(project_id, source_metadata)
+
+    _submit_processing_task(project_id, source_id)
+
+    return source_metadata
+
+
+def _submit_processing_task(project_id: str, source_id: str) -> None:
+    """Submit a background task to fetch + embed the Notion content."""
+    try:
+        from app.services.source_services.source_processing import (
+            source_processing_service,
+        )
+        from app.services.source_services import source_service
+
+        task_service.submit_task(
+            "source_processing",
+            source_id,
+            source_processing_service.process_source,
+            project_id,
+            source_id,
+        )
+
+        source_service.update_source(project_id, source_id, status="processing")
+    except Exception as e:
+        logger.error(
+            "Failed to submit Notion processing task for source %s: %s",
+            source_id,
+            e,
+        )

--- a/backend/app/utils/text/page_markers.py
+++ b/backend/app/utils/text/page_markers.py
@@ -32,6 +32,7 @@ SOURCE_TYPES = [
     "LINK",     # Web URL content
     "YOUTUBE",  # YouTube video transcripts
     "RESEARCH", # Research documents
+    "NOTION",   # Notion pages and database rows
 ]
 
 # Human-readable display names for headers
@@ -45,6 +46,7 @@ SOURCE_TYPE_DISPLAY = {
     "LINK": "URL",
     "YOUTUBE": "YouTube video transcript",
     "RESEARCH": "research document",
+    "NOTION": "Notion workspace content",
 }
 
 
@@ -75,7 +77,7 @@ def build_page_marker(source_type: str, page_num: int, total_pages: int) -> str:
 # Captures: group(1) = page number, group(2) = total pages
 # The .*? allows for optional suffixes like "(continues...)"
 ANY_PAGE_PATTERN = re.compile(
-    r'=== (?:PDF|TEXT|DOCX|PPTX|AUDIO|LINK|YOUTUBE|IMAGE|RESEARCH) PAGE (\d+) of (\d+).*?==='
+    r'=== (?:PDF|TEXT|DOCX|PPTX|AUDIO|LINK|YOUTUBE|IMAGE|RESEARCH|NOTION) PAGE (\d+) of (\d+).*?==='
 )
 
 # Type-specific patterns (for when you need to match a specific type)
@@ -89,6 +91,7 @@ PAGE_PATTERNS = {
     "LINK": re.compile(r'=== LINK PAGE (\d+) of (\d+) ==='),
     "YOUTUBE": re.compile(r'=== YOUTUBE PAGE (\d+) of (\d+) ==='),
     "RESEARCH": re.compile(r'=== RESEARCH PAGE (\d+) of (\d+) ==='),
+    "NOTION": re.compile(r'=== NOTION PAGE (\d+) of (\d+) ==='),
 }
 
 

--- a/backend/app/utils/text/processed_output.py
+++ b/backend/app/utils/text/processed_output.py
@@ -53,6 +53,7 @@ SOURCE_METADATA_KEYS = {
     "LINK": ["url", "title", "content_type", "character_count", "token_count"],
     "YOUTUBE": ["url", "video_id", "language", "is_auto_generated", "duration", "segment_count", "character_count", "token_count"],
     "RESEARCH": ["topic", "link_count", "character_count", "token_count"],
+    "NOTION": ["object_type", "notion_url", "last_edited_time", "page_count", "character_count", "token_count"],
 }
 
 

--- a/backend/supabase/migrations/00042_notion_source_type.sql
+++ b/backend/supabase/migrations/00042_notion_source_type.sql
@@ -1,0 +1,32 @@
+-- Notion source type
+--
+-- The original initial_schema constraint only listed the file-based source
+-- types (PDF/DOCX/.../RESEARCH). Subsequent integration sources (DATABASE,
+-- FRESHDESK, JIRA, MIXPANEL, MCP, DATA/CSV) have been added in code without
+-- a constraint update — at this point the constraint is either out-of-sync
+-- or already dropped on production. Drop and re-create with the full set so
+-- the schema actually matches the application contract going forward.
+
+ALTER TABLE sources DROP CONSTRAINT IF EXISTS valid_type;
+
+ALTER TABLE sources ADD CONSTRAINT valid_type CHECK (
+  type IN (
+    -- File-based document sources
+    'PDF', 'DOCX', 'PPTX', 'IMAGE', 'AUDIO', 'TEXT',
+    -- Tabular data sources
+    'CSV', 'DATA',
+    -- Web sources
+    'LINK', 'YOUTUBE',
+    -- AI-generated sources
+    'RESEARCH',
+    -- Integration / live-API sources
+    'DATABASE', 'FRESHDESK', 'JIRA', 'MIXPANEL', 'MCP',
+    -- Notion (this migration)
+    'NOTION'
+  )
+);
+
+COMMENT ON COLUMN sources.type IS
+  'Source type. File: PDF, DOCX, PPTX, IMAGE, AUDIO, TEXT, CSV, DATA. '
+  'Web: LINK, YOUTUBE. AI: RESEARCH. Integrations: DATABASE, FRESHDESK, '
+  'JIRA, MIXPANEL, MCP, NOTION.';

--- a/backend/supabase/migrations/00042_notion_source_type.sql
+++ b/backend/supabase/migrations/00042_notion_source_type.sql
@@ -6,17 +6,28 @@
 -- a constraint update — at this point the constraint is either out-of-sync
 -- or already dropped on production. Drop and re-create with the full set so
 -- the schema actually matches the application contract going forward.
+--
+-- NOTE: file uploads (`file_upload.py`) write `type = category.upper()`
+-- where category comes from ALLOWED_EXTENSIONS in file_utils.py. The
+-- categories are 'document', 'audio', 'image', 'data', 'link' — so PDF /
+-- DOCX / PPTX / TXT / MD / JSON / HTML / XML all hit production with
+-- `type = 'DOCUMENT'`. AI-extraction labels like 'PDF' / 'DOCX' / 'PPTX'
+-- only appear in processed-file headers, not in sources.type. The
+-- constraint MUST include 'DOCUMENT' or it will reject every PDF upload
+-- ever made. Keeping the AI labels in the list too is harmless and means
+-- future code paths can use either convention without breakage.
 
 ALTER TABLE sources DROP CONSTRAINT IF EXISTS valid_type;
 
 ALTER TABLE sources ADD CONSTRAINT valid_type CHECK (
   type IN (
-    -- File-based document sources
-    'PDF', 'DOCX', 'PPTX', 'IMAGE', 'AUDIO', 'TEXT',
-    -- Tabular data sources
-    'CSV', 'DATA',
+    -- File uploads write category.upper() — this is what most prod rows are
+    'DOCUMENT', 'IMAGE', 'AUDIO', 'DATA', 'LINK',
+    -- AI-extraction labels (used by processed-file headers; tolerated in the
+    -- sources.type column as well so the two never have to be reconciled)
+    'PDF', 'DOCX', 'PPTX', 'TEXT', 'CSV',
     -- Web sources
-    'LINK', 'YOUTUBE',
+    'YOUTUBE',
     -- AI-generated sources
     'RESEARCH',
     -- Integration / live-API sources
@@ -27,6 +38,8 @@ ALTER TABLE sources ADD CONSTRAINT valid_type CHECK (
 );
 
 COMMENT ON COLUMN sources.type IS
-  'Source type. File: PDF, DOCX, PPTX, IMAGE, AUDIO, TEXT, CSV, DATA. '
-  'Web: LINK, YOUTUBE. AI: RESEARCH. Integrations: DATABASE, FRESHDESK, '
-  'JIRA, MIXPANEL, MCP, NOTION.';
+  'Source type. File uploads: DOCUMENT, IMAGE, AUDIO, DATA, LINK '
+  '(category.upper() from file_utils.ALLOWED_EXTENSIONS). '
+  'AI-extraction labels: PDF, DOCX, PPTX, TEXT, CSV. Web: YOUTUBE. '
+  'AI-generated: RESEARCH. Integrations: DATABASE, FRESHDESK, JIRA, '
+  'MIXPANEL, MCP, NOTION.';

--- a/backend/supabase/migrations/00043_log_housekeeping_settings.sql
+++ b/backend/supabase/migrations/00043_log_housekeeping_settings.sql
@@ -1,0 +1,19 @@
+-- Global app-settings row for the log housekeeping scheduler.
+--
+-- Single-row table guarded by a CHECK on a boolean PK so we never end up
+-- with multiple rows competing for "the global config." The scheduler
+-- reads this every tick; the admin toggle in Settings → Logs writes to it.
+
+CREATE TABLE IF NOT EXISTS app_settings (
+  id BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id = TRUE),
+  log_housekeeping JSONB NOT NULL
+    DEFAULT '{"weekly_clear_enabled": true, "last_run_at": null}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO app_settings (id) VALUES (TRUE) ON CONFLICT DO NOTHING;
+
+COMMENT ON TABLE app_settings IS
+  'Single-row global app settings. Currently holds log housekeeping flags '
+  '(weekly_clear_enabled, last_run_at). Add new JSONB columns here for '
+  'future global toggles.';

--- a/backend/tests/test_log_housekeeping.py
+++ b/backend/tests/test_log_housekeeping.py
@@ -1,0 +1,229 @@
+"""
+Tests for the log download / housekeeping feature:
+- user_service.set_settings_key merges into the existing settings JSONB.
+- log_service.clear_logs truncates the active file and removes archives.
+- LogHousekeepingScheduler.tick is idempotent within the 7-day window and
+  respects the weekly_clear_enabled flag.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Importing the user_service module pulls in supabase auth; provide
+# safe placeholders before app imports (mirrors test_notion_source.py).
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault(
+    "SUPABASE_SERVICE_KEY",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoidGVzdCJ9.test",
+)
+
+import importlib
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# user_service.set_settings_key
+# ---------------------------------------------------------------------------
+
+
+def test_set_settings_key_merges_preserving_other_keys(monkeypatch):
+    user_module = importlib.import_module(
+        "app.services.data_services.user_service"
+    )
+
+    svc = user_module.UserService.__new__(user_module.UserService)
+    svc.table = "users"
+    svc.supabase = MagicMock()
+
+    # Existing settings already hold a spending-config field; we must NOT lose it.
+    monkeypatch.setattr(
+        svc,
+        "get_user_settings_raw",
+        lambda user_id: {"cost_limit": 25.0, "reset_frequency": "weekly"},
+    )
+
+    captured = {}
+
+    def fake_save(user_id, settings):
+        captured["user_id"] = user_id
+        captured["settings"] = settings
+        return True
+
+    monkeypatch.setattr(svc, "save_user_settings", fake_save)
+
+    ok = svc.set_settings_key("u1", "auto_delete_logs_on_download", True)
+    assert ok is True
+    assert captured["user_id"] == "u1"
+    assert captured["settings"] == {
+        "cost_limit": 25.0,
+        "reset_frequency": "weekly",
+        "auto_delete_logs_on_download": True,
+    }
+
+
+def test_set_settings_key_noop_when_unchanged(monkeypatch):
+    user_module = importlib.import_module(
+        "app.services.data_services.user_service"
+    )
+    svc = user_module.UserService.__new__(user_module.UserService)
+    svc.table = "users"
+    svc.supabase = MagicMock()
+
+    monkeypatch.setattr(
+        svc,
+        "get_user_settings_raw",
+        lambda user_id: {"auto_delete_logs_on_download": True},
+    )
+    # save_user_settings must not be called for an idempotent toggle.
+    called = {"n": 0}
+
+    def fake_save(user_id, settings):
+        called["n"] += 1
+        return True
+
+    monkeypatch.setattr(svc, "save_user_settings", fake_save)
+
+    assert svc.set_settings_key("u1", "auto_delete_logs_on_download", True) is True
+    assert called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# log_service.clear_logs
+# ---------------------------------------------------------------------------
+
+
+def test_clear_logs_truncates_and_removes_archives(tmp_path, monkeypatch):
+    log_module = importlib.import_module("app.utils.logger")
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    active = log_dir / "backend.log"
+    active.write_text("hello world", encoding="utf-8")
+    (log_dir / "backend.log.1").write_text("archive1", encoding="utf-8")
+    (log_dir / "backend.log.2").write_text("archive2", encoding="utf-8")
+
+    monkeypatch.setattr(log_module, "LOG_DIR", log_dir)
+    monkeypatch.setattr(log_module, "LOG_FILE", active)
+
+    log_service = importlib.import_module("app.services.log_service")
+    result = log_service.clear_logs(initiator="pytest")
+    assert result["success"] is True
+    assert result["cleared"] == 3
+    assert active.read_text() == ""
+    assert not (log_dir / "backend.log.1").exists()
+    assert not (log_dir / "backend.log.2").exists()
+
+
+def test_clear_logs_handles_missing_log_file(monkeypatch):
+    log_module = importlib.import_module("app.utils.logger")
+    monkeypatch.setattr(log_module, "LOG_FILE", None)
+    log_service = importlib.import_module("app.services.log_service")
+    result = log_service.clear_logs(initiator="pytest")
+    assert result == {"success": True, "cleared": 0, "message": "no log file"}
+
+
+# ---------------------------------------------------------------------------
+# LogHousekeepingScheduler.tick
+# ---------------------------------------------------------------------------
+
+
+def _import_scheduler():
+    return importlib.import_module(
+        "app.services.background_services.log_housekeeping_scheduler"
+    )
+
+
+def test_tick_no_op_when_weekly_disabled(monkeypatch):
+    sched = _import_scheduler()
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": False, "last_run_at": None},
+    )
+    cleared = {"called": False}
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: cleared.update(called=True) or {"success": True})
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is False
+    assert result["reason"] == "weekly_clear_enabled=false"
+    assert cleared["called"] is False
+
+
+def test_tick_runs_when_never_run_before(monkeypatch):
+    sched = _import_scheduler()
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": None},
+    )
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: True)
+    called = {"n": 0}
+
+    def fake_clear(initiator="?"):
+        called["n"] += 1
+        return {"success": True, "cleared": 4}
+
+    monkeypatch.setattr(sched, "clear_logs", fake_clear)
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is True
+    assert result["cleared"] == 4
+    assert called["n"] == 1
+
+
+def test_tick_idempotent_within_week(monkeypatch):
+    sched = _import_scheduler()
+    recent = (datetime.now(timezone.utc) - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": recent},
+    )
+    called = {"n": 0}
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True})
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is False
+    assert result["reason"] == "not yet due"
+    assert called["n"] == 0
+
+
+def test_tick_runs_when_older_than_seven_days(monkeypatch):
+    sched = _import_scheduler()
+    stale = (datetime.now(timezone.utc) - timedelta(days=8)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": stale},
+    )
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: True)
+    called = {"n": 0}
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True, "cleared": 2})
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is True
+    assert called["n"] == 1
+
+
+def test_tick_skips_when_update_race_lost(monkeypatch):
+    """If another worker bumps last_run_at between read and write, we must
+    not double-clear."""
+    sched = _import_scheduler()
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": None},
+    )
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: False)
+    called = {"n": 0}
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True})
+
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result["ran"] is False
+    assert result["reason"] == "lost race"
+    assert called["n"] == 0
+
+
+def test_tick_returns_no_config_when_row_missing(monkeypatch):
+    sched = _import_scheduler()
+    monkeypatch.setattr(sched, "_read_housekeeping_row", lambda: None)
+    result = sched.LogHousekeepingScheduler().tick()
+    assert result == {"ran": False, "reason": "no app_settings row"}

--- a/backend/tests/test_log_housekeeping.py
+++ b/backend/tests/test_log_housekeeping.py
@@ -157,7 +157,7 @@ def test_tick_runs_when_never_run_before(monkeypatch):
         sched, "_read_housekeeping_row",
         lambda: {"weekly_clear_enabled": True, "last_run_at": None},
     )
-    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: True)
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new, enabled: True)
     called = {"n": 0}
 
     def fake_clear(initiator="?"):
@@ -195,7 +195,7 @@ def test_tick_runs_when_older_than_seven_days(monkeypatch):
         sched, "_read_housekeeping_row",
         lambda: {"weekly_clear_enabled": True, "last_run_at": stale},
     )
-    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: True)
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new, enabled: True)
     called = {"n": 0}
     monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True, "cleared": 2})
 
@@ -212,7 +212,7 @@ def test_tick_skips_when_update_race_lost(monkeypatch):
         sched, "_read_housekeeping_row",
         lambda: {"weekly_clear_enabled": True, "last_run_at": None},
     )
-    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new: False)
+    monkeypatch.setattr(sched, "_try_update_last_run", lambda prev, new, enabled: False)
     called = {"n": 0}
     monkeypatch.setattr(sched, "clear_logs", lambda **kw: called.update(n=called["n"] + 1) or {"success": True})
 
@@ -220,6 +220,31 @@ def test_tick_skips_when_update_race_lost(monkeypatch):
     assert result["ran"] is False
     assert result["reason"] == "lost race"
     assert called["n"] == 0
+
+
+def test_tick_passes_observed_enabled_to_update(monkeypatch):
+    """Regression: the UPDATE used to hardcode weekly_clear_enabled=True,
+    silently re-enabling the toggle if an admin disabled it between read
+    and write. tick() must thread the observed value through."""
+    sched = _import_scheduler()
+    monkeypatch.setattr(
+        sched, "_read_housekeeping_row",
+        lambda: {"weekly_clear_enabled": True, "last_run_at": None},
+    )
+    captured = {}
+
+    def fake_update(prev, new, enabled):
+        captured["prev"] = prev
+        captured["new"] = new
+        captured["enabled"] = enabled
+        return True
+
+    monkeypatch.setattr(sched, "_try_update_last_run", fake_update)
+    monkeypatch.setattr(sched, "clear_logs", lambda **kw: {"success": True, "cleared": 0})
+
+    sched.LogHousekeepingScheduler().tick()
+    assert captured["enabled"] is True
+    assert captured["prev"] is None
 
 
 def test_tick_returns_no_config_when_row_missing(monkeypatch):

--- a/backend/tests/test_notion_source.py
+++ b/backend/tests/test_notion_source.py
@@ -1,0 +1,377 @@
+"""
+Tests for the Notion source integration: service-level recursion + pagination,
+upload stub creation, and the processor's page/database flows.
+
+These tests stub out the Notion HTTP layer (_make_request) and the embedding /
+summary / storage pipeline so we exercise the wiring without external calls.
+"""
+from __future__ import annotations
+
+import os
+
+# Importing source_services pulls in supabase auth_service, which constructs
+# a dedicated client at import time and refuses to load without these env vars
+# being set. Provide harmless placeholders before any app imports happen.
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+# supabase-py validates the key looks like a JWT (3 base64ish segments). Any
+# well-formed placeholder will do — we never actually call the real client.
+os.environ.setdefault(
+    "SUPABASE_SERVICE_KEY",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoidGVzdCJ9.test",
+)
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# notion_service: recursion + block rendering + pagination
+# ---------------------------------------------------------------------------
+
+
+def _make_block(block_type: str, text: str = "", has_children: bool = False, block_id: str = "b1", extra=None) -> dict:
+    body = {"rich_text": [{"plain_text": text}]}
+    if extra:
+        body.update(extra)
+    return {
+        "id": block_id,
+        "type": block_type,
+        block_type: body,
+        "has_children": has_children,
+    }
+
+
+def test_get_page_recurses_into_toggle_children(monkeypatch):
+    """A toggle with nested children should surface those children in content."""
+    # The package's __init__.py rebinds the `notion_service` attribute to the
+    # singleton, masking the submodule for plain `import … as` resolution.
+    # Use importlib to get the actual module object so we can instantiate
+    # NotionService directly in tests.
+    import importlib
+    ns_module = importlib.import_module(
+        "app.services.integrations.knowledge_bases.notion.notion_service"
+    )
+    svc = ns_module.NotionService()
+    svc._configured = True
+    svc._api_key = "test"
+
+    page_meta = {
+        "id": "page-1",
+        "url": "https://notion.so/page-1",
+        "created_time": "2026-05-01T00:00:00.000Z",
+        "last_edited_time": "2026-05-02T00:00:00.000Z",
+        "properties": {
+            "Name": {"type": "title", "title": [{"plain_text": "My Page"}]},
+        },
+    }
+    parent_children = {
+        "results": [
+            _make_block("paragraph", "Hello world", block_id="b1"),
+            _make_block("toggle", "Outer", has_children=True, block_id="toggle-1"),
+        ],
+        "has_more": False,
+    }
+    toggle_children = {
+        "results": [
+            _make_block("paragraph", "Inside the toggle", block_id="b2"),
+        ],
+        "has_more": False,
+    }
+
+    def fake_request(endpoint, method="GET", json_data=None):
+        if endpoint.startswith("pages/page-1"):
+            return {"success": True, "data": page_meta}
+        if endpoint.startswith("blocks/page-1/children"):
+            return {"success": True, "data": parent_children}
+        if endpoint.startswith("blocks/toggle-1/children"):
+            return {"success": True, "data": toggle_children}
+        raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+    monkeypatch.setattr(svc, "_make_request", fake_request)
+
+    result = svc.get_page("page-1")
+    assert result["success"], result
+    content = result["page"]["content"]
+    assert "Hello world" in content
+    # Toggle marker + nested paragraph (indented one level)
+    assert "Outer" in content
+    assert "Inside the toggle" in content
+    assert result["page"]["title"] == "My Page"
+
+
+def test_get_page_respects_recursion_cap(monkeypatch):
+    """Recursion must stop at MAX_RECURSION_DEPTH so circular pages don't run away."""
+    # The package's __init__.py rebinds the `notion_service` attribute to the
+    # singleton, masking the submodule for plain `import … as` resolution.
+    # Use importlib to get the actual module object so we can instantiate
+    # NotionService directly in tests.
+    import importlib
+    ns_module = importlib.import_module(
+        "app.services.integrations.knowledge_bases.notion.notion_service"
+    )
+    svc = ns_module.NotionService()
+    svc._configured = True
+    svc._api_key = "test"
+
+    page_meta = {"id": "p", "properties": {}}
+
+    def fake_request(endpoint, method="GET", json_data=None):
+        if endpoint.startswith("pages/p"):
+            return {"success": True, "data": page_meta}
+        # Every block has a child of itself (depth-1 child).
+        return {
+            "success": True,
+            "data": {
+                "results": [_make_block("paragraph", "x", has_children=True, block_id="child")],
+                "has_more": False,
+            },
+        }
+
+    monkeypatch.setattr(svc, "_make_request", fake_request)
+    result = svc.get_page("p")
+    assert result["success"]
+    # MAX_RECURSION_DEPTH=5 → top-level call (depth=0) plus 5 recursive layers,
+    # each emitting one paragraph block.
+    assert result["page"]["block_count"] <= ns_module.MAX_RECURSION_DEPTH + 1
+
+
+def test_query_database_paginates(monkeypatch):
+    """query_database should follow has_more / next_cursor until exhausted."""
+    # The package's __init__.py rebinds the `notion_service` attribute to the
+    # singleton, masking the submodule for plain `import … as` resolution.
+    # Use importlib to get the actual module object so we can instantiate
+    # NotionService directly in tests.
+    import importlib
+    ns_module = importlib.import_module(
+        "app.services.integrations.knowledge_bases.notion.notion_service"
+    )
+    svc = ns_module.NotionService()
+    svc._configured = True
+    svc._api_key = "test"
+
+    pages = [
+        {
+            "results": [{"id": f"row-{i}", "properties": {}} for i in range(2)],
+            "has_more": True,
+            "next_cursor": "cursor-1",
+        },
+        {
+            "results": [{"id": f"row-{i+2}", "properties": {}} for i in range(2)],
+            "has_more": True,
+            "next_cursor": "cursor-2",
+        },
+        {
+            "results": [{"id": "row-4", "properties": {}}],
+            "has_more": False,
+        },
+    ]
+    calls = {"i": 0}
+
+    def fake_request(endpoint, method="GET", json_data=None):
+        i = calls["i"]
+        calls["i"] += 1
+        return {"success": True, "data": pages[i]}
+
+    monkeypatch.setattr(svc, "_make_request", fake_request)
+    result = svc.query_database("db-1")
+    assert result["success"]
+    ids = [r["id"] for r in result["results"]]
+    assert ids == ["row-0", "row-1", "row-2", "row-3", "row-4"]
+
+
+# ---------------------------------------------------------------------------
+# notion_upload: stub creation
+# ---------------------------------------------------------------------------
+
+
+def test_add_notion_source_creates_stub(monkeypatch):
+    from app.services.source_services.source_upload import notion_upload
+
+    # Pretend Notion is configured
+    monkeypatch.setattr(notion_upload.notion_service, "is_configured", lambda: True)
+    # Capture the bytes uploaded as raw file
+    captured = {}
+
+    def fake_upload_raw(project_id, source_id, filename, file_data, content_type=None):
+        captured["filename"] = filename
+        captured["file_data"] = file_data
+        return f"raw/{project_id}/{source_id}/{filename}"
+
+    monkeypatch.setattr(notion_upload.storage_service, "upload_raw_file", fake_upload_raw)
+    monkeypatch.setattr(
+        notion_upload.source_index_service, "add_source_to_index", lambda *a, **k: None
+    )
+    # Don't actually queue work
+    monkeypatch.setattr(notion_upload, "_submit_processing_task", lambda *a, **k: None)
+
+    result = notion_upload.add_notion_source(
+        project_id="proj-1",
+        notion_id="notion-page-1",
+        object_type="page",
+        title="My Page",
+        notion_url="https://notion.so/My-Page",
+        last_edited_time="2026-05-19T00:00:00Z",
+    )
+
+    assert result["type"] == "NOTION"
+    assert result["status"] == "uploaded"
+    assert result["embedding_info"]["notion_id"] == "notion-page-1"
+    assert result["embedding_info"]["object_type"] == "page"
+    assert result["embedding_info"]["file_extension"] == ".notion"
+    # Stub bytes are JSON with the right keys
+    stub = json.loads(captured["file_data"].decode("utf-8"))
+    assert stub["notion_id"] == "notion-page-1"
+    assert stub["object_type"] == "page"
+
+
+def test_add_notion_source_rejects_invalid_object_type(monkeypatch):
+    from app.services.source_services.source_upload import notion_upload
+    monkeypatch.setattr(notion_upload.notion_service, "is_configured", lambda: True)
+    with pytest.raises(ValueError, match="object_type"):
+        notion_upload.add_notion_source(
+            project_id="p", notion_id="n", object_type="block"
+        )
+
+
+def test_add_notion_source_requires_configured(monkeypatch):
+    from app.services.source_services.source_upload import notion_upload
+    monkeypatch.setattr(notion_upload.notion_service, "is_configured", lambda: False)
+    with pytest.raises(ValueError, match="Notion not configured"):
+        notion_upload.add_notion_source(
+            project_id="p", notion_id="n", object_type="page"
+        )
+
+
+# ---------------------------------------------------------------------------
+# notion_processor: page + database flows
+# ---------------------------------------------------------------------------
+
+
+def _write_stub(tmp_path: Path, notion_id: str, object_type: str) -> Path:
+    path = tmp_path / f"{notion_id}.notion"
+    path.write_text(json.dumps({
+        "kind": "notion_source",
+        "notion_id": notion_id,
+        "object_type": object_type,
+        "title": "T",
+        "notion_url": "https://notion.so/T",
+        "last_edited_time": "2026-05-01T00:00:00Z",
+    }))
+    return path
+
+
+def _patch_processor_pipeline(monkeypatch):
+    """Stub out storage / embedding / summary / cancellation so the processor
+    only exercises its own logic."""
+    from app.services.source_services.source_processing import notion_processor as np_module
+
+    monkeypatch.setattr(np_module.notion_service, "is_configured", lambda: True)
+    monkeypatch.setattr(np_module.task_service, "is_target_cancelled", lambda _id: False)
+    monkeypatch.setattr(
+        np_module.storage_service, "upload_processed_file",
+        lambda **kwargs: f"processed/{kwargs['source_id']}.txt",
+    )
+    monkeypatch.setattr(
+        np_module.embedding_service, "process_embeddings",
+        lambda **kwargs: {"is_embedded": True, "chunk_count": 3, "token_count": 100},
+    )
+    monkeypatch.setattr(
+        np_module.summary_service, "generate_summary",
+        lambda **kwargs: {"summary": "ok"},
+    )
+    return np_module
+
+
+def test_process_notion_page(tmp_path, monkeypatch):
+    np_module = _patch_processor_pipeline(monkeypatch)
+
+    monkeypatch.setattr(np_module.notion_service, "get_page", lambda nid: {
+        "success": True,
+        "page": {
+            "id": nid,
+            "title": "My Page",
+            "url": "https://notion.so/My-Page",
+            "last_edited_time": "2026-05-02T00:00:00Z",
+            "content": "Hello world\n\n## Section\n\nMore",
+            "block_count": 3,
+        },
+    })
+
+    source_service = MagicMock()
+    raw_path = _write_stub(tmp_path, "page-1", "page")
+    result = np_module.process_notion(
+        project_id="proj-1",
+        source_id="src-1",
+        source={"id": "src-1", "name": "My Page"},
+        raw_file_path=raw_path,
+        source_service=source_service,
+    )
+
+    assert result["success"], result
+    assert result["status"] == "ready"
+    # Final update_source call must include status=ready
+    final_call = source_service.update_source.call_args_list[-1]
+    assert final_call.kwargs.get("status") == "ready"
+
+
+def test_process_notion_database(tmp_path, monkeypatch):
+    np_module = _patch_processor_pipeline(monkeypatch)
+
+    monkeypatch.setattr(np_module.notion_service, "get_database", lambda nid: {
+        "success": True,
+        "database": {
+            "id": nid,
+            "title": "Tasks",
+            "url": "https://notion.so/Tasks",
+            "last_edited_time": "2026-05-03T00:00:00Z",
+            "schema": {"Name": {"type": "title"}, "Status": {"type": "select"}},
+        },
+    })
+    monkeypatch.setattr(np_module.notion_service, "query_database", lambda nid, **kw: {
+        "success": True,
+        "results": [
+            {"id": "row-1", "properties": {"Name": "Task 1", "Status": "Open"}},
+            {"id": "row-2", "properties": {"Name": "Task 2", "Status": "Done"}},
+        ],
+    })
+    monkeypatch.setattr(np_module.notion_service, "get_page", lambda nid: {
+        "success": True,
+        "page": {"id": nid, "title": "row body", "content": "Row body for " + nid},
+    })
+
+    source_service = MagicMock()
+    raw_path = _write_stub(tmp_path, "db-1", "database")
+    result = np_module.process_notion(
+        project_id="proj-1",
+        source_id="src-2",
+        source={"id": "src-2", "name": "Tasks"},
+        raw_file_path=raw_path,
+        source_service=source_service,
+    )
+
+    assert result["success"], result
+    # 1 overview + 2 row pages
+    final_call = source_service.update_source.call_args_list[-1]
+    pi = final_call.kwargs.get("processing_info", {})
+    assert pi.get("total_pages") == 3
+
+
+def test_process_notion_invalid_stub(tmp_path, monkeypatch):
+    np_module = _patch_processor_pipeline(monkeypatch)
+
+    bad = tmp_path / "bad.notion"
+    bad.write_text(json.dumps({"kind": "notion_source"}))  # missing notion_id
+
+    source_service = MagicMock()
+    result = np_module.process_notion(
+        project_id="p",
+        source_id="s",
+        source={"id": "s"},
+        raw_file_path=bad,
+        source_service=source_service,
+    )
+    assert not result["success"]
+    source_service.update_source.assert_called()

--- a/backend/tests/test_notion_source.py
+++ b/backend/tests/test_notion_source.py
@@ -333,8 +333,10 @@ def test_process_notion_database(tmp_path, monkeypatch):
     monkeypatch.setattr(np_module.notion_service, "query_database", lambda nid, **kw: {
         "success": True,
         "results": [
-            {"id": "row-1", "properties": {"Name": "Task 1", "Status": "Open"}},
-            {"id": "row-2", "properties": {"Name": "Task 2", "Status": "Done"}},
+            {"id": "row-1", "title": "Task 1",
+             "properties": {"Name": "Task 1", "Status": "Open"}},
+            {"id": "row-2", "title": "Task 2",
+             "properties": {"Name": "Task 2", "Status": "Done"}},
         ],
     })
     monkeypatch.setattr(np_module.notion_service, "get_page", lambda nid: {
@@ -357,6 +359,97 @@ def test_process_notion_database(tmp_path, monkeypatch):
     final_call = source_service.update_source.call_args_list[-1]
     pi = final_call.kwargs.get("processing_info", {})
     assert pi.get("total_pages") == 3
+
+
+def test_query_database_extracts_title_from_title_property(monkeypatch):
+    """The row's title must come from the title-type property, not from
+    whichever string-valued property happens to come first."""
+    import importlib
+    ns_module = importlib.import_module(
+        "app.services.integrations.knowledge_bases.notion.notion_service"
+    )
+    svc = ns_module.NotionService()
+    svc._configured = True
+    svc._api_key = "test"
+
+    # A row where a URL column comes BEFORE the title column in property order
+    # — the formatted props would otherwise collapse to indistinguishable
+    # strings and the URL would get promoted as the row heading.
+    row = {
+        "id": "row-1",
+        "properties": {
+            "Link": {"type": "url", "url": "https://example.com"},
+            "Name": {"type": "title", "title": [{"plain_text": "Real Title"}]},
+            "Status": {"type": "select", "select": {"name": "Open"}},
+        },
+    }
+    monkeypatch.setattr(svc, "_make_request", lambda *a, **kw: {
+        "success": True,
+        "data": {"results": [row], "has_more": False},
+    })
+
+    result = svc.query_database("db-1")
+    assert result["success"]
+    assert result["results"][0]["title"] == "Real Title"
+
+
+def test_query_database_early_exits_at_limit(monkeypatch):
+    """Pagination must stop once `limit` rows are collected — no over-fetching."""
+    import importlib
+    ns_module = importlib.import_module(
+        "app.services.integrations.knowledge_bases.notion.notion_service"
+    )
+    svc = ns_module.NotionService()
+    svc._configured = True
+    svc._api_key = "test"
+
+    calls = {"n": 0}
+
+    def fake_request(endpoint, method="GET", json_data=None):
+        calls["n"] += 1
+        # Each page returns 50 rows and claims there's more — but the caller
+        # asked for limit=50, so the loop must break after the first page.
+        return {
+            "success": True,
+            "data": {
+                "results": [
+                    {"id": f"row-{i}", "title": "t", "properties": {}}
+                    for i in range(50)
+                ],
+                "has_more": True,
+                "next_cursor": "cursor-x",
+            },
+        }
+
+    monkeypatch.setattr(svc, "_make_request", fake_request)
+    result = svc.query_database("db-1", limit=50)
+    assert result["success"]
+    assert len(result["results"]) == 50
+    assert calls["n"] == 1, "should not have requested a second page"
+
+
+def test_format_db_row_uses_title_field(monkeypatch):
+    """_format_db_row should honour the explicit `title` field, even if a
+    different string-valued property comes earlier."""
+    from app.services.source_services.source_processing.notion_processor import (
+        _format_db_row,
+    )
+    row = {
+        "id": "r",
+        "title": "Real Title",
+        "properties": {
+            "Link": "https://example.com",
+            "Name": "Real Title",
+            "Status": "Open",
+        },
+    }
+    rendered = _format_db_row(row, row_body="Body text")
+    assert rendered.startswith("# Real Title")
+    # The title property itself should not appear twice.
+    assert rendered.count("Real Title") == 1
+    # Other props should still be listed.
+    assert "Link" in rendered and "https://example.com" in rendered
+    assert "Status" in rendered and "Open" in rendered
 
 
 def test_process_notion_invalid_stub(tmp_path, monkeypatch):

--- a/frontend/src/components/project/DownloadLogsConfirmDialog.tsx
+++ b/frontend/src/components/project/DownloadLogsConfirmDialog.tsx
@@ -1,0 +1,78 @@
+/**
+ * DownloadLogsConfirmDialog — confirmation dialog shown before the
+ * support-bundle download starts.
+ *
+ * The dialog has one extra control beyond Cancel/Download: a checkbox
+ * labelled "Delete logs from server after download". `useLogsState`
+ * owns the checkbox value (so it can be remembered across opens via
+ * users.settings.auto_delete_on_download) and triggers the clear after
+ * the download has begun.
+ */
+import React from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog';
+import { Checkbox } from '../ui/checkbox';
+import { Download } from '@phosphor-icons/react';
+
+interface DownloadLogsConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  deleteAfterDownload: boolean;
+  onDeleteAfterDownloadChange: (next: boolean) => void;
+  onConfirm: () => void;
+}
+
+export const DownloadLogsConfirmDialog: React.FC<DownloadLogsConfirmDialogProps> = ({
+  open,
+  onOpenChange,
+  deleteAfterDownload,
+  onDeleteAfterDownloadChange,
+  onConfirm,
+}) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Download log bundle</AlertDialogTitle>
+          <AlertDialogDescription>
+            The ZIP includes the rotating <code>backend.log</code> files
+            (secrets redacted), the list of configured env-var names,
+            applied migrations, and basic deployment metadata.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <label className="flex items-start gap-3 rounded-md border border-stone-200 bg-stone-50 px-3 py-3 cursor-pointer">
+          <Checkbox
+            checked={deleteAfterDownload}
+            onCheckedChange={(value) => onDeleteAfterDownloadChange(value === true)}
+            className="mt-0.5"
+          />
+          <span className="text-sm leading-snug text-stone-700">
+            <span className="font-medium text-stone-900 block">
+              Delete logs from server after download
+            </span>
+            Frees disk space on the deployment. The bundle in your downloads
+            folder is your only copy after this. Your choice is remembered
+            for next time.
+          </span>
+        </label>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            <Download size={16} className="mr-2" />
+            Download
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/frontend/src/components/project/DownloadLogsConfirmDialog.tsx
+++ b/frontend/src/components/project/DownloadLogsConfirmDialog.tsx
@@ -28,6 +28,10 @@ interface DownloadLogsConfirmDialogProps {
   deleteAfterDownload: boolean;
   onDeleteAfterDownloadChange: (next: boolean) => void;
   onConfirm: () => void;
+  /** When false, the "delete after download" checkbox is hidden. The
+   * `/logs/clear` endpoint is admin-only, so non-admins should never
+   * see (and certainly never check) this destructive option. */
+  canDelete?: boolean;
 }
 
 export const DownloadLogsConfirmDialog: React.FC<DownloadLogsConfirmDialogProps> = ({
@@ -36,6 +40,7 @@ export const DownloadLogsConfirmDialog: React.FC<DownloadLogsConfirmDialogProps>
   deleteAfterDownload,
   onDeleteAfterDownloadChange,
   onConfirm,
+  canDelete = true,
 }) => {
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -49,21 +54,23 @@ export const DownloadLogsConfirmDialog: React.FC<DownloadLogsConfirmDialogProps>
           </AlertDialogDescription>
         </AlertDialogHeader>
 
-        <label className="flex items-start gap-3 rounded-md border border-stone-200 bg-stone-50 px-3 py-3 cursor-pointer">
-          <Checkbox
-            checked={deleteAfterDownload}
-            onCheckedChange={(value) => onDeleteAfterDownloadChange(value === true)}
-            className="mt-0.5"
-          />
-          <span className="text-sm leading-snug text-stone-700">
-            <span className="font-medium text-stone-900 block">
-              Delete logs from server after download
+        {canDelete && (
+          <label className="flex items-start gap-3 rounded-md border border-stone-200 bg-stone-50 px-3 py-3 cursor-pointer">
+            <Checkbox
+              checked={deleteAfterDownload}
+              onCheckedChange={(value) => onDeleteAfterDownloadChange(value === true)}
+              className="mt-0.5"
+            />
+            <span className="text-sm leading-snug text-stone-700">
+              <span className="font-medium text-stone-900 block">
+                Delete logs from server after download
+              </span>
+              Frees disk space on the deployment. The bundle in your downloads
+              folder is your only copy after this. Your choice is remembered
+              for next time.
             </span>
-            Frees disk space on the deployment. The bundle in your downloads
-            folder is your only copy after this. Your choice is remembered
-            for next time.
-          </span>
-        </label>
+          </label>
+        )}
 
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>

--- a/frontend/src/components/project/LogsModal.tsx
+++ b/frontend/src/components/project/LogsModal.tsx
@@ -81,6 +81,7 @@ export const LogsModal: React.FC<LogsModalProps> = ({ open, onOpenChange, canCle
           deleteAfterDownload={state.deleteAfterDownload}
           onDeleteAfterDownloadChange={state.setDeleteAfterDownload}
           onConfirm={state.confirmDownload}
+          canDelete={state.canDeleteLogs}
         />
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/project/LogsModal.tsx
+++ b/frontend/src/components/project/LogsModal.tsx
@@ -26,6 +26,7 @@ import { Bug } from '@phosphor-icons/react';
 import { ToastContainer } from '../ui/toast';
 import { LogConsole } from './LogConsole';
 import { useLogsState } from './useLogsState';
+import { DownloadLogsConfirmDialog } from './DownloadLogsConfirmDialog';
 
 interface LogsModalProps {
   open: boolean;
@@ -73,6 +74,14 @@ export const LogsModal: React.FC<LogsModalProps> = ({ open, onOpenChange, canCle
         </div>
 
         <ToastContainer toasts={state.toasts} onDismiss={state.dismissToast} />
+
+        <DownloadLogsConfirmDialog
+          open={state.downloadDialogOpen}
+          onOpenChange={state.setDownloadDialogOpen}
+          deleteAfterDownload={state.deleteAfterDownload}
+          onDeleteAfterDownloadChange={state.setDeleteAfterDownload}
+          onConfirm={state.confirmDownload}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/project/useLogsState.ts
+++ b/frontend/src/components/project/useLogsState.ts
@@ -161,7 +161,7 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
         }
       }, 1500);
     }
-  }, [deleteAfterDownload, loadLines, success, error]);
+  }, [canDeleteLogs, deleteAfterDownload, loadLines, success, error]);
 
   const handleClear = useCallback(async () => {
     if (!confirmingClear) {

--- a/frontend/src/components/project/useLogsState.ts
+++ b/frontend/src/components/project/useLogsState.ts
@@ -9,7 +9,7 @@
  * The two callers differ only in chrome (Dialog vs settings page
  * layout) — every interaction is delegated here.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { logsAPI, type LogLine } from '@/lib/api/logs';
 import { copyToClipboard } from '@/lib/clipboard';
 import { useToast } from '@/components/ui/use-toast';
@@ -38,6 +38,13 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
   const [logFilePresent, setLogFilePresent] = useState(true);
   const [confirmingClear, setConfirmingClear] = useState(false);
 
+  // Download-bundle confirmation dialog state. Lives in this hook (not
+  // in LogsModal/LogsSection) so both surfaces share the same flow.
+  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const [deleteAfterDownload, setDeleteAfterDownload] = useState(false);
+  // Snapshot of the persisted value so we only PUT when the user changed it.
+  const persistedDeleteAfterDownload = useRef<boolean>(false);
+
   const loadLines = useCallback(async () => {
     setLoading(true);
     try {
@@ -58,6 +65,28 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     loadLines();
   }, [active, loadLines]);
 
+  // Load the user's "auto-delete on download" preference once the
+  // surface activates so the checkbox is pre-set the first time the
+  // download dialog opens.
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const prefs = await logsAPI.getPreferences();
+        if (cancelled) return;
+        persistedDeleteAfterDownload.current = prefs.auto_delete_on_download;
+        setDeleteAfterDownload(prefs.auto_delete_on_download);
+      } catch (e) {
+        // Non-fatal — checkbox just stays unchecked.
+        log.warn({ err: e }, 'failed to load log preferences');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [active]);
+
   const formatLines = useMemo(
     () =>
       lines
@@ -76,14 +105,52 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     else error('Could not copy. Select the text manually.');
   }, [lines, formatLines, success, error]);
 
+  /**
+   * Open the download confirmation dialog instead of starting the
+   * download immediately. The actual download + (optional) clear runs in
+   * `confirmDownload` once the user clicks the dialog's Download button.
+   */
   const handleDownload = useCallback(() => {
-    // Browser download via anchor; getAuthUrl puts the JWT in the query
-    // string because <a download> can't set Authorization headers.
+    setDownloadDialogOpen(true);
+  }, []);
+
+  const confirmDownload = useCallback(async () => {
+    setDownloadDialogOpen(false);
+
+    // Start the browser download via anchor (JWT in the query string).
     const a = document.createElement('a');
     a.href = logsAPI.bundleUrl();
     a.rel = 'noopener';
     a.click();
-  }, []);
+
+    // Persist the checkbox state if it changed. Fire-and-forget — a
+    // preference write failure shouldn't block the bundle download.
+    if (deleteAfterDownload !== persistedDeleteAfterDownload.current) {
+      logsAPI
+        .setPreferences({ auto_delete_on_download: deleteAfterDownload })
+        .then(() => {
+          persistedDeleteAfterDownload.current = deleteAfterDownload;
+        })
+        .catch((e) => {
+          log.warn({ err: e }, 'failed to persist log preference');
+        });
+    }
+
+    // If the user opted in, wait briefly so the browser has time to
+    // begin streaming the ZIP, then clear the server-side logs.
+    if (deleteAfterDownload) {
+      window.setTimeout(async () => {
+        try {
+          await logsAPI.clear();
+          success('Logs cleared from server');
+          await loadLines();
+        } catch (e) {
+          log.error({ err: e }, 'failed to clear logs after download');
+          error('Could not clear logs after download');
+        }
+      }, 1500);
+    }
+  }, [deleteAfterDownload, loadLines, success, error]);
 
   const handleClear = useCallback(async () => {
     if (!confirmingClear) {
@@ -117,6 +184,12 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     handleCopy,
     handleDownload,
     handleClear,
+    // Download confirmation dialog state.
+    downloadDialogOpen,
+    setDownloadDialogOpen,
+    deleteAfterDownload,
+    setDeleteAfterDownload,
+    confirmDownload,
     // Toast plumbing — the consumer mounts <ToastContainer /> with these.
     toasts,
     dismissToast,

--- a/frontend/src/components/project/useLogsState.ts
+++ b/frontend/src/components/project/useLogsState.ts
@@ -14,6 +14,7 @@ import { logsAPI, type LogLine } from '@/lib/api/logs';
 import { copyToClipboard } from '@/lib/clipboard';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { getAdminMode } from '@/lib/adminMode';
 
 const log = createLogger('logs-state');
 
@@ -31,6 +32,11 @@ interface UseLogsStateOpts {
 }
 
 export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
+  // /logs/clear is admin-only on the backend (a non-admin's POST would
+  // 403). Surface the same gate to the UI so the "Delete logs after
+  // download" checkbox only renders for admins — non-admins still see
+  // the confirmation dialog but without the destructive option.
+  const canDeleteLogs = getAdminMode();
   const { toasts, dismissToast, success, error } = useToast();
   const [lines, setLines] = useState<LogLine[]>([]);
   const [filter, setFilter] = useState<LevelFilter>('errors');
@@ -67,9 +73,10 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
 
   // Load the user's "auto-delete on download" preference once the
   // surface activates so the checkbox is pre-set the first time the
-  // download dialog opens.
+  // download dialog opens. Skipped for non-admins: they can't delete
+  // logs so the preference would be inert and the GET is wasted work.
   useEffect(() => {
-    if (!active) return;
+    if (!active || !canDeleteLogs) return;
     let cancelled = false;
     (async () => {
       try {
@@ -85,7 +92,7 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     return () => {
       cancelled = true;
     };
-  }, [active]);
+  }, [active, canDeleteLogs]);
 
   const formatLines = useMemo(
     () =>
@@ -125,7 +132,9 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
 
     // Persist the checkbox state if it changed. Fire-and-forget — a
     // preference write failure shouldn't block the bundle download.
-    if (deleteAfterDownload !== persistedDeleteAfterDownload.current) {
+    // Skipped for non-admins since they can't act on the preference
+    // anyway (and the backend write succeeds but is then unused).
+    if (canDeleteLogs && deleteAfterDownload !== persistedDeleteAfterDownload.current) {
       logsAPI
         .setPreferences({ auto_delete_on_download: deleteAfterDownload })
         .then(() => {
@@ -137,8 +146,10 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     }
 
     // If the user opted in, wait briefly so the browser has time to
-    // begin streaming the ZIP, then clear the server-side logs.
-    if (deleteAfterDownload) {
+    // begin streaming the ZIP, then clear the server-side logs. The
+    // canDeleteLogs guard is defense-in-depth — the checkbox is hidden
+    // for non-admins so deleteAfterDownload should already be false.
+    if (canDeleteLogs && deleteAfterDownload) {
       window.setTimeout(async () => {
         try {
           await logsAPI.clear();
@@ -190,6 +201,7 @@ export function useLogsState({ active = true }: UseLogsStateOpts = {}) {
     deleteAfterDownload,
     setDeleteAfterDownload,
     confirmDownload,
+    canDeleteLogs,
     // Toast plumbing — the consumer mounts <ToastContainer /> with these.
     toasts,
     dismissToast,

--- a/frontend/src/components/settings/sections/LogsSection.tsx
+++ b/frontend/src/components/settings/sections/LogsSection.tsx
@@ -123,6 +123,7 @@ export const LogsSection: React.FC = () => {
         deleteAfterDownload={state.deleteAfterDownload}
         onDeleteAfterDownloadChange={state.setDeleteAfterDownload}
         onConfirm={state.confirmDownload}
+        canDelete={state.canDeleteLogs}
       />
     </div>
   );

--- a/frontend/src/components/settings/sections/LogsSection.tsx
+++ b/frontend/src/components/settings/sections/LogsSection.tsx
@@ -52,6 +52,15 @@ const LogHousekeepingCard: React.FC = () => {
       success(next ? 'Weekly log auto-clear enabled' : 'Weekly log auto-clear disabled');
     } catch (e) {
       log.error({ err: e }, 'failed to update housekeeping');
+      // 409 from the backend means the scheduler bumped last_run_at between
+      // our read and write. Re-fetch so the Switch snaps back to the real
+      // server state instead of lingering on the value the user attempted.
+      try {
+        const latest = await logsAPI.getHousekeeping();
+        setConfig(latest);
+      } catch (refreshErr) {
+        log.warn({ err: refreshErr }, 'failed to re-fetch housekeeping after error');
+      }
       error('Could not update log housekeeping setting');
     } finally {
       setSaving(false);

--- a/frontend/src/components/settings/sections/LogsSection.tsx
+++ b/frontend/src/components/settings/sections/LogsSection.tsx
@@ -19,6 +19,7 @@ import { logsAPI, type LogHousekeeping } from '@/lib/api/logs';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { getAdminMode } from '@/lib/adminMode';
 
 const log = createLogger('logs-section');
 
@@ -76,8 +77,11 @@ const LogHousekeepingCard: React.FC = () => {
           )}
         </div>
         <Switch
+          // PUT /logs/housekeeping is admin-only — disable for non-admins
+          // so they can still see the card's last-cleared timestamp without
+          // clicking into a confusing 403.
           checked={config?.weekly_clear_enabled ?? false}
-          disabled={!config || saving}
+          disabled={!config || saving || !getAdminMode()}
           onCheckedChange={handleToggle}
         />
       </div>

--- a/frontend/src/components/settings/sections/LogsSection.tsx
+++ b/frontend/src/components/settings/sections/LogsSection.tsx
@@ -7,11 +7,83 @@
  * what they're sharing.
  *
  * Behavior + content all come from `useLogsState` and `LogConsole` so
- * the modal and this section can never drift out of sync.
+ * the modal and this section can never drift out of sync. This file
+ * additionally hosts the admin-only "Auto-clear logs weekly" toggle
+ * since the housekeeping setting is global, not per-user.
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { LogConsole } from '@/components/project/LogConsole';
 import { useLogsState } from '@/components/project/useLogsState';
+import { DownloadLogsConfirmDialog } from '@/components/project/DownloadLogsConfirmDialog';
+import { logsAPI, type LogHousekeeping } from '@/lib/api/logs';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('logs-section');
+
+const LogHousekeepingCard: React.FC = () => {
+  const { success, error } = useToast();
+  const [config, setConfig] = useState<LogHousekeeping | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await logsAPI.getHousekeeping();
+        if (!cancelled) setConfig(res);
+      } catch (e) {
+        log.warn({ err: e }, 'failed to load housekeeping config');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggle = async (next: boolean) => {
+    if (!config) return;
+    setSaving(true);
+    try {
+      const updated = await logsAPI.setHousekeeping({ weekly_clear_enabled: next });
+      setConfig(updated);
+      success(next ? 'Weekly log auto-clear enabled' : 'Weekly log auto-clear disabled');
+    } catch (e) {
+      log.error({ err: e }, 'failed to update housekeeping');
+      error('Could not update log housekeeping setting');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-stone-200 bg-white p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-medium text-stone-900">
+            Auto-clear logs weekly
+          </h3>
+          <p className="mt-1 text-xs text-stone-600 max-w-prose">
+            Truncates the rotating <code>backend.log</code> files and removes
+            archives once every 7 days so the deployment doesn&apos;t accrue
+            stale diagnostics indefinitely.
+          </p>
+          {config?.last_run_at && (
+            <p className="mt-2 text-xs text-stone-500">
+              Last cleared automatically: {new Date(config.last_run_at).toLocaleString()}
+            </p>
+          )}
+        </div>
+        <Switch
+          checked={config?.weekly_clear_enabled ?? false}
+          disabled={!config || saving}
+          onCheckedChange={handleToggle}
+        />
+      </div>
+    </div>
+  );
+};
 
 export const LogsSection: React.FC = () => {
   const state = useLogsState({ active: true });
@@ -28,6 +100,8 @@ export const LogsSection: React.FC = () => {
         </p>
       </header>
 
+      <LogHousekeepingCard />
+
       <LogConsole
         variant="page"
         panelMaxHeightClassName="max-h-[58vh]"
@@ -41,6 +115,14 @@ export const LogsSection: React.FC = () => {
         onCopy={state.handleCopy}
         onDownload={state.handleDownload}
         onClear={state.handleClear}
+      />
+
+      <DownloadLogsConfirmDialog
+        open={state.downloadDialogOpen}
+        onOpenChange={state.setDownloadDialogOpen}
+        deleteAfterDownload={state.deleteAfterDownload}
+        onDeleteAfterDownloadChange={state.setDeleteAfterDownload}
+        onConfirm={state.confirmDownload}
       />
     </div>
   );

--- a/frontend/src/components/sources/AddSourcesSheet.tsx
+++ b/frontend/src/components/sources/AddSourcesSheet.tsx
@@ -17,6 +17,7 @@ import { McpTab } from './McpTab';
 import { FreshdeskTab } from './FreshdeskTab';
 import { JiraTab } from './JiraTab';
 import { MixpanelTab } from './MixpanelTab';
+import { NotionTab } from './NotionTab';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { MAX_SOURCES } from '../../lib/api/sources';
 
@@ -72,6 +73,7 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
   const canFreshdesk = hasPermission('data_sources', 'freshdesk');
   const canJira = hasPermission('integrations', 'jira');
   const canMixpanel = hasPermission('integrations', 'mixpanel');
+  const canNotion = hasPermission('integrations', 'notion');
   // Note: CSV permission exists (hasPermission('data_sources', 'csv')) but no CSV tab yet
 
   // Research and MCP are always shown (no dedicated permission key) — gated at category level
@@ -89,6 +91,7 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
     : canFreshdesk ? 'freshdesk'
     : canJira ? 'jira'
     : canMixpanel ? 'mixpanel'
+    : canNotion ? 'notion'
     : 'upload';
 
   const tabTriggerClass = "px-4 py-2 rounded-md border border-stone-300 bg-stone-100 text-stone-700 cursor-pointer transition-all hover:bg-stone-200 data-[state=active]:border-amber-600 data-[state=active]:bg-amber-600 data-[state=active]:text-white";
@@ -156,6 +159,11 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
               {canMixpanel && (
                 <TabsTrigger value="mixpanel" className={tabTriggerClass}>
                   Mixpanel
+                </TabsTrigger>
+              )}
+              {canNotion && (
+                <TabsTrigger value="notion" className={tabTriggerClass}>
+                  Notion
                 </TabsTrigger>
               )}
             </TabsList>
@@ -263,6 +271,19 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
                   isAtLimit={isAtLimit}
                   onAddMixpanel={async (name, description) => {
                     await onAddMixpanel(name, description);
+                    onImportComplete();
+                    onOpenChange(false);
+                  }}
+                />
+              </TabsContent>
+            )}
+
+            {canNotion && (
+              <TabsContent value="notion" className="mt-6">
+                <NotionTab
+                  projectId={projectId}
+                  isAtLimit={isAtLimit}
+                  onAdded={() => {
                     onImportComplete();
                     onOpenChange(false);
                   }}

--- a/frontend/src/components/sources/NotionTab.tsx
+++ b/frontend/src/components/sources/NotionTab.tsx
@@ -50,6 +50,17 @@ export const NotionTab: React.FC<NotionTabProps> = ({ projectId, isAtLimit, onAd
   // Debounce the search box so we don't fire on every keystroke.
   const debounceRef = useRef<number | null>(null);
 
+  // Clear any pending debounce on unmount so a search that fires after the
+  // sheet closes doesn't call setState on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {

--- a/frontend/src/components/sources/NotionTab.tsx
+++ b/frontend/src/components/sources/NotionTab.tsx
@@ -1,0 +1,268 @@
+/**
+ * NotionTab Component
+ *
+ * Browse-and-pick UI for adding a Notion page or database as a source.
+ * The shared NOTION_API_KEY drives this — no per-user OAuth. If the admin
+ * hasn't configured the key, we show a passive "not configured" state
+ * (mirroring GoogleDriveTab's pattern).
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CircleNotch,
+  MagnifyingGlass,
+  NotionLogo,
+  Plus,
+  FileText,
+  Table,
+} from '@phosphor-icons/react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { sourcesAPI, type NotionPickerItem } from '../../lib/api/sources';
+import { useToast } from '../ui/use-toast';
+import { createLogger } from '@/lib/logger';
+
+const log = createLogger('notion-tab');
+
+interface NotionTabProps {
+  projectId: string;
+  isAtLimit: boolean;
+  onAdded: () => void;
+}
+
+type FilterType = 'all' | 'page' | 'database';
+
+export const NotionTab: React.FC<NotionTabProps> = ({ projectId, isAtLimit, onAdded }) => {
+  const { error: toastError, success } = useToast();
+
+  const [statusLoading, setStatusLoading] = useState(true);
+  const [configured, setConfigured] = useState(false);
+
+  const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<FilterType>('all');
+  const [results, setResults] = useState<NotionPickerItem[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  // Track which row is currently being imported so we can disable just that
+  // row's button (the rest stay clickable).
+  const [importingId, setImportingId] = useState<string | null>(null);
+
+  // Debounce the search box so we don't fire on every keystroke.
+  const debounceRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const status = await sourcesAPI.getNotionStatus();
+        if (cancelled) return;
+        setConfigured(status.configured);
+      } finally {
+        if (!cancelled) setStatusLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Initial + filter-change loads
+  useEffect(() => {
+    if (!configured) return;
+    runSearch(query, filter);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configured, filter]);
+
+  const runSearch = async (q: string, f: FilterType) => {
+    setSearching(true);
+    try {
+      const items = await sourcesAPI.searchNotion(
+        q || undefined,
+        f === 'all' ? undefined : f,
+        50
+      );
+      setResults(items);
+    } catch (err) {
+      log.error({ err }, 'notion search failed');
+      toastError('Failed to search Notion');
+      setResults([]);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value);
+    if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => runSearch(value, filter), 300);
+  };
+
+  const handlePick = async (item: NotionPickerItem) => {
+    if (isAtLimit || importingId) return;
+    setImportingId(item.id);
+    try {
+      await sourcesAPI.addNotionSource(projectId, {
+        notion_id: item.id,
+        object_type: item.type,
+        title: item.title,
+        notion_url: item.url,
+        last_edited_time: item.last_edited_time,
+      });
+      success(
+        item.type === 'database'
+          ? 'Notion database added — fetching rows…'
+          : 'Notion page added — fetching content…'
+      );
+      onAdded();
+    } catch (err: unknown) {
+      log.error({ err }, 'failed to add notion source');
+      const msg =
+        typeof err === 'object' && err !== null && 'response' in err
+          ? (err as { response?: { data?: { error?: string } } }).response?.data?.error
+          : null;
+      toastError(msg || 'Failed to add Notion source');
+    } finally {
+      setImportingId(null);
+    }
+  };
+
+  const filterButtonClass = (active: boolean) =>
+    `px-3 py-1.5 text-xs rounded-md border transition-colors ${
+      active
+        ? 'border-amber-600 bg-amber-600 text-white'
+        : 'border-stone-300 bg-stone-100 text-stone-700 hover:bg-stone-200'
+    }`;
+
+  const rowIcon = useMemo(() => {
+    return (kind: 'page' | 'database') =>
+      kind === 'database' ? (
+        <Table size={18} weight="duotone" className="text-amber-700 shrink-0" />
+      ) : (
+        <FileText size={18} weight="duotone" className="text-stone-600 shrink-0" />
+      );
+  }, []);
+
+  if (statusLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <CircleNotch size={24} className="animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!configured) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <NotionLogo size={48} weight="duotone" className="text-muted-foreground mb-4" />
+        <h3 className="font-medium mb-2">Notion Not Configured</h3>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          An administrator needs to add the Notion integration token in
+          Admin Settings → API Keys (<code>NOTION_API_KEY</code>) before
+          this can be used.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm">
+        Pick a Notion page or database to import. The page content (including
+        nested toggles and sub-pages) is fetched once and embedded for
+        semantic search in chat.
+      </p>
+
+      <div className="relative">
+        <MagnifyingGlass
+          size={16}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          className="pl-9"
+          placeholder="Search Notion…"
+          value={query}
+          onChange={(e) => handleQueryChange(e.target.value)}
+          disabled={isAtLimit}
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          className={filterButtonClass(filter === 'all')}
+          onClick={() => setFilter('all')}
+        >
+          All
+        </button>
+        <button
+          type="button"
+          className={filterButtonClass(filter === 'page')}
+          onClick={() => setFilter('page')}
+        >
+          Pages
+        </button>
+        <button
+          type="button"
+          className={filterButtonClass(filter === 'database')}
+          onClick={() => setFilter('database')}
+        >
+          Databases
+        </button>
+      </div>
+
+      <div className="border rounded-md max-h-96 overflow-y-auto">
+        {searching ? (
+          <div className="flex justify-center py-8">
+            <CircleNotch size={20} className="animate-spin text-muted-foreground" />
+          </div>
+        ) : results.length === 0 ? (
+          <div className="text-sm text-muted-foreground text-center py-8 px-4">
+            No Notion {filter === 'all' ? 'pages or databases' : `${filter}s`} found.
+            Make sure your Notion integration has been shared with the workspace
+            you want to import from.
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {results.map((item) => (
+              <li
+                key={item.id}
+                className="flex items-center gap-3 px-3 py-2 hover:bg-stone-50"
+              >
+                {rowIcon(item.type)}
+                <div className="flex-1 min-w-0">
+                  <div className="truncate text-sm font-medium">
+                    {item.title || 'Untitled'}
+                  </div>
+                  <div className="truncate text-xs text-muted-foreground">
+                    {item.type === 'database' ? 'Database' : 'Page'}
+                    {item.last_edited_time
+                      ? ` · edited ${new Date(item.last_edited_time).toLocaleDateString()}`
+                      : ''}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="soft"
+                  onClick={() => handlePick(item)}
+                  disabled={isAtLimit || importingId !== null}
+                >
+                  {importingId === item.id ? (
+                    <>
+                      <CircleNotch size={14} className="mr-1.5 animate-spin" />
+                      Adding…
+                    </>
+                  ) : (
+                    <>
+                      <Plus size={14} className="mr-1.5" />
+                      Add
+                    </>
+                  )}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/sources/SourceItem.tsx
+++ b/frontend/src/components/sources/SourceItem.tsx
@@ -35,6 +35,7 @@ import {
   ArrowsClockwise,
   CloudArrowDown,
   Plug,
+  NotionLogo,
 } from '@phosphor-icons/react';
 import {
   DropdownMenu,
@@ -97,6 +98,7 @@ const getSourceIcon = (source: Source): { icon: typeof File; weight?: 'bold' } =
     case '.xlsx': return { icon: FileXls, weight: 'bold' };
     case '.database': return { icon: Table, weight: 'bold' };
     case '.mcp': return { icon: Plug, weight: 'bold' };
+    case '.notion': return { icon: NotionLogo, weight: 'bold' };
     case '.md': return { icon: MarkdownLogo, weight: 'bold' };
     case '.html': return { icon: FileHtml, weight: 'bold' };
     case '.json': case '.xml': return { icon: FileText, weight: 'bold' };
@@ -117,6 +119,7 @@ const getSourceIcon = (source: Source): { icon: typeof File; weight?: 'bold' } =
     case 'DATA': return { icon: Table, weight: 'bold' };
     case 'DATABASE': return { icon: Table, weight: 'bold' };
     case 'MCP': return { icon: Plug, weight: 'bold' };
+    case 'NOTION': return { icon: NotionLogo, weight: 'bold' };
     case 'DOCUMENT': return { icon: FileText, weight: 'bold' };
     default: return { icon: File, weight: 'bold' };
   }

--- a/frontend/src/components/sources/SourcesPanel.tsx
+++ b/frontend/src/components/sources/SourcesPanel.tsx
@@ -58,6 +58,7 @@ import {
   CaretRight,
   Plus,
   Plug,
+  NotionLogo,
 } from '@phosphor-icons/react';
 import { createLogger } from '@/lib/logger';
 import { patchOne, removeOne, upsertOne } from '@/lib/resourceState';
@@ -100,6 +101,7 @@ const getSourceIcon = (source: Source): typeof File => {
     case '.csv': return FileCsv;
     case '.database': return Table;
     case '.mcp': return Plug;
+    case '.notion': return NotionLogo;
     case '.md': return MarkdownLogo;
     case '.html': return FileHtml;
     case '.json': case '.xml': return FileText;
@@ -120,6 +122,7 @@ const getSourceIcon = (source: Source): typeof File => {
     case 'DATA': return Table;
     case 'DATABASE': return Table;
     case 'MCP': return Plug;
+    case 'NOTION': return NotionLogo;
     case 'DOCUMENT': return FileText;
     default: return File;
   }

--- a/frontend/src/lib/api/logs.ts
+++ b/frontend/src/lib/api/logs.ts
@@ -28,6 +28,15 @@ export interface ClientErrorPayload {
   timestamp?: string;
 }
 
+export interface LogPreferences {
+  auto_delete_on_download: boolean;
+}
+
+export interface LogHousekeeping {
+  weekly_clear_enabled: boolean;
+  last_run_at: string | null;
+}
+
 export const logsAPI = {
   async getRecent(n = 100, level: 'errors' | 'warnings' | 'all' = 'errors') {
     const res = await api.get<RecentLogsResponse>('/logs/recent', {
@@ -45,6 +54,34 @@ export const logsAPI = {
   async clear() {
     const res = await api.post<{ success: boolean; cleared: number }>('/logs/clear');
     return res.data;
+  },
+
+  /** Per-user "auto-delete logs after download" preference. */
+  async getPreferences(): Promise<LogPreferences> {
+    const res = await api.get<{ success: boolean } & LogPreferences>('/logs/preferences');
+    return { auto_delete_on_download: !!res.data.auto_delete_on_download };
+  },
+
+  async setPreferences(prefs: LogPreferences): Promise<LogPreferences> {
+    const res = await api.put<{ success: boolean } & LogPreferences>('/logs/preferences', prefs);
+    return { auto_delete_on_download: !!res.data.auto_delete_on_download };
+  },
+
+  /** Global weekly auto-clear configuration (read is open; write is admin-only). */
+  async getHousekeeping(): Promise<LogHousekeeping> {
+    const res = await api.get<{ success: boolean } & LogHousekeeping>('/logs/housekeeping');
+    return {
+      weekly_clear_enabled: !!res.data.weekly_clear_enabled,
+      last_run_at: res.data.last_run_at ?? null,
+    };
+  },
+
+  async setHousekeeping(prefs: { weekly_clear_enabled: boolean }): Promise<LogHousekeeping> {
+    const res = await api.put<{ success: boolean } & LogHousekeeping>('/logs/housekeeping', prefs);
+    return {
+      weekly_clear_enabled: !!res.data.weekly_clear_enabled,
+      last_run_at: res.data.last_run_at ?? null,
+    };
   },
 
   /** Fire-and-forget client error report. We don't await the response in

--- a/frontend/src/lib/api/sources.ts
+++ b/frontend/src/lib/api/sources.ts
@@ -91,6 +91,18 @@ export interface ChunkContent {
 }
 
 /**
+ * A single result row returned by GET /notion/search — used by the Notion picker.
+ */
+export interface NotionPickerItem {
+  id: string;
+  type: 'page' | 'database';
+  title?: string;
+  url?: string;
+  created_time?: string;
+  last_edited_time?: string;
+}
+
+/**
  * Processed content returned from the processed content API
  * Educational Note: This is used for viewing extracted text from sources
  * in the Sources panel. Users can click on a processed source to see
@@ -122,7 +134,7 @@ export interface RawFileUrl {
  */
 export const VIEWABLE_EXTENSIONS = [
   '.pdf', '.txt', '.docx', '.pptx', '.md', '.json', '.html', '.xml',  // Documents
-  '.link', '.research', '.mcp',                                          // Web content / MCP
+  '.link', '.research', '.mcp', '.notion',                              // Web content / MCP / Notion
 ];
 
 export const NON_VIEWABLE_EXTENSIONS = [
@@ -615,6 +627,71 @@ class SourcesAPI {
       return response.data.source;
     } catch (error) {
       log.error({ err: error }, 'failed to add Mixpanel source');
+      throw error;
+    }
+  }
+
+  /**
+   * Check whether the global Notion integration is configured (i.e. the
+   * admin has set NOTION_API_KEY). Returns false rather than throwing on
+   * misconfiguration so the picker can show a friendly empty state.
+   */
+  async getNotionStatus(): Promise<{ configured: boolean }> {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/notion/status`);
+      return { configured: !!response.data?.configured };
+    } catch (error) {
+      log.error({ err: error }, 'failed to fetch notion status');
+      return { configured: false };
+    }
+  }
+
+  /**
+   * Search the connected Notion workspace for pages/databases (paginated server-side).
+   */
+  async searchNotion(
+    query?: string,
+    type?: 'page' | 'database',
+    limit = 50
+  ): Promise<NotionPickerItem[]> {
+    try {
+      const params: Record<string, string> = { limit: String(limit) };
+      if (query) params.q = query;
+      if (type) params.type = type;
+      const response = await axios.get(`${API_BASE_URL}/notion/search`, { params });
+      return (response.data?.results || []) as NotionPickerItem[];
+    } catch (error) {
+      log.error({ err: error }, 'failed to search notion');
+      throw error;
+    }
+  }
+
+  /**
+   * Add a Notion source (one page or one database) to a project.
+   * Educational Note: Notion content IS embedded for RAG — unlike Jira/Mixpanel
+   * which are live-API flags, Notion pages/databases are fetched once during
+   * processing, chunked, and stored for semantic search.
+   */
+  async addNotionSource(
+    projectId: string,
+    payload: {
+      notion_id: string;
+      object_type: 'page' | 'database';
+      title?: string;
+      notion_url?: string;
+      last_edited_time?: string;
+      name?: string;
+      description?: string;
+    }
+  ): Promise<Source> {
+    try {
+      const response = await axios.post(
+        `${API_BASE_URL}/projects/${projectId}/sources/notion`,
+        payload
+      );
+      return response.data.source;
+    } catch (error) {
+      log.error({ err: error }, 'failed to add Notion source');
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
Roll-up of two features shipped on develop:

- **Notion sources** (#286): browse-and-pick UI to import a Notion page or database as a project source. Recursive block walking, pagination, processed-output integration, full RAG pipeline.
- **Log housekeeping** (#287): in-dialog "delete logs after download" toggle persisted per user, plus a weekly auto-clear scheduler with an admin Settings toggle. Restored /logs/clear to admin-only; non-admin UI surfaces are read-only.
- **Migration hotfix**: `00043` corrected the `sources.type` CHECK to include `DOCUMENT` so file uploads stop failing the constraint.

## Test plan
- [x] All CI checks green on the source PRs (pytest, lint+build).
- [x] Both features verified locally with full backend test suite (335+ tests) and `tsc`/`eslint` clean.
- [ ] Once merged, smoke on prod: open Logs modal, hit Download, verify confirmation dialog; toggle weekly auto-clear in Settings; create a Notion source and confirm processing completes.