### PR TITLE
feat(chat): skeleton bubbles on chat switch — no more blank flash

### DIFF
--- a/frontend/src/components/chat/ChatMessagesSkeleton.tsx
+++ b/frontend/src/components/chat/ChatMessagesSkeleton.tsx
@@ -18,6 +18,7 @@
  * `aria-busy="true"` on the wrapper so screen readers announce
  * "loading" instead of reading the empty bubble divs aloud.
  */
+import React from 'react';
 import { Skeleton } from '../ui/skeleton';
 
 const MAX_BUBBLES = 6;

--- a/frontend/src/components/chat/ChatMessagesSkeleton.tsx
+++ b/frontend/src/components/chat/ChatMessagesSkeleton.tsx
@@ -1,0 +1,86 @@
+/**
+ * ChatMessagesSkeleton — alternating user / AI bubble placeholders
+ * shown while a chat's message history is being fetched.
+ *
+ * Used in two places:
+ *   1. ChatPanel project-mount loading branch (was a hand-rolled
+ *      inline skeleton — extracted here so the two surfaces stay in
+ *      lockstep).
+ *   2. ChatPanel chat-switch path — sized by the sidebar's cached
+ *      `message_count` so a 2-message chat shows 2 placeholders and
+ *      a 20-message chat shows the capped 6.
+ *
+ * Why the cap: the panel scrolls; the user never sees more than a
+ * handful at once. Rendering 50 placeholders for a 50-message chat
+ * is just animated noise and inflates the initial paint cost for no
+ * UX benefit.
+ *
+ * `aria-busy="true"` on the wrapper so screen readers announce
+ * "loading" instead of reading the empty bubble divs aloud.
+ */
+import { Skeleton } from '../ui/skeleton';
+
+const MAX_BUBBLES = 6;
+const DEFAULT_BUBBLES = 4;
+
+interface ChatMessagesSkeletonProps {
+  /** Expected message count for the chat being loaded. Capped at
+   * MAX_BUBBLES. Defaults to DEFAULT_BUBBLES when omitted or
+   * non-positive (e.g. a brand-new chat whose count is unknown). */
+  count?: number;
+}
+
+export const ChatMessagesSkeleton: React.FC<ChatMessagesSkeletonProps> = ({
+  count,
+}) => {
+  // Brand-new chats with count=0 render nothing — the caller's empty
+  // state takes over once the fetch lands.
+  if (count === 0) return null;
+
+  const bubbleCount = Math.min(
+    MAX_BUBBLES,
+    !count || count < 0 ? DEFAULT_BUBBLES : count,
+  );
+
+  return (
+    <div className="space-y-4" aria-busy="true" aria-live="polite">
+      {Array.from({ length: bubbleCount }, (_, i) => {
+        // Alternate user (right, single bubble) / AI (left, avatar +
+        // 2–3 text rows) — matches the rhythm of an actual chat
+        // transcript so the placeholder reads as "messages incoming"
+        // not "panel half-broken".
+        const isUser = i % 2 === 0;
+        // Deterministic width variation so the skeleton doesn't look
+        // like a metronome. The (7 * i) % 30 nudge keeps consecutive
+        // bubbles visibly different widths without random churn on
+        // re-render.
+        const widthPct = 55 + ((i * 7) % 30);
+        return isUser ? (
+          <UserBubble key={i} widthPct={widthPct} />
+        ) : (
+          <AIBubble key={i} widthPct={widthPct} />
+        );
+      })}
+    </div>
+  );
+};
+
+const UserBubble: React.FC<{ widthPct: number }> = ({ widthPct }) => (
+  <div className="flex justify-end">
+    <Skeleton
+      className="h-10 rounded-2xl"
+      style={{ width: `${widthPct}%` }}
+    />
+  </div>
+);
+
+const AIBubble: React.FC<{ widthPct: number }> = ({ widthPct }) => (
+  <div className="flex justify-start gap-3">
+    <Skeleton className="h-8 w-8 rounded-full flex-shrink-0" />
+    <div className="space-y-2 flex-1" style={{ maxWidth: `${widthPct}%` }}>
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-3/4" />
+    </div>
+  </div>
+);

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -8,7 +8,7 @@
 import React, { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
 import { Sparkle } from '@phosphor-icons/react';
 import axios from 'axios';
-import { Skeleton } from '../ui/skeleton';
+import { ChatMessagesSkeleton } from './ChatMessagesSkeleton';
 import { chatsAPI } from '@/lib/api/chats';
 import type { Chat, ChatMetadata, ChatSyncPayload, StudioSignal } from '@/lib/api/chats';
 import type { CostTracking } from '@/lib/api/projects';
@@ -74,6 +74,18 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   const [showChatList, setShowChatList] = useState(false);
   const [allChats, setAllChats] = useState<ChatMetadata[]>([]);
   const [loading, setLoading] = useState(true);
+  // Per-chat-switch loading. Distinct from `loading` (project mount,
+  // fires once on first render); this one fires for the click →
+  // fetch-resolve window on every chat switch so the message list
+  // shows a skeleton instead of the previous chat lingering then
+  // popping. Suppressed for the mid-send recover path so an in-flight
+  // conversation doesn't flicker.
+  const [switchingChat, setSwitchingChat] = useState(false);
+  // Cached `message_count` of the chat we're switching INTO so the
+  // skeleton can size itself before `activeChat` lands. Captured at
+  // click time from the sidebar's `allChats` row. Default 4 matches
+  // the prior hand-rolled skeleton when count is unknown.
+  const targetMessageCountRef = useRef<number>(4);
   // Derive sending state for current chat from parent-owned Set
   const sending = activeChat ? sendingChatIds.has(activeChat.id) : false;
   const [exportingChat, setExportingChat] = useState(false);
@@ -212,7 +224,16 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
    * just-streamed assistant text. When `sendingLockRef` is held for this
    * chat we merge instead of replacing.
    */
-  const loadFullChat = async (chatId: string) => {
+  const loadFullChat = async (
+    chatId: string,
+    opts: { showSkeleton?: boolean } = {},
+  ) => {
+    // `showSkeleton` is false for background refetches (event-driven
+    // refresh after an insight save, the `openChatId` deep-link path)
+    // where we don't want to wipe a stable view with placeholders.
+    // The explicit-switch path (`handleSelectChat`) passes true.
+    const showSkeleton = opts.showSkeleton ?? false;
+    if (showSkeleton) setSwitchingChat(true);
     try {
       const chat = await chatsAPI.getChat(projectId, chatId);
       const midSend = sendingLockRef.current && activeChatIdRef.current === chatId;
@@ -230,6 +251,8 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     } catch (err) {
       log.error({ err }, 'failed to load chat');
       errorWithLogs('Failed to load chat');
+    } finally {
+      if (showSkeleton) setSwitchingChat(false);
     }
   };
 
@@ -242,7 +265,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       const chats = await chatsAPI.listChats(projectId);
       setAllChats(chats);
 
-      // If we have chats and no active chat, load the first one
+      // If we have chats and no active chat, load the first one.
+      // No per-chat skeleton: the outer `loading` skeleton already
+      // covers this initial-mount path.
       if (chats.length > 0 && !activeChat) {
         await loadFullChat(chats[0].id);
       }
@@ -263,10 +288,15 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
 
-  // Switch to a specific chat when parent requests it (e.g. from ActiveTasksBar "Open" button)
+  // Switch to a specific chat when parent requests it (e.g. from
+  // ActiveTasksBar "Open" button). Treated as an explicit user-driven
+  // navigation — clear the current view and show the skeleton.
   useEffect(() => {
     if (openChatId && openChatId !== activeChat?.id) {
-      loadFullChat(openChatId);
+      const targetMeta = allChats.find((c) => c.id === openChatId);
+      targetMessageCountRef.current = targetMeta?.message_count ?? 4;
+      setActiveChat(null);
+      loadFullChat(openChatId, { showSkeleton: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openChatId]);
@@ -280,6 +310,8 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<{ chatId?: string }>).detail;
       if (detail?.chatId && detail.chatId === activeChatIdRef.current) {
+        // Background refetch (insight save, etc.) — keep the current
+        // view visible while we refresh. No skeleton flash.
         loadFullChat(detail.chatId);
       }
     };
@@ -1062,7 +1094,11 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     try {
       const newChat = await chatsAPI.createChat(projectId, 'New Chat');
       setAllChats((prev) => [newChat, ...prev]);
-      await loadFullChat(newChat.id);
+      // New chat has zero messages — the skeleton renders nothing,
+      // then the existing empty state takes over on fetch resolution.
+      targetMessageCountRef.current = 0;
+      setActiveChat(null);
+      await loadFullChat(newChat.id, { showSkeleton: true });
       // Backend pre-seeds selected_source_ids with the project's DB-type
       // sources on chat create (Sno 40 / #247); loadFullChat fetches that
       // selection and notifies parents via onActiveChatChange.
@@ -1101,10 +1137,22 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   }, []);
 
   /**
-   * Select a chat from the list
+   * Select a chat from the list.
+   *
+   * Clears the previous chat immediately so the message list shows a
+   * skeleton instead of the old chat lingering. The skeleton is sized
+   * from the sidebar's cached `message_count` (no extra fetch).
+   * Re-selecting the already-active chat is a no-op — no skeleton flash.
    */
   const handleSelectChat = async (chatId: string) => {
-    await loadFullChat(chatId);
+    if (chatId === activeChat?.id) {
+      setShowChatList(false);
+      return;
+    }
+    const targetMeta = allChats.find((c) => c.id === chatId);
+    targetMessageCountRef.current = targetMeta?.message_count ?? 4;
+    setActiveChat(null);
+    await loadFullChat(chatId, { showSkeleton: true });
     setShowChatList(false);
   };
 
@@ -1123,7 +1171,11 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         onActiveChatChange(null, []);
 
         if (remainingChats.length > 0) {
-          await loadFullChat(remainingChats[0].id);
+          // The user just deleted the active chat; fall-back to the
+          // next one is effectively a switch. Show the skeleton.
+          const fallback = remainingChats[0];
+          targetMessageCountRef.current = fallback.message_count ?? 4;
+          await loadFullChat(fallback.id, { showSkeleton: true });
         }
       }
       success('Chat deleted');
@@ -1203,29 +1255,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             Ask questions about your sources or request analysis
           </p>
         </div>
-        <div className="flex-1 p-6 space-y-4">
-          {/* Skeleton message bubbles mimicking a chat conversation */}
-          <div className="flex justify-end">
-            <Skeleton className="h-10 w-2/3 rounded-2xl" />
-          </div>
-          <div className="flex justify-start gap-3">
-            <Skeleton className="h-8 w-8 rounded-full flex-shrink-0" />
-            <div className="space-y-2 flex-1">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-5/6" />
-              <Skeleton className="h-4 w-3/4" />
-            </div>
-          </div>
-          <div className="flex justify-end">
-            <Skeleton className="h-8 w-1/2 rounded-2xl" />
-          </div>
-          <div className="flex justify-start gap-3">
-            <Skeleton className="h-8 w-8 rounded-full flex-shrink-0" />
-            <div className="space-y-2 flex-1">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-4/5" />
-            </div>
-          </div>
+        <div className="flex-1 p-6">
+          {/* Reuses the same component the chat-switch path uses so the
+              two surfaces stay in lockstep visually. Default count
+              renders 4 alternating bubbles (matching the prior
+              hand-rolled markup). */}
+          <ChatMessagesSkeleton />
         </div>
         <ToastContainer toasts={toasts} onDismiss={dismissToast} />
       </div>
@@ -1276,7 +1311,18 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         exportingChat={exportingChat}
       />
 
-      {rawMode && activeChat ? (
+      {switchingChat ? (
+        // Chat-switch placeholder. Clears the previous chat's messages
+        // and shows skeleton bubbles sized by the sidebar's cached
+        // message_count so the surface stays alive while the new
+        // chat's getChat lands. See `handleSelectChat` for the click
+        // path; `recoverChatFromServer` and event-driven background
+        // refreshes intentionally bypass this so an active stream
+        // doesn't flicker.
+        <div className="flex-1 p-6 overflow-y-auto">
+          <ChatMessagesSkeleton count={targetMessageCountRef.current} />
+        </div>
+      ) : rawMode && activeChat ? (
         // Local ErrorBoundary: a syntax-highlighter chunk-load failure
         // shouldn't crash the entire chat panel — let the user click
         // back out of Raw mode and keep using the normal view. resetKey

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -228,10 +228,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     chatId: string,
     opts: { showSkeleton?: boolean } = {},
   ) => {
-    // `showSkeleton` is false for background refetches (event-driven
-    // refresh after an insight save, the `openChatId` deep-link path)
-    // where we don't want to wipe a stable view with placeholders.
-    // The explicit-switch path (`handleSelectChat`) passes true.
+    // `showSkeleton` is false by default for background refetches
+    // (event-driven refresh after an insight save) where we don't
+    // want to wipe a stable view with placeholders. Explicit
+    // navigation paths — `handleSelectChat`, `openChatId` deep-link,
+    // `handleDeleteChat` fallback, `handleNewChat` — all opt in
+    // by passing true.
     const showSkeleton = opts.showSkeleton ?? false;
     if (showSkeleton) setSwitchingChat(true);
     try {


### PR DESCRIPTION
## Summary

The last remaining Delta pain point in the "Loading experience of chat messages" row was the **brief blank flash** when switching between chats. The project-mount path already had a skeleton; the chat-switch path didn't — `loadFullChat` fetched first, then `setActiveChat(newChat)` snapped the new content in. On a 100–300ms `getChat` round-trip the previous chat lingered then popped to the new one.

This PR closes the gap by clearing the old chat immediately on click and rendering skeleton bubbles sized by the sidebar's cached `message_count` while the new chat loads.

## What changed

**Created**
- `frontend/src/components/chat/ChatMessagesSkeleton.tsx` (~30 lines)
  - Alternating user / AI bubbles via the existing `<Skeleton>` primitive
  - Capped at 6 (rendering 50 placeholders for a 50-message chat is animated noise)
  - Returns `null` when `count === 0` so brand-new chats fall through to the empty state cleanly
  - Deterministic width variation so the placeholder doesn't read as a metronome
  - `aria-busy="true"` for screen readers

**Modified**
- `frontend/src/components/chat/ChatPanel.tsx`
  - New `switchingChat` state + `targetMessageCountRef` distinct from the existing project-level `loading`
  - `loadFullChat` takes opt-in `{ showSkeleton }` — defaults to false so background paths (insight refresh, etc.) stay silent
  - `handleSelectChat` / `handleNewChat` / `handleDeleteChat` fallback / `openChatId` deep-link: capture target `message_count`, clear `activeChat`, then fetch with `showSkeleton: true`
  - The render slot for messages branches on `switchingChat` first, then the existing `rawMode` / normal split
  - Inline 25-line hand-rolled skeleton in the project-mount branch replaced with the new component (two surfaces now in lockstep)

## What stays silent

- **Mid-send `recoverChatFromServer`** — already calls `chatsAPI.getChat` directly (never went through `loadFullChat`), so unchanged. An in-flight conversation won't flicker.
- **Window event refresh** (insight save updating the chat) — explicit `showSkeleton: false`. Keeps the current view visible while data refreshes underneath.
- **Initial project mount** — covered by the outer `loading` skeleton already; the new component is reused there.
- **Re-selecting the already-active chat** — early return in `handleSelectChat`, no flash.

## Verified locally

- `npm run lint` → **0 errors** (2 pre-existing warnings unrelated)
- `npm run build` → green

## Test plan

- [ ] Open a project with 3+ chats. Click between them on a throttled network (Slow 3G in DevTools) — confirm the old chat clears immediately and skeleton bubbles appear sized for the target chat.
- [ ] Click a 2-message chat → 2 bubbles. Click a 20-message chat → exactly 6 (cap). Click a brand-new chat with `message_count=0` → nothing renders, then ChatEmptyState lands.
- [ ] Send a chat message; while it's streaming, kill the dev server briefly to trigger `recoverChatFromServer`. Confirm **no skeleton flash** — recovery stays silent.
- [ ] While streaming, click a different chat in the sidebar — confirm the skeleton DOES show (legitimate switch).
- [ ] Hard-reload on a project → confirm the existing full-page skeleton still renders (now using the extracted component).
- [ ] Delete the active chat → the fallback chat shows the skeleton during its load.
- [ ] Click an already-active chat row → no flash (no-op).

## Out of scope

- In-memory cache for recently-visited chats (instant repeat-visits)
- Hover prefetch on chat-list rows
- Persistent cache across page reloads
- Same blank-flash polish for Sources / Studio panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)