### PR TITLE
fix(xlsx): persist converted CSV to raw-files so chat analyzer can read it

### DIFF
--- a/backend/app/services/source_services/source_processing/xlsx_processor.py
+++ b/backend/app/services/source_services/source_processing/xlsx_processor.py
@@ -22,6 +22,7 @@ from typing import Dict, Any
 
 import pandas as pd
 
+from app.services.integrations.supabase import storage_service
 from app.services.source_services.source_processing.csv_processor import process_csv
 
 logger = logging.getLogger(__name__)
@@ -86,5 +87,44 @@ def process_xlsx(
     # removes it on completion.
     csv_path = raw_file_path.with_suffix('.csv')
     csv_path.write_text(csv_text, encoding='utf-8')
+
+    # Also persist the converted CSV in the raw-files bucket as
+    # `{source_id}.csv`. The chat-side csv_analyzer downloads the data via
+    # `storage_service.download_raw_file(project_id, source_id, f"{source_id}.csv")`
+    # (analysis_executor.py:75-83). For native-CSV uploads that object
+    # lands there naturally at upload time; for XLSX-converted sources the
+    # only object in raw-files is `{source_id}.xlsx`, so without this step
+    # every chat question 404s and the analyzer falls back to a low-quality
+    # answer hallucinated from the source summary. Production logs from
+    # 2026-05-25 captured 5 sources hitting that loop before the user
+    # gave up and re-uploaded as .csv.
+    csv_bytes = csv_text.encode('utf-8')
+    try:
+        raw_csv_path = storage_service.upload_raw_file(
+            project_id=project_id,
+            source_id=source_id,
+            filename=f"{source_id}.csv",
+            file_data=csv_bytes,
+            content_type='text/csv; charset=utf-8',
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to upload converted CSV for XLSX source %s: %s",
+            source_id, exc,
+        )
+        raw_csv_path = None
+    if not raw_csv_path:
+        source_service.update_source(
+            project_id,
+            source_id,
+            status='error',
+            processing_info={
+                'error': (
+                    'Converted CSV could not be uploaded to storage. '
+                    'Retry the source or re-upload the XLSX.'
+                )
+            },
+        )
+        return {'success': False, 'error': 'Failed to upload converted CSV to storage'}
 
     return process_csv(project_id, source_id, source, csv_path, source_service)

--- a/backend/app/services/source_services/source_processing/xlsx_processor.py
+++ b/backend/app/services/source_services/source_processing/xlsx_processor.py
@@ -98,21 +98,16 @@ def process_xlsx(
     # answer hallucinated from the source summary. Production logs from
     # 2026-05-25 captured 5 sources hitting that loop before the user
     # gave up and re-uploaded as .csv.
-    csv_bytes = csv_text.encode('utf-8')
-    try:
-        raw_csv_path = storage_service.upload_raw_file(
-            project_id=project_id,
-            source_id=source_id,
-            filename=f"{source_id}.csv",
-            file_data=csv_bytes,
-            content_type='text/csv; charset=utf-8',
-        )
-    except Exception as exc:
-        logger.error(
-            "Failed to upload converted CSV for XLSX source %s: %s",
-            source_id, exc,
-        )
-        raw_csv_path = None
+    # upload_raw_file catches all exceptions internally and returns None on
+    # failure (logging the cause with full context), so no try/except needed
+    # here — the None-check below is the only branch that can ever fire.
+    raw_csv_path = storage_service.upload_raw_file(
+        project_id=project_id,
+        source_id=source_id,
+        filename=f"{source_id}.csv",
+        file_data=csv_text.encode('utf-8'),
+        content_type='text/csv; charset=utf-8',
+    )
     if not raw_csv_path:
         source_service.update_source(
             project_id,


### PR DESCRIPTION
## Incident
User report: \"XLSX data is not fully effortless. It was asking it multiple times to reload.\" Production logs (2026-05-25 bundle, `f2e4802c-backend.log`) showed every XLSX upload silently breaking chat-side CSV analysis.

**Five distinct XLSX sources, same 404 loop:**

| Source ID | Uploaded → ready | Chat queries | 404s per query |
|---|---|---|---|
| `cf5c6b80…` | 10:28:13 → 10:28:20 | 1 | 3× on `cf5c6b80.csv` |
| `9f7e8a53…` | 10:34:14 → 10:34:22 | 2 | 3-4× on `9f7e8a53.csv` |
| `a2be7035…` | 10:35:57 → 10:36:06 | ≥4 | 4× on `a2be7035.csv` |
| `b891a37c…` | (similar) | — | 4× on `b891a37c.csv` |
| `e1f98677…` | (similar) | — | 4× on `e1f98677.csv` |
| **`18e45a0c…` (native .csv)** | 10:51:13 → 10:51:22 | multiple | **0** ← works |

Trace from log line 9137:
\`\`\`
10:28:13  Processing source cf5c6b80 (ext=.xlsx)
10:28:13  Dispatching to xlsx_processor → process_csv
10:28:20  CSV processed: NINE DEMO .xlsx (11 rows, 13 columns)   ← status=ready ✓
10:28:34  CHAT_ITER iter=1 tools=['analyze_csv_agent']
10:28:38  ERROR Failed to download raw file …/cf5c6b80.csv: 404 Object not found
10:28:40  ERROR Failed to download raw file …/cf5c6b80.csv: 404 Object not found
10:28:43  ERROR Failed to download raw file …/cf5c6b80.csv: 404 Object not found
10:28:49  Completed in 4 iterations    ← agent surrendered, hallucinated answer
\`\`\`

3-4 retries per question is exactly the \"asking it multiple times\" symptom — pandas inside the analyzer loops, the agent eventually returns a low-quality fallback answer from the source summary.

## Root cause
- `xlsx_processor.process_xlsx` (`xlsx_processor.py:30-49`) converts the workbook → CSV text → local temp file → calls `process_csv`. `process_csv` uploads the CSV to the **`processed-files`** bucket as `{source_id}.txt`.
- `analysis_executor._load_dataframe` (`analysis_executor.py:75-83`) hard-codes:
  ```python
  storage_service.download_raw_file(project_id, source_id, f\"{source_id}.csv\")
  ```
  Reads from **`raw-files`**, looking for `{source_id}.csv`.
- `upload_chunked.py:346` stores all uploads at `{source_id}{original_ext}`. For native CSV → `{source_id}.csv` exists naturally. For XLSX → only `{source_id}.xlsx` exists; `{source_id}.csv` is never written anywhere.

## Fix
In `xlsx_processor.process_xlsx`, after generating the CSV text and writing the local copy that `process_csv` reads, also upload the CSV bytes to **`raw-files`** as `{source_id}.csv` via the existing `upload_raw_file` helper (which already handles duplicate-cleanup retries — `storage_service.py:226-228`). Now both paths leave the same object at the same path the analyzer expects.

- **Native CSV** path: unchanged. Object lands in raw-files at upload time, fix is a no-op.
- **XLSX** path: the converted CSV (with `=== SHEET: <name> ===` separators for multi-sheet workbooks) lands in raw-files alongside the original `.xlsx`. Analyzer downloads it, pandas reads it, agent answers from real data.
- **Upload failure**: source flips to `status=error` with a clear message instead of a green \"ready\" badge on a broken source.

No changes to `csv_processor`, `analysis_executor`, `main_chat_service`, or the frontend.

## Test plan
- [ ] Smoke (primary): upload a multi-sheet `.xlsx`, wait for `ready`, ask \"What columns are in the spreadsheet?\" — agent answers with column names from real data, no 4× 404 loop in `backend.log`.
- [ ] Storage check: `raw-files/{project}/{source}/{source_id}.xlsx` AND `raw-files/{project}/{source}/{source_id}.csv` both present after processing.
- [ ] Single-sheet XLSX works.
- [ ] Native `.csv` upload regression: still works (no path change there).
- [ ] Empty workbook: still flips to `status=error` with the existing \"Workbook is empty\" message (the new upload step runs after the empty-check).

## Operator note for existing affected sources
Already-uploaded XLSX rows in production won't have `{source_id}.csv` in raw-files. Affected users can hit \"Retry\" on the source (`/projects/{id}/sources/{source_id}/retry`) — that re-runs the processor and the new upload step now persists the converted CSV. No backfill script required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)