### PR TITLE
Sync develop → main: persist API keys + Notion setup guide

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -38,6 +38,18 @@ def create_app(config_name='development'):
     setup_logging(app.config.get('LOG_LEVEL', 'DEBUG'))
     config[config_name].init_app(app)
 
+    # Hydrate runtime env vars from persisted API keys (Supabase). Build-time
+    # env wins for anything explicitly set by docker-compose / Coolify; this
+    # only fills in keys the operator left blank, so UI saves survive
+    # container restarts. Wrapped so a Supabase outage doesn't block boot —
+    # the operator still gets the app up enough to surface the issue in
+    # Admin Settings.
+    try:
+        from app.services.app_settings.api_key_store import api_key_store
+        api_key_store.hydrate_environ()
+    except Exception as exc:  # noqa: BLE001
+        app.logger.warning("API key hydration skipped: %s", exc)
+
     # Honor X-Forwarded-* headers when running behind Coolify's reverse
     # proxy (nginx/Traefik terminates HTTPS, then forwards over plain
     # HTTP to the backend container). Without this, request.host_url and

--- a/backend/app/api/settings/api_keys.py
+++ b/backend/app/api/settings/api_keys.py
@@ -246,19 +246,39 @@ def get_api_keys():
         }
     """
     try:
+        # One Supabase round-trip up front so we know which keys are in the
+        # persistent store vs only injected by the host (Coolify / compose).
+        # The distinction tells the UI whether to render a "Pinned by
+        # deployment" badge and disable the input.
+        from app.services.app_settings.api_key_store import api_key_store
+        db_keys = set(api_key_store.load_all().keys())
+
         api_keys = []
         for key_config in API_KEYS_CONFIG:
-            value = env_service.get_key(key_config['id'])
+            key_id = key_config['id']
+            value = env_service.get_key(key_id)
             masked_value = env_service.mask_key(value) if value else ''
 
+            in_db = key_id in db_keys
+            if not value:
+                source = 'unset'
+            elif in_db:
+                source = 'db'
+            else:
+                # Value is present in os.environ but the store doesn't have
+                # it — it was injected by the host environment and the UI
+                # cannot override it from here.
+                source = 'env'
+
             api_keys.append({
-                'id': key_config['id'],
+                'id': key_id,
                 'name': key_config['name'],
                 'description': key_config['description'],
                 'category': key_config['category'],
                 'required': key_config.get('required', False),
                 'value': masked_value,
-                'is_set': bool(value)
+                'is_set': bool(value),
+                'source': source,
             })
 
         return jsonify({

--- a/backend/app/api/settings/api_keys.py
+++ b/backend/app/api/settings/api_keys.py
@@ -249,9 +249,14 @@ def get_api_keys():
         # One Supabase round-trip up front so we know which keys are in the
         # persistent store vs only injected by the host (Coolify / compose).
         # The distinction tells the UI whether to render a "Pinned by
-        # deployment" badge and disable the input.
+        # deployment" badge and disable the input. We compare the actual
+        # values, not just key presence — when an operator pins a key via
+        # the host AND a stale DB entry exists for the same name, the host
+        # value wins in os.environ but the DB still contains the old one;
+        # treating presence-in-DB as "source: 'db'" would wrongly make the
+        # UI editable.
         from app.services.app_settings.api_key_store import api_key_store
-        db_keys = set(api_key_store.load_all().keys())
+        db_values = api_key_store.load_all()
 
         api_keys = []
         for key_config in API_KEYS_CONFIG:
@@ -259,15 +264,16 @@ def get_api_keys():
             value = env_service.get_key(key_id)
             masked_value = env_service.mask_key(value) if value else ''
 
-            in_db = key_id in db_keys
             if not value:
                 source = 'unset'
-            elif in_db:
+            elif db_values.get(key_id) == value:
                 source = 'db'
             else:
-                # Value is present in os.environ but the store doesn't have
-                # it — it was injected by the host environment and the UI
-                # cannot override it from here.
+                # Value is present in os.environ but doesn't match what's
+                # in the store (either nothing there, or a stale entry the
+                # host env is now overriding). Either way the UI can't
+                # change it from here — the operator must update the host
+                # env.
                 source = 'env'
 
             api_keys.append({

--- a/backend/app/services/app_settings/api_key_store.py
+++ b/backend/app/services/app_settings/api_key_store.py
@@ -139,8 +139,9 @@ class ApiKeyStore:
                 .execute()
             )
             return bool(resp.data)
-        except Exception as exc:
-            logger.exception("ApiKeyStore: failed to write api_keys: %s", exc)
+        except Exception:
+            # logger.exception already attaches the traceback via sys.exc_info()
+            logger.exception("ApiKeyStore: failed to write api_keys")
             return False
 
     # ------------------------------------------------------------------

--- a/backend/app/services/app_settings/api_key_store.py
+++ b/backend/app/services/app_settings/api_key_store.py
@@ -1,0 +1,268 @@
+"""
+ApiKeyStore — persistent, encrypted storage for API keys configured via the
+Admin Settings → API Keys UI.
+
+Why this exists:
+    `env_service.set_key()` used to write to /app/.env, which is excluded by
+    backend/.dockerignore and lives on the container's ephemeral filesystem.
+    Every key saved through the UI vanished on the next container restart.
+    This module stores those keys in the Supabase `app_settings.api_keys`
+    JSONB column so they survive restarts, redeploys, OOM kills, etc.
+
+Encryption:
+    Values are Fernet-encrypted before insert. The encryption key is derived
+    from the SECRET_KEY env var (SHA-256 → urlsafe-base64). If SECRET_KEY is
+    missing — e.g. a dev workstation that hasn't bootstrapped one — values
+    are stored with a `plain:` prefix so the store keeps working without
+    crashing the admin UI; a warning is logged so the operator notices.
+
+Source resolution at runtime:
+    Build-time env vars (set by docker-compose `environment:` / Coolify
+    secrets) take precedence over DB values. `hydrate_environ()` only sets
+    os.environ keys that are currently unset or empty — letting an operator
+    "pin" a key via host env if they want to, while the UI is otherwise
+    authoritative.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.services.integrations.supabase import get_supabase, is_supabase_enabled
+
+logger = logging.getLogger(__name__)
+
+
+_PLAINTEXT_PREFIX = "plain:"
+
+
+def _derive_fernet_key(secret: str) -> bytes:
+    """Derive a Fernet-compatible 32-byte key from SECRET_KEY via SHA-256."""
+    digest = hashlib.sha256(secret.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+class ApiKeyStore:
+    """
+    Singleton-style accessor for the encrypted app_settings.api_keys JSONB.
+
+    Methods are deliberately small and synchronous: this gets called on
+    every Admin Settings save and at app startup, and the data set is tiny
+    (≤ 30 keys per deploy), so a JSONB read-modify-write per call is fine.
+    """
+
+    def __init__(self) -> None:
+        secret = os.getenv("SECRET_KEY", "").strip()
+        if secret:
+            self._fernet: Optional[Fernet] = Fernet(_derive_fernet_key(secret))
+            self._encryption_disabled = False
+        else:
+            self._fernet = None
+            self._encryption_disabled = True
+            logger.warning(
+                "SECRET_KEY is not set — ApiKeyStore will store values without "
+                "encryption (prefixed with 'plain:'). Set SECRET_KEY in your "
+                "environment to enable Fernet encryption-at-rest."
+            )
+
+    # ------------------------------------------------------------------
+    # Encryption helpers
+    # ------------------------------------------------------------------
+
+    def _encrypt(self, value: str) -> str:
+        if self._encryption_disabled or self._fernet is None:
+            return f"{_PLAINTEXT_PREFIX}{value}"
+        return self._fernet.encrypt(value.encode("utf-8")).decode("ascii")
+
+    def _decrypt(self, ciphertext: str) -> Optional[str]:
+        if ciphertext.startswith(_PLAINTEXT_PREFIX):
+            return ciphertext[len(_PLAINTEXT_PREFIX):]
+        if self._fernet is None:
+            # Ciphertext exists but we can't decrypt it because SECRET_KEY is
+            # missing now. Log and skip — the admin UI will show the key as
+            # unset and the operator can re-enter it.
+            logger.warning(
+                "Cannot decrypt stored API key — SECRET_KEY missing or rotated. "
+                "Operator must re-save the key via the UI."
+            )
+            return None
+        try:
+            return self._fernet.decrypt(ciphertext.encode("ascii")).decode("utf-8")
+        except InvalidToken:
+            logger.warning(
+                "Stored API key ciphertext failed decryption (likely rotated "
+                "SECRET_KEY). Operator must re-save the affected key."
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Supabase access
+    # ------------------------------------------------------------------
+
+    def _read_raw(self) -> Dict[str, str]:
+        """Return the raw {key: ciphertext} map from Supabase, or {} on miss."""
+        if not is_supabase_enabled():
+            return {}
+        try:
+            client = get_supabase()
+            resp = (
+                client.table("app_settings")
+                .select("api_keys")
+                .eq("id", True)
+                .limit(1)
+                .execute()
+            )
+        except Exception as exc:
+            logger.warning("ApiKeyStore: could not read app_settings: %s", exc)
+            return {}
+        rows = resp.data or []
+        if not rows:
+            return {}
+        return rows[0].get("api_keys") or {}
+
+    def _write_raw(self, raw: Dict[str, str]) -> bool:
+        """Persist the full raw map. Caller is responsible for read-modify-write."""
+        if not is_supabase_enabled():
+            return False
+        try:
+            client = get_supabase()
+            resp = (
+                client.table("app_settings")
+                .update({"api_keys": raw})
+                .eq("id", True)
+                .execute()
+            )
+            return bool(resp.data)
+        except Exception as exc:
+            logger.exception("ApiKeyStore: failed to write api_keys: %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def load_all(self) -> Dict[str, str]:
+        """Return {key_id: plaintext} for every successfully-decrypted entry."""
+        raw = self._read_raw()
+        out: Dict[str, str] = {}
+        for k, ciphertext in raw.items():
+            if not isinstance(ciphertext, str):
+                continue
+            plaintext = self._decrypt(ciphertext)
+            if plaintext is not None:
+                out[k] = plaintext
+        return out
+
+    def has(self, key_id: str) -> bool:
+        return key_id in self._read_raw()
+
+    def set(self, key_id: str, value: str) -> bool:
+        if not key_id:
+            return False
+        raw = self._read_raw()
+        raw[key_id] = self._encrypt(value)
+        return self._write_raw(raw)
+
+    def delete(self, key_id: str) -> bool:
+        if not key_id:
+            return False
+        raw = self._read_raw()
+        if key_id not in raw:
+            return True  # nothing to do — idempotent
+        del raw[key_id]
+        return self._write_raw(raw)
+
+    def hydrate_environ(self) -> int:
+        """
+        Populate os.environ with stored keys for any that are currently unset
+        or empty. Build-time env vars win when both are present — that lets
+        an operator pin a key via host env if they want, while the UI remains
+        authoritative for everything else. Returns the count of vars hydrated.
+        """
+        applied = 0
+        for k, v in self.load_all().items():
+            existing = os.environ.get(k)
+            if existing is None or existing == "":
+                os.environ[k] = v
+                applied += 1
+        if applied:
+            logger.info("ApiKeyStore: hydrated %d API key(s) from Supabase", applied)
+        return applied
+
+
+# Module-level helper for the one-time migration of any legacy
+# `backend/.env` API-key entries into the store. Called from EnvService
+# during first __init__ so existing self-hosted deployments don't lose
+# their previously-saved keys.
+def migrate_env_file_into_store(env_file: Path, known_keys: set[str]) -> int:
+    """
+    If `env_file` exists and contains any KEY=VALUE lines whose key is in
+    `known_keys` (i.e. recognized by API_KEYS_CONFIG), copy each into the
+    store and strip those lines from the file. Returns the count migrated.
+    Non-API keys (PORT, FLASK_ENV, etc.) are left untouched.
+    """
+    if not env_file.exists():
+        return 0
+    try:
+        text = env_file.read_text(encoding="utf-8")
+    except Exception as exc:
+        logger.warning("Could not read %s for API-key migration: %s", env_file, exc)
+        return 0
+
+    keep_lines: list[str] = []
+    migrated: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            keep_lines.append(line)
+            continue
+        k, v = stripped.split("=", 1)
+        k = k.strip()
+        # Trim matching surrounding quotes only
+        v = v.strip()
+        if len(v) >= 2 and v[0] == v[-1] and v[0] in ('"', "'"):
+            v = v[1:-1]
+        if k in known_keys and v:
+            migrated.append((k, v))
+            continue
+        keep_lines.append(line)
+
+    if not migrated:
+        return 0
+
+    store = ApiKeyStore()
+    written = 0
+    for k, v in migrated:
+        if store.set(k, v):
+            written += 1
+        else:
+            # If the write failed (e.g. Supabase unreachable), bail without
+            # touching the file so we don't lose the operator's keys.
+            logger.warning(
+                "ApiKeyStore migration could not persist %s — leaving %s "
+                "untouched and skipping cleanup.",
+                k,
+                env_file,
+            )
+            return written
+
+    try:
+        env_file.write_text("\n".join(keep_lines) + ("\n" if keep_lines else ""), encoding="utf-8")
+        logger.info(
+            "ApiKeyStore migration: moved %d API key(s) from %s into Supabase.",
+            written,
+            env_file,
+        )
+    except Exception as exc:
+        logger.warning("Could not rewrite %s after migration: %s", env_file, exc)
+    return written
+
+
+# Singleton-ish instance for callers that just need the store.
+api_key_store = ApiKeyStore()

--- a/backend/app/services/app_settings/env_service.py
+++ b/backend/app/services/app_settings/env_service.py
@@ -1,174 +1,163 @@
 """
-Service for managing environment variables and .env file operations.
+EnvService — facade for reading/writing the runtime environment variables
+that the rest of the app consults via ``os.getenv``.
 
-Educational Note: This service provides a safe way to read, write, and
-update the .env file while maintaining the Flask app's environment.
+History note: an earlier implementation wrote runtime updates to
+``backend/.env`` on disk. That file is excluded by ``backend/.dockerignore``
+and lives on the container's ephemeral filesystem (only ``/app/data`` is
+volumed), so every key saved through the Admin Settings UI evaporated on
+the next container restart. Runtime writes are now routed through
+``ApiKeyStore``, which persists encrypted values into Supabase's
+``app_settings.api_keys`` JSONB column. Build-time env vars (set by
+docker-compose / Coolify) still take precedence — see
+``ApiKeyStore.hydrate_environ``.
 
-Stateless Deployment Note: On stateless container deployments (ECS, Fargate,
-Lambda), .env file writes will be lost on container restart. For those
-environments, use environment variable injection (e.g., ECS task definition,
-Secrets Manager) instead of runtime .env writes.
+This class keeps the same public surface so existing callers don't change:
+``get_key`` / ``set_key`` / ``delete_key`` / ``mask_key`` / ``reload_env``
+all still work. ``reload_env`` is now a no-op (kept for API compat) because
+there's no longer a file to reload.
+
+Rotation note: rotating ``SECRET_KEY`` invalidates ciphertexts in the
+store. The admin UI will then show the affected keys as unset and the
+operator must re-save them via the UI.
 """
 import logging
 import os
 from pathlib import Path
-from typing import Optional, Dict
-from dotenv import load_dotenv, set_key, unset_key
+from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
 
 
 class EnvService:
     """
-    Service for managing environment variables and .env file.
+    Service for managing environment variables.
 
-    Educational Note: This class encapsulates all .env file operations,
-    providing methods for CRUD operations on environment variables.
+    Reads remain ``os.getenv``-backed. Writes are dual-path: they update
+    the current process's ``os.environ`` immediately (so the same request
+    sees the new value) and persist into ``ApiKeyStore`` so the value
+    survives container restarts.
     """
 
     def __init__(self):
-        """Initialize the service and locate the .env file."""
-        # Find the .env file in the backend directory
+        # Path retained only for the one-time migration of legacy
+        # backend/.env entries into the store. We no longer write to this
+        # file in normal operation.
         self.backend_dir = Path(__file__).parent.parent.parent.parent
-        self.env_path = self.backend_dir / '.env'
+        self.env_path = self.backend_dir / ".env"
 
-        # Create .env file if it doesn't exist
-        if not self.env_path.exists():
-            self.env_path.touch()
+        # One-shot migration: if backend/.env still has API-key entries from
+        # the previous code path, move them into the store and strip them
+        # from the file. Idempotent — re-running on an empty file is a no-op.
+        # Best-effort: any failure (no Supabase yet, .env unreadable) is
+        # logged and skipped; the rest of the app must still come up.
+        try:
+            from app.services.app_settings.api_key_store import (
+                migrate_env_file_into_store,
+            )
+            # Lazy import to avoid a circular dep with API_KEYS_CONFIG.
+            from app.api.settings.api_keys import API_KEYS_CONFIG  # noqa: WPS433
 
-        # Load current environment variables
-        self.reload_env()
+            known = {entry["id"] for entry in API_KEYS_CONFIG}
+            migrate_env_file_into_store(self.env_path, known)
+        except Exception as exc:  # noqa: BLE001 — migration is best-effort
+            logger.warning("Legacy .env migration skipped: %s", exc)
 
-    def reload_env(self):
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def reload_env(self) -> None:
         """
-        Reload environment variables from the .env file.
+        No-op kept for backwards compatibility.
 
-        Educational Note: This ensures our app has the latest values
-        after any .env file updates.
+        Historical behaviour: re-read ``backend/.env`` into ``os.environ``.
+        Runtime writes now go through ``ApiKeyStore`` and ``os.environ`` is
+        updated in place inside ``set_key`` / ``delete_key``, so this call
+        has nothing to do. Existing call sites that invoke it after a save
+        keep working without modification.
         """
-        load_dotenv(self.env_path, override=True)
+        return None
 
     def get_key(self, key: str) -> Optional[str]:
-        """
-        Get an environment variable value.
-
-        Args:
-            key: The environment variable name
-
-        Returns:
-            The value or None if not found
-        """
+        """Return the current value of an environment variable, or None."""
         return os.getenv(key)
 
-    def set_key(self, key: str, value: str):
-        """
-        Set an environment variable in the .env file.
+    # ------------------------------------------------------------------
+    # Writes — dual-path: os.environ (immediate) + ApiKeyStore (persistent)
+    # ------------------------------------------------------------------
 
-        Educational Note: This uses python-dotenv's set_key function
-        which safely updates the .env file without losing other values.
-        It also handles commented lines properly.
+    def set_key(self, key: str, value: str) -> None:
+        """
+        Persist a key into the store and update the running process env.
 
         Args:
-            key: The environment variable name
-            value: The value to set
+            key: Environment variable name (e.g. ``"NOTION_API_KEY"``).
+            value: The value to store. Pass a non-empty string — callers
+                should ``delete_key`` for clearing.
         """
         if not key or not isinstance(key, str):
             raise ValueError("Key must be a non-empty string")
+        if value is None:
+            raise ValueError("Value cannot be None — use delete_key to clear")
 
-        # First, check if the key exists as a comment and remove it
-        if self.env_path.exists():
-            with open(self.env_path, 'r') as f:
-                lines = f.readlines()
-
-            # Remove any commented versions of this key
-            new_lines = []
-            for line in lines:
-                # Skip commented lines that contain this key
-                if line.strip().startswith('#') and f'{key}=' in line:
-                    continue
-                new_lines.append(line)
-
-            # Write back without the commented key
-            with open(self.env_path, 'w') as f:
-                f.writelines(new_lines)
-
-        # Use python-dotenv's set_key to update the .env file
-        success = set_key(self.env_path, key, value, quote_mode='never')
-        if not success:
-            raise RuntimeError(f"Failed to set key {key} in .env file")
-
-        # Also set in current environment immediately
+        # Update the running process first so the same request that's
+        # making this save can immediately use the new value (e.g. the
+        # validate-then-save flow).
         os.environ[key] = value
 
-    def delete_key(self, key: str):
-        """
-        Remove an environment variable from the .env file.
+        # Persist — failures here are logged inside the store and don't
+        # raise, but we surface a warning at the call site so the operator
+        # sees a hint in the response logs.
+        from app.services.app_settings.api_key_store import api_key_store
 
-        Args:
-            key: The environment variable name to remove
-        """
+        ok = api_key_store.set(key, value)
+        if not ok:
+            logger.warning(
+                "EnvService.set_key: persisted to os.environ but ApiKeyStore "
+                "write failed for %s — value will be lost on container restart.",
+                key,
+            )
+
+    def delete_key(self, key: str) -> None:
+        """Remove the key from both the running process and the store."""
         if not key or not isinstance(key, str):
             raise ValueError("Key must be a non-empty string")
 
-        # Use python-dotenv's unset_key to remove from .env file
-        success = unset_key(self.env_path, key)
-        if not success:
-            # Key might not exist, which is okay
-            pass
+        os.environ.pop(key, None)
 
-        # Also remove from current environment
-        if key in os.environ:
-            del os.environ[key]
+        from app.services.app_settings.api_key_store import api_key_store
 
-    def save(self):
-        """
-        Save changes to the .env file.
+        api_key_store.delete(key)
 
-        Educational Note: Since we're using set_key/unset_key,
-        changes are already saved. This method is for consistency.
-        """
-        # Changes are already saved by set_key/unset_key
-        # This method exists for API consistency
-        pass
+    def save(self) -> None:
+        """No-op kept for backwards compatibility (writes are immediate)."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Display helpers
+    # ------------------------------------------------------------------
 
     def mask_key(self, value: Optional[str]) -> str:
         """
-        Mask an API key for display, showing only first and last few characters.
+        Mask an API key for display.
 
-        Educational Note: This is crucial for security - we never want to
-        expose full API keys in the UI or logs.
-
-        Args:
-            value: The API key to mask
-
-        Returns:
-            Masked version like 'sk-abc***xyz'
+        Returns ``'sk-...xyz'``-style output. Short values (<= 8 chars)
+        are fully masked. Empty / None returns ``''``.
         """
         if not value:
-            return ''
-
+            return ""
         if len(value) <= 8:
-            # Very short keys, mask entirely
-            return '***'
-
-        # Show first 3 and last 3 characters
+            return "***"
         return f"{value[:3]}***{value[-3:]}"
 
     def get_all_keys(self) -> Dict[str, str]:
         """
-        Get all environment variables from the .env file.
+        Read every persisted API key as ``{key: plaintext}``.
 
-        Returns:
-            Dictionary of all key-value pairs
+        Reads from the store, not from any file. Used by diagnostic
+        surfaces — never echo this directly to the browser.
         """
-        env_vars = {}
-        if self.env_path.exists():
-            with open(self.env_path, 'r') as f:
-                for line in f:
-                    line = line.strip()
-                    if line and not line.startswith('#') and '=' in line:
-                        key, value = line.split('=', 1)
-                        # Remove quotes if present
-                        value = value.strip('"').strip("'")
-                        env_vars[key] = value
-        return env_vars
+        from app.services.app_settings.api_key_store import api_key_store
+
+        return api_key_store.load_all()

--- a/backend/supabase/migrations/00044_app_settings_api_keys.sql
+++ b/backend/supabase/migrations/00044_app_settings_api_keys.sql
@@ -1,0 +1,21 @@
+-- Persistent storage for API keys saved via Admin Settings → API Keys.
+--
+-- Before this migration, env_service.set_key() wrote to /app/.env inside the
+-- container. That file is excluded by backend/.dockerignore and lives on the
+-- container's ephemeral filesystem (only /app/data is volumed), so every key
+-- saved through the UI evaporated on the next container restart.
+--
+-- We now route writes through app_settings.api_keys instead. Values are
+-- Fernet-encrypted in the application layer before insert; the decryption
+-- key is derived from the SECRET_KEY env var. The column is JSONB so each
+-- API_KEY_NAME maps to one ciphertext entry.
+
+ALTER TABLE app_settings
+  ADD COLUMN IF NOT EXISTS api_keys JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN app_settings.api_keys IS
+  'Map of API_KEY_NAME -> Fernet-encrypted ciphertext (base64). Decryption '
+  'key is derived from the SECRET_KEY env var via SHA-256 → urlsafe-base64. '
+  'Rotating SECRET_KEY invalidates stored ciphertexts — admins must re-save. '
+  'Service-role only via Supabase default RLS (no permissive policies grant '
+  'anon/authenticated access to this table).';

--- a/backend/tests/test_api_key_store.py
+++ b/backend/tests/test_api_key_store.py
@@ -132,6 +132,33 @@ def test_decrypt_fails_gracefully_after_secret_rotation(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_source_classification_uses_value_match_not_just_presence(monkeypatch):
+    """
+    Regression: when an operator pins a key via the host env AND a stale DB
+    entry exists for the same name, source must be 'env' (not 'db'). The
+    earlier implementation classified by name presence, which silently
+    exposed pinned keys as editable in the UI.
+    """
+    monkeypatch.setenv("SECRET_KEY", "s")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    # Both stores have an entry for the same key, but the values differ.
+    store_mod.ApiKeyStore().set("NOTION_API_KEY", "stale-db-value")
+    monkeypatch.setenv("NOTION_API_KEY", "host-pinned-value")
+
+    # This is the exact comparison the GET handler performs.
+    db_values = store_mod.ApiKeyStore().load_all()
+    value = os.environ["NOTION_API_KEY"]
+    if not value:
+        source = "unset"
+    elif db_values.get("NOTION_API_KEY") == value:
+        source = "db"
+    else:
+        source = "env"
+    assert source == "env"
+
+
 def test_hydrate_environ_does_not_overwrite_existing(monkeypatch):
     monkeypatch.setenv("SECRET_KEY", "s")
     table = _FakeAppSettingsTable()

--- a/backend/tests/test_api_key_store.py
+++ b/backend/tests/test_api_key_store.py
@@ -1,0 +1,252 @@
+"""
+Tests for ApiKeyStore — encrypted persistence of API keys.
+
+These tests stub out the Supabase client so the round-trips happen against
+a dict the test controls. The Fernet path is exercised end-to-end (real
+crypto) when SECRET_KEY is set; the plaintext-fallback path is exercised
+when it's not.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Supabase auth_service constructs a dedicated client at import time.
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault(
+    "SUPABASE_SERVICE_KEY",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoidGVzdCJ9.test",
+)
+
+
+def _import_store_module():
+    return importlib.import_module(
+        "app.services.app_settings.api_key_store"
+    )
+
+
+class _FakeAppSettingsTable:
+    """In-memory stand-in for the Supabase app_settings table singleton row."""
+
+    def __init__(self, initial: dict | None = None) -> None:
+        self.row = {"api_keys": dict(initial or {})}
+
+    def select(self, _columns: str):
+        return _Query(self, mode="select")
+
+    def update(self, payload: dict):
+        return _Query(self, mode="update", payload=payload)
+
+
+class _Query:
+    def __init__(self, table: _FakeAppSettingsTable, mode: str, payload=None):
+        self.table = table
+        self.mode = mode
+        self.payload = payload
+        self._where_id = None
+
+    def eq(self, _column: str, value):  # only used for ("id", True)
+        self._where_id = value
+        return self
+
+    def limit(self, _n: int):
+        return self
+
+    def execute(self):
+        if self.mode == "select":
+            return MagicMock(data=[{"api_keys": dict(self.table.row["api_keys"])}])
+        if self.mode == "update" and self.payload is not None:
+            self.table.row["api_keys"] = dict(self.payload["api_keys"])
+            return MagicMock(data=[{"api_keys": dict(self.table.row["api_keys"])}])
+        return MagicMock(data=[])
+
+
+def _install_fake_supabase(monkeypatch, table: _FakeAppSettingsTable):
+    """Wire a fake Supabase client into the store's get_supabase()."""
+    store_mod = _import_store_module()
+    client = MagicMock()
+    client.table.return_value = table
+    monkeypatch.setattr(store_mod, "get_supabase", lambda: client)
+    monkeypatch.setattr(store_mod, "is_supabase_enabled", lambda: True)
+    return store_mod
+
+
+# ---------------------------------------------------------------------------
+# Encryption round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_fernet_round_trip_preserves_value(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "test-secret-for-fernet-derivation")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    store = store_mod.ApiKeyStore()
+    assert store.set("NOTION_API_KEY", "ntn_top_secret_value") is True
+
+    # The raw column must not contain the plaintext.
+    stored_ciphertext = table.row["api_keys"]["NOTION_API_KEY"]
+    assert "ntn_top_secret_value" not in stored_ciphertext
+    assert not stored_ciphertext.startswith("plain:")
+
+    # Round-tripping via a fresh ApiKeyStore instance (same SECRET_KEY)
+    # must recover the original.
+    fresh = store_mod.ApiKeyStore()
+    loaded = fresh.load_all()
+    assert loaded["NOTION_API_KEY"] == "ntn_top_secret_value"
+
+
+def test_plaintext_fallback_when_secret_key_missing(monkeypatch, caplog):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    with caplog.at_level("WARNING"):
+        store = store_mod.ApiKeyStore()
+    assert any("SECRET_KEY" in r.message for r in caplog.records)
+
+    store.set("FOO", "bar")
+    raw = table.row["api_keys"]["FOO"]
+    assert raw.startswith("plain:")
+    assert store.load_all() == {"FOO": "bar"}
+
+
+def test_decrypt_fails_gracefully_after_secret_rotation(monkeypatch):
+    """If SECRET_KEY rotates, old ciphertexts can't decrypt; load_all skips
+    them instead of throwing so the admin UI keeps working."""
+    monkeypatch.setenv("SECRET_KEY", "original-secret")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    store_mod.ApiKeyStore().set("FOO", "bar")
+    # Rotate the secret — a NEW store instance will use a different Fernet key.
+    monkeypatch.setenv("SECRET_KEY", "rotated-secret")
+    loaded = store_mod.ApiKeyStore().load_all()
+    assert "FOO" not in loaded  # decryption silently skipped
+
+
+# ---------------------------------------------------------------------------
+# hydrate_environ
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_environ_does_not_overwrite_existing(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "s")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    # DB has one value; os.environ has a non-empty competing value.
+    store_mod.ApiKeyStore().set("PINNED_BY_HOST", "db-value")
+    monkeypatch.setenv("PINNED_BY_HOST", "host-value")
+
+    store_mod.ApiKeyStore().hydrate_environ()
+    assert os.environ["PINNED_BY_HOST"] == "host-value"
+
+
+def test_hydrate_environ_fills_in_empty(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "s")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    store_mod.ApiKeyStore().set("UNSET_BY_HOST", "from-db")
+    monkeypatch.delenv("UNSET_BY_HOST", raising=False)
+
+    n = store_mod.ApiKeyStore().hydrate_environ()
+    assert n >= 1
+    assert os.environ["UNSET_BY_HOST"] == "from-db"
+
+
+# ---------------------------------------------------------------------------
+# JSONB merge preserves unrelated keys
+# ---------------------------------------------------------------------------
+
+
+def test_set_preserves_unrelated_keys(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "s")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    store = store_mod.ApiKeyStore()
+    store.set("A", "alpha")
+    store.set("B", "beta")
+    store.set("A", "alpha2")  # update, not replace-whole-map
+
+    loaded = store.load_all()
+    assert loaded == {"A": "alpha2", "B": "beta"}
+
+
+def test_delete_is_idempotent(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "s")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    store = store_mod.ApiKeyStore()
+    store.set("A", "alpha")
+    assert store.delete("A") is True
+    assert store.delete("A") is True  # no-op the second time
+    assert store.load_all() == {}
+
+
+# ---------------------------------------------------------------------------
+# First-boot legacy migration
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_env_file_moves_known_keys(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "s")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# header comment\n"
+        "NOTION_API_KEY=ntn_legacy_value\n"
+        "PORT=5001\n"  # unrelated — must be kept
+        "OPENAI_API_KEY=\"sk-quoted\"\n"
+        "\n",
+        encoding="utf-8",
+    )
+
+    migrated = store_mod.migrate_env_file_into_store(
+        env_file, known_keys={"NOTION_API_KEY", "OPENAI_API_KEY"}
+    )
+    assert migrated == 2
+
+    # Store has the keys (decrypted).
+    loaded = store_mod.ApiKeyStore().load_all()
+    assert loaded["NOTION_API_KEY"] == "ntn_legacy_value"
+    assert loaded["OPENAI_API_KEY"] == "sk-quoted"
+
+    # PORT must still be in the file.
+    text = env_file.read_text(encoding="utf-8")
+    assert "PORT=5001" in text
+    assert "NOTION_API_KEY" not in text
+    assert "OPENAI_API_KEY" not in text
+
+
+def test_migrate_env_file_skips_when_no_matching_keys(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "s")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("PORT=5001\nFLASK_ENV=production\n", encoding="utf-8")
+    before = env_file.read_text(encoding="utf-8")
+
+    n = store_mod.migrate_env_file_into_store(
+        env_file, known_keys={"NOTION_API_KEY"}
+    )
+    assert n == 0
+    # File untouched.
+    assert env_file.read_text(encoding="utf-8") == before
+
+
+def test_migrate_env_file_absent_is_zero(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "s")
+    table = _FakeAppSettingsTable()
+    store_mod = _install_fake_supabase(monkeypatch, table)
+
+    missing = tmp_path / "nope.env"
+    assert store_mod.migrate_env_file_into_store(missing, {"NOTION_API_KEY"}) == 0

--- a/frontend/src/components/settings/sections/ApiKeysSection.tsx
+++ b/frontend/src/components/settings/sections/ApiKeysSection.tsx
@@ -236,6 +236,10 @@ export const ApiKeysSection: React.FC = () => {
     const isModified = !!modifiedKeys[apiKey.id];
     const isConfigured = apiKey.is_set && !isModified;
     const validation = validationState[apiKey.id];
+    // 'env' = pinned by the host (docker-compose / Coolify). Input + Validate
+    // + Delete are all disabled because the UI cannot override or remove a
+    // host-injected value — the operator has to change it in deployment env.
+    const isPinned = apiKey.source === 'env';
 
     return (
       <div
@@ -265,6 +269,14 @@ export const ApiKeysSection: React.FC = () => {
                 Active
               </span>
             )}
+            {isPinned && (
+              <span
+                className="inline-flex items-center gap-1 text-[11px] font-medium text-stone-700 bg-stone-200 px-2 py-0.5 rounded-full"
+                title="This key is set via the host environment and can't be changed from the UI."
+              >
+                Pinned by deployment
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-1 opacity-60 group-hover:opacity-100 transition-opacity">
             <button
@@ -278,9 +290,9 @@ export const ApiKeysSection: React.FC = () => {
             <button
               type="button"
               onClick={() => setDeleteConfirmId(apiKey.id)}
-              disabled={!apiKey.value && !apiKey.is_set}
+              disabled={(!apiKey.value && !apiKey.is_set) || isPinned}
               className="p-1.5 rounded-md text-stone-400 hover:text-red-500 hover:bg-red-50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-              title="Delete key"
+              title={isPinned ? 'Pinned by deployment — change in host environment' : 'Delete key'}
             >
               <Trash size={15} />
             </button>
@@ -291,16 +303,17 @@ export const ApiKeysSection: React.FC = () => {
         <div className="flex gap-2">
           <Input
             type={showApiKeys[apiKey.id] ? 'text' : 'password'}
-            placeholder={`Enter ${apiKey.name} key...`}
+            placeholder={isPinned ? 'Set via host environment' : `Enter ${apiKey.name} key...`}
             value={modifiedKeys[apiKey.id] !== undefined ? modifiedKeys[apiKey.id] : apiKey.value}
             onChange={(e) => updateApiKey(apiKey.id, e.target.value)}
-            className="font-mono text-[12px] flex-1 h-9 bg-white border-stone-200 focus:border-amber-400"
+            disabled={isPinned}
+            className="font-mono text-[12px] flex-1 h-9 bg-white border-stone-200 focus:border-amber-400 disabled:bg-stone-50 disabled:cursor-not-allowed"
           />
           <Button
             variant="default"
             size="sm"
             onClick={() => validateApiKey(apiKey.id)}
-            disabled={!modifiedKeys[apiKey.id] || modifiedKeys[apiKey.id].includes('***') || validation?.validating}
+            disabled={isPinned || !modifiedKeys[apiKey.id] || modifiedKeys[apiKey.id].includes('***') || validation?.validating}
             className="h-9 px-3.5 text-[12px] font-semibold min-w-[115px]"
           >
             {validation?.validating ? (
@@ -320,6 +333,13 @@ export const ApiKeysSection: React.FC = () => {
         {/* Description + validation feedback */}
         <div className="mt-2 space-y-1">
           <p className="text-[11px] text-stone-400 leading-relaxed">{apiKey.description}</p>
+          {isPinned && (
+            <p className="text-[11px] text-stone-500 leading-relaxed">
+              This key is set via the host environment (docker-compose /
+              Coolify) and can&apos;t be changed from the UI. Update it in
+              your deployment env and restart the backend to pick up changes.
+            </p>
+          )}
           {validation?.message && (() => {
             if (!validation.valid) {
               return (

--- a/frontend/src/components/sources/AddSourcesSheet.tsx
+++ b/frontend/src/components/sources/AddSourcesSheet.tsx
@@ -98,12 +98,18 @@ export const AddSourcesSheet: React.FC<AddSourcesSheetProps> = ({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="left" className="w-[500px] sm:w-[600px]">
-        <SheetHeader>
+      {/* flex-col + a flex-1 overflow-y-auto body so long content (e.g. the
+          full Notion setup guide) scrolls inside the sheet instead of
+          getting clipped below the viewport. */}
+      <SheetContent
+        side="left"
+        className="w-[500px] sm:w-[600px] flex flex-col h-full"
+      >
+        <SheetHeader className="flex-shrink-0">
           <SheetTitle>Add sources</SheetTitle>
         </SheetHeader>
 
-        <div className="mt-6">
+        <div className="mt-6 flex-1 overflow-y-auto pr-1 -mr-1">
           <p className="text-sm text-muted-foreground mb-4">
             Sources let NoobBook base its responses on the information that
             matters most to you. ({sourcesCount}/{MAX_SOURCES} used)

--- a/frontend/src/components/sources/NotionSetupGuide.tsx
+++ b/frontend/src/components/sources/NotionSetupGuide.tsx
@@ -1,0 +1,156 @@
+/**
+ * NotionSetupGuide — step-by-step instructions for getting a Notion
+ * integration token created, wired into NoobBook, and granted access to
+ * the pages the user wants to import.
+ *
+ * Two variants:
+ *  - "full"    : all 9 steps. Used in the Notion tab's "Not Configured"
+ *                empty state so a first-time admin can complete setup
+ *                without leaving the app.
+ *  - "sharing" : just the per-page sharing reminder (steps 6–9). Used
+ *                when the integration token IS configured but the search
+ *                returned no results — almost always because the user
+ *                hasn't shared any pages with the integration yet.
+ *
+ * We don't try to deep-link into Admin Settings → API Keys: that surface
+ * lives in another sheet (AppSettings) and chaining sheet-over-sheet is
+ * fiddly. The guide references the path in text instead — users can close
+ * Add Sources and use the existing admin nav.
+ */
+import React from 'react';
+import { ArrowSquareOut, Info, NotionLogo } from '@phosphor-icons/react';
+
+interface NotionSetupGuideProps {
+  variant: 'full' | 'sharing';
+}
+
+const NOTION_INTEGRATIONS_URL = 'https://www.notion.so/profile/integrations';
+
+const Step: React.FC<{ n: number; children: React.ReactNode }> = ({ n, children }) => (
+  <li className="flex gap-3">
+    <span
+      aria-hidden="true"
+      className="shrink-0 mt-0.5 inline-flex items-center justify-center w-6 h-6 rounded-full bg-amber-600 text-white text-xs font-semibold"
+    >
+      {n}
+    </span>
+    <div className="text-sm leading-relaxed text-stone-700">{children}</div>
+  </li>
+);
+
+const ExternalLinkButton: React.FC<{ href: string; children: React.ReactNode }> = ({
+  href,
+  children,
+}) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-amber-600 bg-amber-600 text-white text-xs font-medium hover:bg-amber-700 hover:border-amber-700 transition-colors"
+  >
+    {children}
+    <ArrowSquareOut size={12} weight="bold" />
+  </a>
+);
+
+const SharingSteps: React.FC = () => (
+  <ol className="space-y-3">
+    <Step n={1}>
+      In Notion, open the page or database you want to import.
+    </Step>
+    <Step n={2}>
+      Click the <strong>•••</strong> menu in the top-right of the page.
+    </Step>
+    <Step n={3}>
+      Pick <strong>Connections</strong> → search for your integration (e.g.{' '}
+      <em>NoobBook</em>) → <strong>Confirm</strong>.
+    </Step>
+    <Step n={4}>
+      <span className="inline-flex items-start gap-1.5">
+        <Info size={14} weight="fill" className="text-amber-600 shrink-0 mt-0.5" />
+        <span>
+          <strong>Tip:</strong> sharing a parent page auto-grants access to
+          every nested child. Sharing your workspace root once is usually
+          enough.
+        </span>
+      </span>
+    </Step>
+  </ol>
+);
+
+export const NotionSetupGuide: React.FC<NotionSetupGuideProps> = ({ variant }) => {
+  if (variant === 'sharing') {
+    return (
+      <div className="text-left rounded-md border border-stone-200 bg-stone-50 px-4 py-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <NotionLogo size={18} weight="duotone" className="text-stone-700" />
+          <h4 className="text-sm font-semibold text-stone-900">
+            Share pages with the integration to see them here
+          </h4>
+        </div>
+        <SharingSteps />
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-left rounded-md border border-stone-200 bg-stone-50 px-5 py-5 space-y-5">
+      {/* Section 1: integration token setup (admin) */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <h4 className="text-sm font-semibold text-stone-900">
+            Once per deployment (admin)
+          </h4>
+          <ExternalLinkButton href={NOTION_INTEGRATIONS_URL}>
+            Open Notion integrations
+          </ExternalLinkButton>
+        </div>
+        <ol className="space-y-3">
+          <Step n={1}>
+            Go to{' '}
+            <a
+              href={NOTION_INTEGRATIONS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-amber-700 underline hover:text-amber-800"
+            >
+              notion.so/profile/integrations
+            </a>{' '}
+            and click <strong>+ New integration</strong>.
+          </Step>
+          <Step n={2}>
+            Name it (e.g. <em>NoobBook</em>), pick your workspace, set type
+            to <strong>Internal</strong>.
+          </Step>
+          <Step n={3}>
+            Under <strong>Capabilities</strong>, enable{' '}
+            <strong>Read content</strong>. Read-only is enough — NoobBook
+            never writes back to Notion.
+          </Step>
+          <Step n={4}>
+            Copy the <strong>Internal Integration Secret</strong> (starts
+            with <code className="text-[11px] px-1 py-0.5 rounded bg-stone-200">ntn_…</code>{' '}
+            or <code className="text-[11px] px-1 py-0.5 rounded bg-stone-200">secret_…</code>).
+          </Step>
+          <Step n={5}>
+            Paste it into <strong>Admin Settings → API Keys → Notion Integration</strong>{' '}
+            and click <strong>Validate &amp; Save</strong>.
+          </Step>
+        </ol>
+      </section>
+
+      {/* Section 2: per-page sharing (every user, every resource) */}
+      <section className="space-y-3 pt-1 border-t border-stone-200">
+        <h4 className="text-sm font-semibold text-stone-900 pt-3">
+          For each page or database you want to import
+        </h4>
+        <p className="text-xs text-stone-500 leading-relaxed -mt-1">
+          The token alone doesn&apos;t expose anything — you have to share
+          each resource with the integration explicitly. This is also how
+          you keep private pages out of NoobBook.
+        </p>
+        <SharingSteps />
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/components/sources/NotionTab.tsx
+++ b/frontend/src/components/sources/NotionTab.tsx
@@ -21,6 +21,7 @@ import { Input } from '../ui/input';
 import { sourcesAPI, type NotionPickerItem } from '../../lib/api/sources';
 import { useToast } from '../ui/use-toast';
 import { createLogger } from '@/lib/logger';
+import { NotionSetupGuide } from './NotionSetupGuide';
 
 const log = createLogger('notion-tab');
 
@@ -163,14 +164,16 @@ export const NotionTab: React.FC<NotionTabProps> = ({ projectId, isAtLimit, onAd
 
   if (!configured) {
     return (
-      <div className="flex flex-col items-center justify-center py-12 text-center">
-        <NotionLogo size={48} weight="duotone" className="text-muted-foreground mb-4" />
-        <h3 className="font-medium mb-2">Notion Not Configured</h3>
-        <p className="text-sm text-muted-foreground max-w-sm">
-          An administrator needs to add the Notion integration token in
-          Admin Settings → API Keys (<code>NOTION_API_KEY</code>) before
-          this can be used.
-        </p>
+      <div className="py-6 space-y-5">
+        <div className="flex flex-col items-center text-center">
+          <NotionLogo size={48} weight="duotone" className="text-muted-foreground mb-3" />
+          <h3 className="font-medium mb-1">Notion Not Configured</h3>
+          <p className="text-sm text-muted-foreground max-w-sm">
+            Notion needs a one-time setup before pages and databases can be
+            imported. Follow the steps below to get connected.
+          </p>
+        </div>
+        <NotionSetupGuide variant="full" />
       </div>
     );
   }
@@ -227,10 +230,11 @@ export const NotionTab: React.FC<NotionTabProps> = ({ projectId, isAtLimit, onAd
             <CircleNotch size={20} className="animate-spin text-muted-foreground" />
           </div>
         ) : results.length === 0 ? (
-          <div className="text-sm text-muted-foreground text-center py-8 px-4">
-            No Notion {filter === 'all' ? 'pages or databases' : `${filter}s`} found.
-            Make sure your Notion integration has been shared with the workspace
-            you want to import from.
+          <div className="py-6 px-4 space-y-4">
+            <p className="text-sm text-muted-foreground text-center">
+              No Notion {filter === 'all' ? 'pages or databases' : `${filter}s`} found.
+            </p>
+            <NotionSetupGuide variant="sharing" />
           </div>
         ) : (
           <ul className="divide-y">

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -18,6 +18,15 @@ export interface ApiKey {
   required?: boolean;
   value: string;
   is_set: boolean;
+  /**
+   * Where the current value came from. Older backends won't send this; treat
+   * undefined as the legacy default (editable).
+   *  - 'env':   injected by the host environment (docker-compose / Coolify).
+   *             Pinned — the UI cannot override or delete it from here.
+   *  - 'db':    persisted in Supabase via the UI — editable + deletable.
+   *  - 'unset': no value anywhere.
+   */
+  source?: 'env' | 'db' | 'unset';
 }
 
 export interface ApiKeyUpdate {


### PR DESCRIPTION
## Summary
Roll-up of 4 commits sitting on develop:

- **Persist API keys in Supabase** (#290): UI-saved API keys now survive container restarts (encrypted via Fernet in `app_settings.api_keys`). Build-time env vars still win when present, surfaced as a "Pinned by deployment" badge in the UI.
- **Notion setup guide**: inline 9-step setup guide in the "Notion Not Configured" empty state — including the per-page sharing reminder that's almost always the actual blocker.
- **Sheet scroll fix**: AddSourcesSheet body is now scrollable so the full guide isn't clipped below the viewport.
- **Greptile P1+P2 fix on #290**: source classification now compares actual values (not just key presence) so a stale DB entry shadowed by a host-injected key correctly reports as 'env'-pinned.

## Test plan
- [x] CI green on the source PRs (pytest, lint+build).
- [x] Full backend suite (362+ tests) passes; tsc + eslint clean.
- [ ] Smoke on prod after merge: save a Notion key via Admin Settings → restart backend → key still set; add a Notion source → picker populates → processing completes.