### PR TITLE
fix(freshdesk): finish 30→90 day bump missed by db409ee

### DIFF
--- a/backend/app/api/sources/uploads.py
+++ b/backend/app/api/sources/uploads.py
@@ -440,7 +440,7 @@ def sync_freshdesk_source(project_id: str, source_id: str):
 
 @sources_bp.route('/projects/<project_id>/sources/<source_id>/freshdesk-backfill', methods=['POST'])
 def backfill_freshdesk_source(project_id: str, source_id: str):
-    """Clear all tickets and re-fetch last 30 days as a background task."""
+    """Clear all tickets and re-fetch last 90 days as a background task."""
     try:
         from app.services.integrations.freshdesk.freshdesk_service import freshdesk_service
         if not freshdesk_service.is_configured():
@@ -451,7 +451,7 @@ def backfill_freshdesk_source(project_id: str, source_id: str):
         task_service.submit_task(
             "freshdesk_backfill", source_id,
             _run_freshdesk_sync,
-            project_id, source_id, "backfill", 30, True,
+            project_id, source_id, "backfill", 90, True,
         )
 
         return jsonify({

--- a/backend/app/services/source_services/source_processing/freshdesk_processor.py
+++ b/backend/app/services/source_services/source_processing/freshdesk_processor.py
@@ -117,7 +117,7 @@ def process_freshdesk(
     embedding_info = source.get("embedding_info", {}) or {}
     raw_meta = _load_raw_metadata(raw_file_path)
 
-    days_back = embedding_info.get("days_back") or raw_meta.get("days_back") or 30
+    days_back = embedding_info.get("days_back") or raw_meta.get("days_back") or 90
 
     # Step 1: Check if global tickets already exist (skip sync if so)
     existing_stats = freshdesk_sync_service.get_sync_stats()

--- a/backend/app/services/source_services/source_upload/freshdesk_upload.py
+++ b/backend/app/services/source_services/source_upload/freshdesk_upload.py
@@ -27,7 +27,7 @@ def add_freshdesk_source(
     project_id: str,
     name: Optional[str] = None,
     description: str = "",
-    days_back: int = 30,
+    days_back: int = 90,
 ) -> Dict[str, Any]:
     """
     Create a FRESHDESK source in a project and trigger processing.

--- a/frontend/src/components/sources/FreshdeskTab.tsx
+++ b/frontend/src/components/sources/FreshdeskTab.tsx
@@ -81,7 +81,7 @@ export const FreshdeskTab: React.FC<FreshdeskTabProps> = ({ isAtLimit, onAddFres
       </Button>
 
       <p className="text-xs text-muted-foreground">
-        NoobBook will sync the last 30 days of tickets, generate a summary, and enable SQL-based ticket analysis in chat.
+        NoobBook will sync the last 90 days of tickets, generate a summary, and enable SQL-based ticket analysis in chat.
       </p>
     </div>
   );

--- a/frontend/src/components/sources/SourceItem.tsx
+++ b/frontend/src/components/sources/SourceItem.tsx
@@ -518,7 +518,7 @@ export const SourceItem: React.FC<SourceItemProps> = ({
               Re-sync Freshdesk Tickets
             </AlertDialogTitle>
             <AlertDialogDescription>
-              This will <strong>clear all synced tickets</strong> and re-fetch the last 30 days from Freshdesk. If you only need the latest updates, use the <strong>sync button</strong> instead — it fetches only new and updated tickets without clearing existing data.
+              This will <strong>clear all synced tickets</strong> and re-fetch the last 90 days from Freshdesk. If you only need the latest updates, use the <strong>sync button</strong> instead — it fetches only new and updated tickets without clearing existing data.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/frontend/src/components/sources/SourcesPanel.tsx
+++ b/frontend/src/components/sources/SourcesPanel.tsx
@@ -509,7 +509,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     try {
       const created = await sourcesAPI.addFreshdeskSource(projectId, name, description);
       setSources((prev) => upsertOne(prev, { ...created, active: selectedSourceIdsRef.current.includes(created.id) }, { prepend: true }));
-      success('Freshdesk sync started — fetching last 30 days of tickets. Check the status bar for progress.');
+      success('Freshdesk sync started — fetching last 90 days of tickets. Check the status bar for progress.');
       setSheetOpen(false);
     } catch (err: unknown) {
       log.error({ err }, 'failed to add Freshdesk source');


### PR DESCRIPTION
## Summary

[db409ee](https://github.com/TeacherOp/NoobBook/commit/db409ee) bumped the Freshdesk default fetch window from 30 → 90 days in 4 files but missed **7 stale references** — 1 live bug, 2 latent backend regressions, 3 user-visible UI strings, and 1 docstring.

### The live bug
`backend/app/api/sources/uploads.py:454` — the `freshdesk-backfill` endpoint submitted the background task with a hard-coded `30`:
```python
project_id, source_id, "backfill", 30, True,
```
So the "Clear and re-fetch" action in the UI would silently re-pull only 30 days, even though the surrounding defaults all said 90.

### Latent backend regressions
- `source_upload/freshdesk_upload.py` — `add_freshdesk_source(days_back=30)` default. The outer wrapper at `source_service.py:432` passes 90 explicitly today, so it didn't bite — but any internal caller omitting the kwarg would get 30.
- `source_processing/freshdesk_processor.py:120` — fallback `or 30` when a source's stored metadata lacks `days_back` (older sources / failed metadata writes).

### User-visible UI strings (all said "30 days")
- `FreshdeskTab.tsx` — onboarding hint in the Add-source dialog
- `SourcesPanel.tsx` — sync-started toast
- `SourceItem.tsx` — backfill confirmation dialog

## End-to-end verification

| FE call | Endpoint | Resolves to |
|---|---|---|
| `addFreshdeskSource` | `POST /sources/freshdesk` | `uploads.py` default → **90** ✓ |
| `syncFreshdesk` | `POST /sources/{id}/freshdesk-sync` | `uploads.py` default → **90** ✓ |
| `backfillFreshdesk` | `POST /sources/{id}/freshdesk-backfill` | hard-coded **90** (this PR) ✓ |

All paths flow into `FreshdeskSyncService.sync_tickets(days_back=90)` → `fetch_all_tickets_batched(days_back=90)` → `since = now - timedelta(days=90)`.

Remaining `30`s in freshdesk code are intentional and unrelated to the fetch window (auto-sync interval, HTTP timeouts, pagination safeguards, SQL example queries in the analyzer prompt).

## Test plan

- [ ] Add a new Freshdesk source via the UI — onboarding hint reads "last 90 days"
- [ ] Sync triggers toast reading "fetching last 90 days of tickets"
- [ ] Click "Clear and re-fetch" — confirm dialog reads "last 90 days from Freshdesk"; backend fetches ~90 days of tickets (not 30)
- [ ] Existing sources without `days_back` in metadata re-sync at 90 days via the processor fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)