### PR TITLE
fix(chat): keep user messages with image attachments in chat transcript

### DIFF
--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -135,6 +135,19 @@ class ChatService:
         return chats
 
     @staticmethod
+    def _content_has_tool_block(content: List[Dict[str, Any]]) -> bool:
+        """True if a list-content message includes any tool_use / tool_result
+        block — i.e. it's a Claude tool-chain intermediate, not user-visible.
+
+        Centralized so the two call sites (`_is_displayable_message` and the
+        transcript filter in `get_chat`) can't drift if the tool block types
+        ever change."""
+        return any(
+            isinstance(b, dict) and b.get("type") in ("tool_use", "tool_result")
+            for b in content
+        )
+
+    @staticmethod
     def _is_displayable_message(msg: Dict[str, Any]) -> bool:
         """
         True if a message row should appear in the user-visible chat
@@ -155,11 +168,7 @@ class ChatService:
         #      displayable.
         # Distinguish by inspecting the block types.
         if isinstance(content, list):
-            has_tool_block = any(
-                isinstance(b, dict) and b.get("type") in ("tool_use", "tool_result")
-                for b in content
-            )
-            if has_tool_block:
+            if ChatService._content_has_tool_block(content):
                 return False
             has_image = any(
                 isinstance(b, dict) and b.get("type") == "image"
@@ -345,11 +354,7 @@ class ChatService:
                 # (keep — the formatter re-signs storage URLs and projects
                 # the block list down to the frontend shape).
                 if isinstance(content, list):
-                    has_tool_block = any(
-                        isinstance(b, dict) and b.get("type") in ("tool_use", "tool_result")
-                        for b in content
-                    )
-                    if has_tool_block:
+                    if ChatService._content_has_tool_block(content):
                         continue
                     # Lazy import: message_service depends on storage_service
                     # and storage_service depends on supabase client, so a

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -146,10 +146,35 @@ class ChatService:
         if msg.get("role") not in ("user", "assistant"):
             return False
         content = msg.get("content")
-        # List-content rows are tool-chain intermediates (assistant
-        # tool_use envelopes and user tool_result wrappers).
+        # List-content rows fall into two distinct buckets:
+        #   1. Tool-chain intermediates (assistant tool_use envelopes,
+        #      user tool_result wrappers) — NOT displayable, the final
+        #      assistant message already carries the accumulated text.
+        #   2. User messages with inline image attachments, persisted as
+        #      [{type:image,...}, {type:text,...}] by the upload route —
+        #      displayable.
+        # Distinguish by inspecting the block types.
         if isinstance(content, list):
-            return False
+            has_tool_block = any(
+                isinstance(b, dict) and b.get("type") in ("tool_use", "tool_result")
+                for b in content
+            )
+            if has_tool_block:
+                return False
+            has_image = any(
+                isinstance(b, dict) and b.get("type") == "image"
+                for b in content
+            )
+            if has_image:
+                return True
+            # Pure-text list (rare but legal) — non-empty if any text block
+            # has non-empty content.
+            text = "\n".join(
+                b.get("text", "")
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+            return bool(text.strip())
         if isinstance(content, dict):
             text = content.get("text", "")
         elif isinstance(content, str):
@@ -315,9 +340,35 @@ class ChatService:
                 if role not in ["user", "assistant"]:
                     continue
 
-                # Skip list-content messages — these are tool chain intermediates
-                # (tool_use assistant responses and tool_result user messages)
+                # List-content rows are either tool-chain intermediates
+                # (skip) or user messages with inline image attachments
+                # (keep — the formatter re-signs storage URLs and projects
+                # the block list down to the frontend shape).
                 if isinstance(content, list):
+                    has_tool_block = any(
+                        isinstance(b, dict) and b.get("type") in ("tool_use", "tool_result")
+                        for b in content
+                    )
+                    if has_tool_block:
+                        continue
+                    # Lazy import: message_service depends on storage_service
+                    # and storage_service depends on supabase client, so a
+                    # top-level import creates a circular load at app start.
+                    from app.services.data_services import message_service as _ms
+                    formatted = _ms.message_service._format_message_for_frontend(msg)
+                    formatted_content = formatted.get("content")
+                    # Skip if the formatter projected the message down to
+                    # nothing renderable (empty list / empty string).
+                    if not formatted_content:
+                        continue
+                    display_messages.append({
+                        "id": formatted.get("id"),
+                        "role": formatted.get("role"),
+                        "content": formatted_content,
+                        "timestamp": formatted.get("timestamp"),
+                        "model": formatted.get("model"),
+                        "citations": formatted.get("citations", []),
+                    })
                     continue
 
                 if isinstance(content, dict):

--- a/backend/supabase/migrations/00045_chat_count_image_messages.sql
+++ b/backend/supabase/migrations/00045_chat_count_image_messages.sql
@@ -1,0 +1,73 @@
+-- Migration: list_chats_with_message_count — count image-attachment messages
+-- Description: 00029 introduced this RPC with a filter that excluded ALL
+--              jsonb_typeof(content) = 'array' rows on the assumption that
+--              array content always meant tool_use / tool_result wrappers.
+--
+--              That assumption broke when inline image attachments shipped:
+--              user messages with a screenshot persist as
+--                  [{"type":"image","storage_path":...}, {"type":"text","text":"..."}]
+--              i.e. array-typed content that IS user-visible. The previous
+--              SQL undercounted those messages in the chat sidebar, and the
+--              mirror Python filter (`_is_displayable_message`) dropped them
+--              from the chat transcript entirely.
+--
+--              This migration recreates the RPC with a more precise array
+--              filter that mirrors the corrected Python logic:
+--                - skip arrays containing any tool_use / tool_result block
+--                - count arrays that contain an image block (with or without
+--                  text) — those are the inline-attachment user messages
+--                - count arrays whose text blocks have non-empty trimmed text
+
+CREATE OR REPLACE FUNCTION list_chats_with_message_count(p_project_id UUID)
+RETURNS TABLE (
+    id UUID,
+    title TEXT,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ,
+    costs JSONB,
+    message_count BIGINT
+)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT
+        c.id,
+        c.title,
+        c.created_at,
+        c.updated_at,
+        c.costs,
+        COALESCE((
+            SELECT COUNT(*)
+            FROM messages m
+            WHERE m.chat_id = c.id
+              AND m.role IN ('user', 'assistant')
+              AND (
+                  -- string-typed JSONB: "hello" → trimmed text length > 0
+                  (jsonb_typeof(m.content) = 'string'
+                      AND length(btrim(m.content #>> '{}')) > 0)
+                  -- object-typed JSONB: {"text":"hello"} → text field non-empty
+                  OR (jsonb_typeof(m.content) = 'object'
+                      AND length(btrim(COALESCE(m.content->>'text', ''))) > 0)
+                  -- array-typed JSONB: user message with inline image
+                  -- attachments. Allowed if it contains NO tool_use/
+                  -- tool_result block, AND has either an image block or a
+                  -- text block with non-empty content.
+                  OR (jsonb_typeof(m.content) = 'array'
+                      AND NOT EXISTS (
+                          SELECT 1 FROM jsonb_array_elements(m.content) elem
+                          WHERE elem->>'type' IN ('tool_use', 'tool_result')
+                      )
+                      AND EXISTS (
+                          SELECT 1 FROM jsonb_array_elements(m.content) elem
+                          WHERE elem->>'type' = 'image'
+                             OR (elem->>'type' = 'text'
+                                 AND length(btrim(COALESCE(elem->>'text', ''))) > 0)
+                      ))
+              )
+        ), 0)::BIGINT AS message_count
+    FROM chats c
+    WHERE c.project_id = p_project_id
+    ORDER BY c.updated_at DESC;
+$$;
+
+GRANT EXECUTE ON FUNCTION list_chats_with_message_count(UUID) TO anon, authenticated, service_role;


### PR DESCRIPTION
## The actual root cause

The previous PRs (#295, #296) were necessary but insufficient. Even with the signed-URL fix and `SUPABASE_PUBLIC_URL` corrected on Coolify, screenshots still vanished on refresh — because **`chat_service.get_chat()` was filtering the user messages out of the response entirely**.

Confirmed by querying prod directly:

```sql
SELECT id, role, content FROM messages WHERE chat_id = '…';
-- d6fc6969  user       [{"type":"image","url":"https://app.noobbooklm.com/storage/...", ...}, {"type":"text","text":"what is this image"}]
-- d6370c7e  user       [{"type":"image", ...}, {"type":"text","text":"again"}]
-- (3 user messages exist in the DB)
```

But the formatted API response had ZERO user messages:

```
total messages in formatted chat: 4
0 assistant 1ea4b864 ...
1 assistant 3e82aa5e ...
2 assistant 3a0d8125 ...
3 assistant 89d7e094 ...
```

## Why

The filter at `chat_service.get_chat:320-321` (and the mirror at `_is_displayable_message:151-152`) drops every list-content row on the assumption that list content = `tool_use` / `tool_result` wrapper:

\`\`\`python
if isinstance(content, list):
    continue   # 'tool chain intermediate'
\`\`\`

That assumption was true when written, but stopped holding when inline image attachments shipped — user messages with a screenshot now persist as a list of `{image_block, text_block}`. The filter swept them up with the tool intermediates and the frontend rendered exactly what it got: AI bubbles with nothing above them.

## What changed

Three places had the same bad assumption; all three fixed to distinguish "tool chain list" from "user image+text list":

1. **`chat_service.get_chat`** — routes user-content lists through `message_service._format_message_for_frontend`, which re-signs storage URLs on every read (so chats whose persisted URL was minted before the `SUPABASE_PUBLIC_URL` env fix will heal as soon as this deploys — no backfill).
2. **`chat_service._is_displayable_message`** — same distinction; sidebar count now includes image messages.
3. **`backend/supabase/migrations/00045_chat_count_image_messages.sql`** — recreates the `list_chats_with_message_count` RPC with the matching SQL filter (arrays count when they have no tool block AND have either an image block or non-empty text block).

## Test plan

- [ ] Deploy on Coolify
- [ ] Run migration `00045`
- [ ] Refresh the existing BMW-logo chat → previous user messages with images render with the screenshot and text caption
- [ ] Send a new screenshot in a fresh chat → bubble appears on send, survives refresh, image actually loads
- [ ] Send a text-only message → no regression on the no-attachment path
- [ ] Tool-use chats (web search, DB query) still skip their intermediate envelopes — assistant transcript stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)