### PR TITLE
ci: enable @claude on PRs/issues (subscription OAuth auth)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,46 @@
+name: Claude Code
+
+# Lets you mention @claude in an issue or PR comment (or PR review) to have
+# Claude respond — review the diff, answer a question, or make a change.
+#
+# Auth uses a Claude subscription via an OAuth token (no pay-as-you-go API key):
+#   1. Run `claude setup-token` locally (requires a Pro/Max plan) to mint a token.
+#   2. Add it as the repo secret CLAUDE_CODE_OAUTH_TOKEN
+#      (Settings → Secrets and variables → Actions).
+# This workflow must live on the default branch to fire on PR/issue comments.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only spin up a runner when someone actually mentions @claude.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/claude.yml` so mentioning **@claude** in an issue/PR comment (or PR review) triggers Claude Code to respond — review the diff, answer, or make changes.

This must live on the default branch (`main`) to fire on comment events, hence the PR to `main`.

### Auth: Claude subscription (no pay-as-you-go API key)
Configured to use an OAuth token billed against a Max/Pro subscription:

```yaml
claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

### Required before this works (one-time, manual)
1. **Install the GitHub App:** https://github.com/apps/claude (grant Contents / Issues / Pull requests).
2. **Mint a token:** run `claude setup-token` locally (Max/Pro plan) — it prints a long-lived OAuth token.
3. **Add the secret:** repo Settings → Secrets and variables → Actions → `CLAUDE_CODE_OAUTH_TOKEN`.

Once the secret exists and this is merged to `main`, comment `@claude review this PR` on any PR to test.

> Note: token may need periodic re-minting via `setup-token`, and runs count against the subscription's rate limits.