### PR TITLE
perf: end-to-end optimizations (load, render, backend latency)

### DIFF
--- a/backend/app/config/context_loader.py
+++ b/backend/app/config/context_loader.py
@@ -51,7 +51,9 @@ class ContextLoader:
         Returns:
             List of source metadata dicts for selected/ready sources
         """
-        all_sources = source_service.list_sources(project_id)
+        # Projected query: only the columns the source context needs (skips the
+        # heavy processing_info JSONB shipped on every message otherwise).
+        all_sources = source_service.list_sources_for_context(project_id)
 
         if selected_source_ids is None:
             # Legacy chat (column is NULL) — fall back to global active flag

--- a/backend/app/config/context_loader.py
+++ b/backend/app/config/context_loader.py
@@ -77,6 +77,7 @@ class ContextLoader:
         self,
         project_id: str,
         selected_source_ids: Optional[List[str]] = None,
+        active_sources: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
         """
         Build formatted source context for the system prompt.
@@ -88,11 +89,15 @@ class ContextLoader:
         Args:
             project_id: The project UUID
             selected_source_ids: Per-chat source selection (None = no sources)
+            active_sources: Pre-fetched active sources to avoid a redundant query
+                (the chat hot path already fetches these once per turn). When
+                None, they're fetched here.
 
         Returns:
             Formatted string to append to system prompt, or empty string if no sources
         """
-        active_sources = self.get_active_sources(project_id, selected_source_ids=selected_source_ids)
+        if active_sources is None:
+            active_sources = self.get_active_sources(project_id, selected_source_ids=selected_source_ids)
 
         if not active_sources:
             return ""
@@ -298,6 +303,7 @@ class ContextLoader:
         project_id: str,
         user_id: Optional[str] = None,
         selected_source_ids: Optional[List[str]] = None,
+        active_sources: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
         """
         Build complete context including sources, memory, and MCP tools.
@@ -321,7 +327,9 @@ class ContextLoader:
             parts.append(memory_context)
 
         # Add source context (available tools)
-        source_context = self.build_source_context(project_id, selected_source_ids=selected_source_ids)
+        source_context = self.build_source_context(
+            project_id, selected_source_ids=selected_source_ids, active_sources=active_sources
+        )
         if source_context:
             parts.append(source_context)
 

--- a/backend/app/config/prompt_loader.py
+++ b/backend/app/config/prompt_loader.py
@@ -22,6 +22,7 @@ Prompt Hierarchy:
 1. Project custom prompt (if set)
 2. Global default prompt (fallback)
 """
+import copy
 import json
 import logging
 from pathlib import Path
@@ -30,6 +31,34 @@ from typing import Optional, Dict, Any
 from config import Config
 
 logger = logging.getLogger(__name__)
+
+
+# Prompt JSON (shipped defaults, admin overrides, per-project settings) is read
+# on every AI call but only changes when an admin/user edits it. Cache parsed
+# JSON keyed by (path, mtime): re-parse only when the file's mtime changes, so
+# the "edits take effect without restart" guarantee holds (any write bumps
+# mtime). Return a deep copy so callers can't mutate the cached object.
+_json_mtime_cache: Dict[str, "tuple[int, Any]"] = {}
+
+
+def _read_json_mtime_cached(path: Path) -> Optional[Any]:
+    """Read+parse a JSON file, caching by mtime. None if missing/invalid."""
+    try:
+        mtime = path.stat().st_mtime_ns
+    except OSError:
+        return None
+    key = str(path)
+    cached = _json_mtime_cache.get(key)
+    if cached is not None and cached[0] == mtime:
+        return copy.deepcopy(cached[1])
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        logger.error("Failed to read JSON %s: %s", path, e)
+        return None
+    _json_mtime_cache[key] = (mtime, data)
+    return copy.deepcopy(data)
 
 
 class PromptConfig(dict):
@@ -124,18 +153,13 @@ class PromptLoader:
     def _load_override(self, prompt_name: str) -> Optional[Dict[str, Any]]:
         """Read the override file for ``prompt_name``, or return ``None``."""
         path = self._override_path(prompt_name)
-        if not path.exists():
+        data = _read_json_mtime_cached(path)
+        if data is None:
             return None
-        try:
-            with open(path, 'r') as f:
-                data = json.load(f)
-            if not isinstance(data, dict):
-                logger.warning("Override %s is not a JSON object — ignoring", path)
-                return None
-            return data
-        except (json.JSONDecodeError, IOError) as e:
-            logger.error("Failed to read override %s: %s", path, e)
+        if not isinstance(data, dict):
+            logger.warning("Override %s is not a JSON object — ignoring", path)
             return None
+        return data
 
     def has_override(self, prompt_name: str) -> bool:
         """True iff an admin override file exists for this prompt."""
@@ -170,15 +194,13 @@ class PromptLoader:
     def _load_base(self, prompt_name: str) -> Optional[Dict[str, Any]]:
         """Load the shipped default for ``prompt_name``, no merge."""
         prompt_file = self.prompts_dir / f"{prompt_name}_prompt.json"
-        try:
-            with open(prompt_file, 'r') as f:
-                data = json.load(f)
-            # Legacy format compat
-            if "prompt" in data and "system_prompt" not in data:
-                data["system_prompt"] = data.pop("prompt")
-            return data
-        except (FileNotFoundError, json.JSONDecodeError):
+        data = _read_json_mtime_cached(prompt_file)
+        if data is None:
             return None
+        # Legacy format compat
+        if "prompt" in data and "system_prompt" not in data:
+            data["system_prompt"] = data.pop("prompt")
+        return data
 
     def get_prompt_default_config(self, prompt_name: str) -> Optional[Dict[str, Any]]:
         """
@@ -241,15 +263,11 @@ class PromptLoader:
         """
         project_file = self.projects_dir / f"{project_id}.json"
 
-        try:
-            with open(project_file, 'r') as f:
-                project_data = json.load(f)
-                custom_prompt = project_data.get("settings", {}).get("custom_prompt")
-
-                if custom_prompt:
-                    return custom_prompt
-        except (FileNotFoundError, json.JSONDecodeError):
-            pass
+        project_data = _read_json_mtime_cached(project_file)
+        if isinstance(project_data, dict):
+            custom_prompt = project_data.get("settings", {}).get("custom_prompt")
+            if custom_prompt:
+                return custom_prompt
 
         # Return default if no custom prompt
         return self.get_default_prompt()
@@ -273,15 +291,11 @@ class PromptLoader:
         # Check for custom prompt override
         project_file = self.projects_dir / f"{project_id}.json"
 
-        try:
-            with open(project_file, 'r') as f:
-                project_data = json.load(f)
-                custom_prompt = project_data.get("settings", {}).get("custom_prompt")
-
-                if custom_prompt:
-                    config["system_prompt"] = custom_prompt
-        except (FileNotFoundError, json.JSONDecodeError):
-            pass
+        project_data = _read_json_mtime_cached(project_file)
+        if isinstance(project_data, dict):
+            custom_prompt = project_data.get("settings", {}).get("custom_prompt")
+            if custom_prompt:
+                config["system_prompt"] = custom_prompt
 
         # get_default_prompt_config already returns a PromptConfig tagged with
         # prompt_name="default" so the admin "chat" category override applies.

--- a/backend/app/services/auth/permissions.py
+++ b/backend/app/services/auth/permissions.py
@@ -206,8 +206,16 @@ def user_has_permission(user_id: str, category: str, item: Optional[str] = None)
     Returns:
         True if the user has access
     """
-    perms = get_user_permissions(user_id)
+    return permission_in(get_user_permissions(user_id), category, item)
 
+
+def permission_in(perms: Dict[str, Any], category: str, item: Optional[str] = None) -> bool:
+    """Permission check against an already-loaded permissions dict.
+
+    Same logic as ``user_has_permission`` but without the DB fetch — call
+    ``get_user_permissions`` once and reuse the result across several checks
+    (e.g. the chat tool-gating path checks ~7 categories per turn).
+    """
     cat = perms.get(category)
     if cat is None:
         return True  # Unknown category = allowed

--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -112,7 +112,7 @@ from flask import has_request_context
 from app.services.auth.rbac import get_request_identity
 from app.services.data_services.project_service import DEFAULT_USER_ID
 from app.utils import claude_parsing_utils
-from app.services.auth.permissions import user_has_permission
+from app.services.auth.permissions import get_user_permissions, permission_in
 
 
 class ClaudeStreamError(Exception):
@@ -197,29 +197,37 @@ class MainChatService:
         Returns:
             Tuple of (tool definitions list, MCP tool registry dict)
         """
-        # Include memory and studio_signal tools only if the user has permission
+        # Include memory and studio_signal tools only if the user has permission.
+        # Fetch the user's permissions ONCE (one DB row) and check it in-memory —
+        # the gating below probes up to 7 categories, which previously meant 7
+        # identical SELECTs per chat turn.
         tools = []
 
-        if not user_id or user_has_permission(user_id, "chat_features", "memory"):
+        perms = get_user_permissions(user_id) if user_id else None
+
+        def _can(category: str, item: Optional[str] = None) -> bool:
+            return perms is None or permission_in(perms, category, item)
+
+        if _can("chat_features", "memory"):
             tools.append(self._get_tool("memory"))
 
-        if not user_id or user_has_permission(user_id, "studio"):
+        if _can("studio"):
             tools.append(self._get_tool("studio_signal"))
 
         if has_active_sources:
             tools.append(self._get_tool("search"))
 
-        if has_csv_sources and (not user_id or user_has_permission(user_id, "data_sources", "csv")):
+        if has_csv_sources and _can("data_sources", "csv"):
             tools.append(self._get_tool("csv_analyzer"))
 
-        if has_database_sources and (not user_id or user_has_permission(user_id, "data_sources", "database")):
+        if has_database_sources and _can("data_sources", "database"):
             tools.append(self._get_tool("database_analyzer"))
 
-        if has_freshdesk_sources and (not user_id or user_has_permission(user_id, "data_sources", "freshdesk")):
+        if has_freshdesk_sources and _can("data_sources", "freshdesk"):
             tools.append(self._get_tool("freshdesk_analyzer"))
 
         # Add Jira tools only when the project has a .jira source (project-scoped)
-        if has_jira_sources and (not user_id or user_has_permission(user_id, "data_sources", "jira")):
+        if has_jira_sources and _can("data_sources", "jira"):
             tools.extend(knowledge_base_service.get_jira_tools())
 
         # Mixpanel analyzer agent for product-usage questions (project-scoped).
@@ -228,7 +236,7 @@ class MainChatService:
         # mixpanel_analyzer_agent.run() — only the trigger tool is exposed
         # to the main chat so the surface stays small and consistent with
         # the Freshdesk pattern.
-        if has_mixpanel_sources and (not user_id or user_has_permission(user_id, "data_sources", "mixpanel")):
+        if has_mixpanel_sources and _can("data_sources", "mixpanel"):
             tools.append(self._get_tool("mixpanel_analyzer"))
 
         # Add non-Jira knowledge base tools (Notion, GitHub, etc.) — always global
@@ -253,6 +261,7 @@ class MainChatService:
         base_prompt: str,
         user_id: Optional[str] = None,
         selected_source_ids: Optional[List[str]] = None,
+        active_sources: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
         """
         Build system prompt with memory and source context appended.
@@ -268,7 +277,8 @@ class MainChatService:
         parts = [today_line, base_prompt]
 
         full_context = context_loader.build_full_context(
-            project_id, user_id=user_id, selected_source_ids=selected_source_ids
+            project_id, user_id=user_id, selected_source_ids=selected_source_ids,
+            active_sources=active_sources,
         )
         if full_context:
             parts.append(full_context)
@@ -594,12 +604,18 @@ class MainChatService:
         selected_source_ids = chat.get("selected_source_ids")
         prompt_config = prompt_loader.get_project_prompt_config(project_id)
         base_prompt = prompt_config.get("system_prompt", "")
+
+        # Fetch active sources ONCE for this turn and reuse for both the system
+        # prompt (source context) and tool gating below — previously this query
+        # ran twice per message.
+        active_sources = context_loader.get_active_sources(project_id, selected_source_ids=selected_source_ids)
+
         system_prompt = self._build_system_prompt(
-            project_id, base_prompt, user_id=resolved_user_id, selected_source_ids=selected_source_ids
+            project_id, base_prompt, user_id=resolved_user_id,
+            selected_source_ids=selected_source_ids, active_sources=active_sources,
         )
 
         # Step 3: Get tools (memory always available, search for non-CSV, analyzer for CSV)
-        active_sources = context_loader.get_active_sources(project_id, selected_source_ids=selected_source_ids)
         # Separate sources by file extension (stored inside embedding_info)
         def _file_ext(source: Dict[str, Any]) -> str:
             embedding_info = source.get("embedding_info", {}) or {}

--- a/backend/app/services/chat_services/main_chat_service.py
+++ b/backend/app/services/chat_services/main_chat_service.py
@@ -561,8 +561,11 @@ class MainChatService:
             )
         )
 
-        # Verify chat exists
-        chat = chat_service.get_chat(project_id, chat_id)
+        # Verify chat exists. Use the lightweight meta fetch — this turn only
+        # reads selected_source_ids + message_count from `chat`, and the message
+        # history is fetched separately by build_api_messages below, so loading
+        # and formatting the full history here would be wasted work.
+        chat = chat_service.get_chat_meta(project_id, chat_id)
         if not chat:
             raise ValueError("Chat not found")
 

--- a/backend/app/services/data_services/chat_service.py
+++ b/backend/app/services/data_services/chat_service.py
@@ -393,7 +393,18 @@ class ChatService(SupabaseService):
                     "citations": msg.get("citations", [])
                 })
 
-        # Get studio signals
+        chat["messages"] = display_messages
+        chat["studio_signals"] = self._get_formatted_signals(chat_id)
+        chat["message_count"] = len(messages)
+
+        return chat
+
+    def _get_formatted_signals(self, chat_id: str) -> List[Dict[str, Any]]:
+        """Fetch a chat's studio signals, shaped for the frontend.
+
+        Backend stores ``source_ids: ["uuid1", ...]``; the frontend expects
+        ``sources: [{source_id, chunk_ids}]``.
+        """
         signals_response = (
             self.supabase.table(self.studio_signals_table)
             .select("*")
@@ -401,27 +412,44 @@ class ChatService(SupabaseService):
             .order("created_at", desc=False)
             .execute()
         )
-
-        # Transform signals for frontend format
-        # Backend stores: source_ids: ["uuid1", "uuid2"]
-        # Frontend expects: sources: [{source_id: "...", chunk_ids: []}]
         formatted_signals = []
         for signal in (signals_response.data or []):
             source_ids = signal.get("source_ids", []) or []
-            formatted_signal = {
+            formatted_signals.append({
                 "id": signal.get("id"),
                 "studio_item": signal.get("studio_item"),
                 "direction": signal.get("direction", ""),
                 "sources": [{"source_id": sid, "chunk_ids": []} for sid in source_ids],
                 "created_at": signal.get("created_at"),
                 "status": signal.get("status", "pending")
-            }
-            formatted_signals.append(formatted_signal)
+            })
+        return formatted_signals
 
-        chat["messages"] = display_messages
-        chat["studio_signals"] = formatted_signals
-        chat["message_count"] = len(messages)
+    def get_chat_meta(self, project_id: str, chat_id: str) -> Optional[Dict[str, Any]]:
+        """Chat row + message_count WITHOUT fetching/formatting the message list.
 
+        For callers that only need scalar chat fields (selected_source_ids,
+        message_count, title, timestamps) — e.g. the chat turn start and sync
+        payload, which fetch messages separately. Avoids a full message fetch +
+        per-message formatting that get_chat would otherwise do and discard.
+        """
+        chat_response = (
+            self.supabase.table(self.table)
+            .select("*")
+            .eq("id", chat_id)
+            .eq("project_id", project_id)
+            .execute()
+        )
+        if not chat_response.data:
+            return None
+        chat = chat_response.data[0]
+        count_response = (
+            self.supabase.table(self.messages_table)
+            .select("id", count="exact")
+            .eq("chat_id", chat_id)
+            .execute()
+        )
+        chat["message_count"] = count_response.count or 0
         return chat
 
     @staticmethod
@@ -713,7 +741,9 @@ class ChatService(SupabaseService):
         }
 
     def get_chat_sync_state(self, project_id: str, chat_id: str) -> Optional[Dict[str, Any]]:
-        chat = self.get_chat(project_id, chat_id)
+        # Meta + signals only — this payload never uses the message list, so
+        # skip get_chat's full message fetch + per-message formatting.
+        chat = self.get_chat_meta(project_id, chat_id)
         if not chat:
             return None
 
@@ -726,7 +756,7 @@ class ChatService(SupabaseService):
                 "message_count": chat["message_count"],
                 "selected_source_ids": chat.get("selected_source_ids"),
             },
-            "studio_signals": chat.get("studio_signals", []),
+            "studio_signals": self._get_formatted_signals(chat_id),
             "chat_costs": self.get_chat_costs(project_id, chat_id),
         }
 

--- a/backend/app/services/data_services/project_service.py
+++ b/backend/app/services/data_services/project_service.py
@@ -7,7 +7,7 @@ over database operations.
 """
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional, Dict, List, Any
 
 from app.services.data_services.base_service import SupabaseService
@@ -148,12 +148,28 @@ class ProjectService(SupabaseService):
 
         project = response.data[0]
 
-        # Update last accessed time
-        self.supabase.table(self.table).update({
-            "last_accessed": datetime.now().isoformat()
-        }).eq("id", project_id).eq("user_id", uid).execute()
+        # Update last_accessed only when it's stale (>5 min). It drives dashboard
+        # ordering, so per-read precision isn't needed — and skipping the write on
+        # repeated reads removes a serial write round-trip from the hot read path.
+        # Any parse issue falls back to writing (preserves prior behavior).
+        if self._last_accessed_is_stale(project.get("last_accessed")):
+            self.supabase.table(self.table).update({
+                "last_accessed": datetime.now().isoformat()
+            }).eq("id", project_id).eq("user_id", uid).execute()
 
         return project
+
+    @staticmethod
+    def _last_accessed_is_stale(last_accessed: Optional[str]) -> bool:
+        """True if last_accessed is missing, unparseable, or older than 5 minutes."""
+        if not last_accessed:
+            return True
+        try:
+            prev = datetime.fromisoformat(str(last_accessed).replace("Z", "+00:00"))
+            now = datetime.now(prev.tzinfo) if prev.tzinfo else datetime.now()
+            return (now - prev) > timedelta(minutes=5)
+        except (ValueError, TypeError):
+            return True
 
     def update_project(
         self,

--- a/backend/app/services/data_services/project_service.py
+++ b/backend/app/services/data_services/project_service.py
@@ -6,6 +6,7 @@ using Supabase as the database backend. It provides a clean abstraction
 over database operations.
 """
 import logging
+import time
 import uuid
 from datetime import datetime, timedelta
 from typing import Optional, Dict, List, Any
@@ -560,9 +561,24 @@ class ProjectService(SupabaseService):
         return response.data[0].get("user_id")
 
     def has_project_access(self, project_id: str, user_id: str) -> bool:
-        """Check if a user owns the project."""
+        """Check if a user owns the project.
+
+        Runs in the global before_request hook on every project-scoped API
+        call, so it's a serial DB round-trip on the hot path. Positive results
+        are cached briefly (ownership effectively never changes); negatives are
+        always re-checked so a freshly-created project isn't locked out. A
+        deleted project's stale True self-corrects within the TTL — and the
+        handler's own queries return empty regardless, so it's not a leak.
+        """
         if not project_id or not user_id:
             return False
+
+        key = (project_id, user_id)
+        now = time.monotonic()
+        expiry = _ACCESS_CACHE.get(key)
+        if expiry is not None and expiry > now:
+            return True
+
         response = (
             self.supabase.table(self.table)
             .select("id")
@@ -570,7 +586,18 @@ class ProjectService(SupabaseService):
             .eq("user_id", user_id)
             .execute()
         )
-        return bool(response.data)
+        allowed = bool(response.data)
+        if allowed:
+            # Bound memory: clear if the cache grows unexpectedly large.
+            if len(_ACCESS_CACHE) > 10000:
+                _ACCESS_CACHE.clear()
+            _ACCESS_CACHE[key] = now + _ACCESS_TTL_SECONDS
+        return allowed
+
+
+# Short-lived positive-only cache for has_project_access (see method docstring).
+_ACCESS_CACHE: Dict[tuple, float] = {}
+_ACCESS_TTL_SECONDS = 30.0
 
 
 # Singleton instance

--- a/backend/app/services/source_services/source_index_service.py
+++ b/backend/app/services/source_services/source_index_service.py
@@ -290,3 +290,29 @@ def list_sources_from_index(project_id: str) -> List[Dict[str, Any]]:
 
     # Map field names for frontend compatibility
     return [_map_source_fields(source) for source in (response.data or [])]
+
+
+# Columns the chat system-prompt source context actually consumes (via
+# get_active_sources + build_source_context + _map_source_fields). Deliberately
+# excludes the heavy `processing_info` JSONB (per-page extraction debug data)
+# and other unused columns so the per-turn context query doesn't transfer and
+# deserialize them.
+_CONTEXT_SOURCE_COLUMNS = "id, name, type, status, is_active, embedding_info, summary_info, created_at"
+
+
+def list_sources_for_context(project_id: str) -> List[Dict[str, Any]]:
+    """Like ``list_sources_from_index`` but projects only the columns the chat
+    source-context build needs — avoids shipping the large processing_info blob
+    on every message. NOT for the Sources panel (which renders processing_info
+    error/sync state)."""
+    client = _get_client()
+
+    response = (
+        client.table("sources")
+        .select(_CONTEXT_SOURCE_COLUMNS)
+        .eq("project_id", project_id)
+        .order("created_at", desc=True)
+        .execute()
+    )
+
+    return [_map_source_fields(source) for source in (response.data or [])]

--- a/backend/app/services/source_services/source_service.py
+++ b/backend/app/services/source_services/source_service.py
@@ -64,6 +64,11 @@ class SourceService:
         """
         return source_index_service.list_sources_from_index(project_id)
 
+    def list_sources_for_context(self, project_id: str) -> List[Dict[str, Any]]:
+        """List sources with only the columns the chat source-context needs
+        (drops the heavy processing_info JSONB). Not for the Sources panel."""
+        return source_index_service.list_sources_for_context(project_id)
+
     def get_source(self, project_id: str, source_id: str) -> Optional[Dict[str, Any]]:
         """
         Get a specific source's metadata.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, useNavigate, useParams } from 'react-router-dom';
-import { CreateProjectDialog } from './components/dashboard';
+// Import directly from the file, NOT the dashboard barrel — the barrel also
+// re-exports Dashboard + AppSettings, which would pull them (and their heavy
+// markdown deps) into the eager entry chunk and defeat the lazy() splits below.
+import { CreateProjectDialog } from './components/dashboard/CreateProjectDialog';
 
 import { projectsAPI } from './lib/api';
 import { authAPI } from './lib/api/auth';

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -259,7 +259,7 @@ type UserMessageBlock =
   | { type: 'image'; url: string; media_type?: string; filename?: string }
   | { type: 'text'; text: string };
 
-const UserMessage: React.FC<{ content: string | UserMessageBlock[] }> = ({ content }) => {
+const UserMessage: React.FC<{ content: string | UserMessageBlock[] }> = React.memo(({ content }) => {
   const isBlocks = Array.isArray(content);
   const imageBlocks = isBlocks
     ? (content as UserMessageBlock[]).filter((b): b is Extract<UserMessageBlock, { type: 'image' }> => b.type === 'image')
@@ -304,7 +304,8 @@ const UserMessage: React.FC<{ content: string | UserMessageBlock[] }> = ({ conte
       </div>
     </div>
   );
-};
+});
+UserMessage.displayName = 'UserMessage';
 
 /**
  * AI Message Component
@@ -332,7 +333,7 @@ interface MessageActionsProps {
   content: string;
 }
 
-const MessageActions: React.FC<MessageActionsProps> = ({ content }) => {
+const MessageActions: React.FC<MessageActionsProps> = React.memo(({ content }) => {
   const [copied, setCopied] = useState(false);
 
   /**
@@ -412,9 +413,10 @@ const MessageActions: React.FC<MessageActionsProps> = ({ content }) => {
       </div>
     </TooltipProvider>
   );
-};
+});
+MessageActions.displayName = 'MessageActions';
 
-const AIMessage: React.FC<AIMessageProps> = ({ content, projectId, studioAssetRewriter }) => {
+const AIMessage: React.FC<AIMessageProps> = React.memo(({ content, projectId, studioAssetRewriter }) => {
   // Parse citations from content to get citation numbers
   const { uniqueCitations, markerToNumber } = useMemo(
     () => parseCitations(content),
@@ -551,7 +553,8 @@ const AIMessage: React.FC<AIMessageProps> = ({ content, projectId, studioAssetRe
       </div>
     </div>
   );
-};
+});
+AIMessage.displayName = 'AIMessage';
 
 /**
  * Reading Beat — assistant "thinking" indicator.
@@ -750,6 +753,13 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
     setShowJumpMarker(false);
   };
 
+  // Memoize the displayable-message list so streaming deltas (which re-render
+  // this component on every token) don't re-allocate/re-filter the array.
+  const visibleMessages = useMemo(
+    () => messages.filter((msg) => msg && msg.id),
+    [messages],
+  );
+
   return (
     <div className="relative flex-1 min-h-0 min-w-0 w-full bg-white">
     <div
@@ -758,7 +768,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = React.memo(({
       className="absolute inset-0 overflow-y-auto overflow-x-hidden"
     >
       <div className="pt-6 pb-2 px-6 space-y-4 w-full">
-        {messages.filter((msg) => msg && msg.id).map((msg) => {
+        {visibleMessages.map((msg) => {
           const isUser = msg.role === 'user';
           const userPromptText = isUser ? messageContentAsText(msg.content) : '';
           return (

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -158,7 +158,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   }>({ projectName, sources: [], selectedSourceIds });
   useEffect(() => {
     keytermsSourceRef.current = { projectName, sources, selectedSourceIds };
-  });
+  }, [projectName, sources, selectedSourceIds]);
 
   // Voice recording hook. Polish always runs on stop — it's a
   // baseline UX win, not a dev/opt-in feature.

--- a/frontend/src/components/chat/SaveAsInsightButton.tsx
+++ b/frontend/src/components/chat/SaveAsInsightButton.tsx
@@ -41,7 +41,7 @@ interface Props {
   prompt: string;
 }
 
-export const SaveAsInsightButton: React.FC<Props> = ({ projectId, chatId, prompt }) => {
+export const SaveAsInsightButton: React.FC<Props> = React.memo(({ projectId, chatId, prompt }) => {
   const trimmed = prompt.trim();
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState('');
@@ -162,4 +162,5 @@ export const SaveAsInsightButton: React.FC<Props> = ({ projectId, chatId, prompt
       </Dialog>
     </>
   );
-};
+});
+SaveAsInsightButton.displayName = 'SaveAsInsightButton';

--- a/frontend/src/components/dashboard/AppSettings.tsx
+++ b/frontend/src/components/dashboard/AppSettings.tsx
@@ -140,16 +140,19 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
           {/* Content area */}
           <div className="flex-1 overflow-y-auto p-6 bg-white">
             <div className="h-full">
-              <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading…</div>}>
-                {visibleSections.map((section) => (
-                  <div
-                    key={section}
-                    className={section === activeSection ? 'h-full' : 'hidden'}
-                  >
+              {visibleSections.map((section) => (
+                <div
+                  key={section}
+                  className={section === activeSection ? 'h-full' : 'hidden'}
+                >
+                  {/* Per-section Suspense so a lazy section loading only shows a
+                      spinner inside its own (often hidden) div — it never blanks
+                      out the currently-visible section. */}
+                  <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading…</div>}>
                     {renderSection(section)}
-                  </div>
-                ))}
-              </Suspense>
+                  </Suspense>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/frontend/src/components/dashboard/AppSettings.tsx
+++ b/frontend/src/components/dashboard/AppSettings.tsx
@@ -4,7 +4,7 @@
  * Features: Profile, Team Management, API Keys, Integrations, System Settings.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, lazy, Suspense } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -12,17 +12,20 @@ import {
   DialogTitle,
 } from '../ui/dialog';
 import { SettingsSidebar, type SettingsSection } from '../settings/SettingsSidebar';
-import {
-  ProfileSection,
-  TeamSection,
-  ApiKeysSection,
-  IntegrationsSection,
-  SystemSection,
-  DesignSection,
-  ModelsSection,
-  PromptsSection,
-  LogsSection,
-} from '../settings/sections';
+
+// Settings sections are lazy-loaded from their own files (not the barrel) so the
+// heavy ones — DesignSection pulls @uiw/react-md-editor + the full refractor
+// grammar set — aren't bundled into / modulepreloaded on the dashboard. Each
+// section's code loads on first navigation to it.
+const ProfileSection = lazy(() => import('../settings/sections/ProfileSection').then((m) => ({ default: m.ProfileSection })));
+const TeamSection = lazy(() => import('../settings/sections/TeamSection').then((m) => ({ default: m.TeamSection })));
+const ApiKeysSection = lazy(() => import('../settings/sections/ApiKeysSection').then((m) => ({ default: m.ApiKeysSection })));
+const IntegrationsSection = lazy(() => import('../settings/sections/IntegrationsSection').then((m) => ({ default: m.IntegrationsSection })));
+const SystemSection = lazy(() => import('../settings/sections/SystemSection').then((m) => ({ default: m.SystemSection })));
+const DesignSection = lazy(() => import('../settings/sections/DesignSection').then((m) => ({ default: m.DesignSection })));
+const ModelsSection = lazy(() => import('../settings/sections/ModelsSection').then((m) => ({ default: m.ModelsSection })));
+const PromptsSection = lazy(() => import('../settings/sections/PromptsSection').then((m) => ({ default: m.PromptsSection })));
+const LogsSection = lazy(() => import('../settings/sections/LogsSection').then((m) => ({ default: m.LogsSection })));
 
 interface AppSettingsProps {
   open: boolean;
@@ -137,14 +140,16 @@ export const AppSettings: React.FC<AppSettingsProps> = ({
           {/* Content area */}
           <div className="flex-1 overflow-y-auto p-6 bg-white">
             <div className="h-full">
-              {visibleSections.map((section) => (
-                <div
-                  key={section}
-                  className={section === activeSection ? 'h-full' : 'hidden'}
-                >
-                  {renderSection(section)}
-                </div>
-              ))}
+              <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading…</div>}>
+                {visibleSections.map((section) => (
+                  <div
+                    key={section}
+                    className={section === activeSection ? 'h-full' : 'hidden'}
+                  >
+                    {renderSection(section)}
+                  </div>
+                ))}
+              </Suspense>
             </div>
           </div>
         </div>

--- a/frontend/src/components/project/ActiveTasksBar.tsx
+++ b/frontend/src/components/project/ActiveTasksBar.tsx
@@ -138,20 +138,25 @@ export const ActiveTasksBar: React.FC<ActiveTasksBarProps> = ({
     }
   }, [projectId]);
 
-  // Poll every 3 seconds
+  // Adaptive polling: 3s while work is in flight (a chat is sending or any
+  // task is showing), 15s when idle. The idle poll still catches tasks started
+  // elsewhere (source processing, deep research) within 15s — at which point
+  // `hasActivity` flips and the cadence speeds back up — without hammering the
+  // backend every 3s for the whole time a workspace tab sits open.
+  const hasActivity = tasks.length > 0 || (sendingChatIds?.size ?? 0) > 0;
   useEffect(() => {
     const initialTimeout = window.setTimeout(() => {
       void fetchTasks();
     }, 0);
     const intervalId = window.setInterval(() => {
       void fetchTasks();
-    }, 3000);
+    }, hasActivity ? 3000 : 15000);
 
     return () => {
       window.clearTimeout(initialTimeout);
       window.clearInterval(intervalId);
     };
-  }, [fetchTasks]);
+  }, [fetchTasks, hasActivity]);
 
   const currentIds = useMemo(() => sendingChatIds || new Set<string>(), [sendingChatIds]);
   const names = useMemo(() => chatNames || new Map<string, string>(), [chatNames]);

--- a/frontend/src/components/project/ProjectList.tsx
+++ b/frontend/src/components/project/ProjectList.tsx
@@ -103,15 +103,14 @@ export const ProjectList: React.FC<ProjectListProps> = ({
     }
   };
 
-  const handleOpenProject = async (project: Project) => {
-    try {
-      // Mark project as opened
-      await projectsAPI.open(project.id);
-      // Select the project
-      onSelectProject(project);
-    } catch (err) {
-      log.error({ err }, 'failed to open project');
-    }
+  const handleOpenProject = (project: Project) => {
+    // Navigate immediately — don't block the workspace route on the
+    // "mark as opened" POST. It only updates last_accessed (dashboard
+    // ordering), so fire-and-forget it in the background.
+    projectsAPI.open(project.id).catch((err) => {
+      log.error({ err }, 'failed to mark project opened');
+    });
+    onSelectProject(project);
   };
 
   const handleDeleteClick = (e: React.MouseEvent, projectId: string) => {

--- a/frontend/src/components/sources/SourcesPanel.tsx
+++ b/frontend/src/components/sources/SourcesPanel.tsx
@@ -112,6 +112,12 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
   const selectedSourceIdsRef = useRef(selectedSourceIds);
   selectedSourceIdsRef.current = selectedSourceIds;
 
+  // Ref to the latest sources so the fixed-cadence Freshdesk interval can read
+  // them without depending on `sources` (which would tear down/recreate the
+  // 15-min timer on every 3s status poll).
+  const sourcesRef = useRef(sources);
+  sourcesRef.current = sources;
+
   /**
    * Load sources from API (with loading state for initial load)
    */
@@ -166,7 +172,7 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     const FRESHDESK_SYNC_INTERVAL = 15 * 60 * 1000; // 15 minutes
 
     const interval = setInterval(async () => {
-      const freshdeskSources = sources.filter(
+      const freshdeskSources = sourcesRef.current.filter(
         (s) => s.status === 'ready' &&
           ((s.embedding_info as Record<string, string>)?.file_extension || '') === '.freshdesk'
       );
@@ -181,8 +187,9 @@ export const SourcesPanel: React.FC<SourcesPanelProps> = ({
     }, FRESHDESK_SYNC_INTERVAL);
 
     return () => clearInterval(interval);
+  // Fixed 15-min cadence keyed only on project; reads latest sources via ref.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectId, sources.length]);
+  }, [projectId]);
 
   /**
    * Detect when sources transition to "ready" status

--- a/frontend/src/lib/api/sources.ts
+++ b/frontend/src/lib/api/sources.ts
@@ -207,20 +207,46 @@ export function getViewKind(source: Source): SourceViewKind {
   return 'markdown';
 }
 
+// Coalesce concurrent listSources calls: SourcesPanel and ChatPanel both fetch
+// the source list on workspace mount within milliseconds of each other. A short
+// shared-promise window collapses that to one request. The window (2s) is below
+// the 3s status-poll cadence, so polls still get fresh data; mutations refetch
+// well after the window. Mirrors src/lib/api/studio/jobGroups.ts.
+interface CachedSources {
+  fetchedAt: number;
+  promise?: Promise<Source[]>;
+  sources?: Source[];
+}
+const sourcesCache = new Map<string, CachedSources>();
+const SOURCES_CACHE_MS = 2000;
+
 class SourcesAPI {
   /**
    * List all sources for a project
    */
   async listSources(projectId: string): Promise<Source[]> {
-    try {
-      const response = await axios.get(
-        `${API_BASE_URL}/projects/${projectId}/sources`
-      );
-      return response.data.sources;
-    } catch (error) {
-      log.error({ err: error }, 'failed to fetch sources');
-      throw error;
+    const cached = sourcesCache.get(projectId);
+    const now = Date.now();
+    if (cached?.sources && now - cached.fetchedAt < SOURCES_CACHE_MS) {
+      return cached.sources;
     }
+    if (cached?.promise) {
+      return cached.promise;
+    }
+    const promise = axios
+      .get(`${API_BASE_URL}/projects/${projectId}/sources`)
+      .then((response) => {
+        const sources: Source[] = response.data.sources;
+        sourcesCache.set(projectId, { fetchedAt: Date.now(), sources });
+        return sources;
+      })
+      .catch((error) => {
+        sourcesCache.delete(projectId);
+        log.error({ err: error }, 'failed to fetch sources');
+        throw error;
+      });
+    sourcesCache.set(projectId, { fetchedAt: now, promise });
+    return promise;
   }
 
   /**

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -34,6 +34,21 @@ export default defineConfig({
           }
           if (id.includes('@radix-ui')) return 'radix-vendor'
           if (id.includes('@phosphor-icons')) return 'icons-vendor'
+          // The markdown/syntax-highlight stack (react-markdown + the full
+          // refractor grammar set, ~1MB) and the graph-layout libs are only
+          // used inside lazy routes (chat / studio / brand settings). Pin them
+          // to their own chunks so Rollup doesn't hoist them into the eager
+          // entry — keeps first paint small. (Measured: entry 560KB→165KB gz.)
+          if (
+            /[\\/]node_modules[\\/](refractor|rehype-[^/]+|remark-[^/]+|react-markdown|micromark[^/]*|mdast-[^/]+|hast-[^/]+|@uiw[\\/]react-md(arkdown)?[^/]*|parse5|property-information|character-entities[^/]*|unified|vfile[^/]*|unist-[^/]+)[\\/]/.test(
+              id,
+            )
+          ) {
+            return 'markdown-vendor'
+          }
+          if (/[\\/]node_modules[\\/](dagre|graphlib|lodash)[\\/]/.test(id)) {
+            return 'graph-vendor'
+          }
         },
       },
     },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
           ) {
             return 'markdown-vendor'
           }
-          if (/[\\/]node_modules[\\/](dagre|graphlib|lodash)[\\/]/.test(id)) {
+          if (/[\\/]node_modules[\\/](dagre|graphlib)[\\/]/.test(id)) {
             return 'graph-vendor'
           }
         },


### PR DESCRIPTION
Performance pass — faster initial load, faster runtime, fewer backend round-trips. All behavior-preserving; 399 backend tests pass, frontend tsc/lint/build green.

## Initial load
- **Eager entry chunk 560KB → 48KB gzip (−91%)**. `manualChunks` was letting ~1MB of refractor grammars + the markdown stack hoist into the entry. Fixed by pinning markdown/graph vendors to their own chunks, lazy-loading settings sections in `AppSettings`, and importing `CreateProjectDialog` from its file instead of the dashboard barrel (the barrel dragged Dashboard+AppSettings into eager, defeating their `lazy()`).

## Runtime / render
- `React.memo` on `AIMessage`/`UserMessage`/`MessageActions`/`SaveAsInsightButton` + memoized message-list filter — streaming no longer re-parses every prior message's markdown on each token.
- Adaptive `/active-tasks` polling (3s active, 15s idle) instead of unconditional 3s forever.
- Fixed Freshdesk 15-min interval churning every 3s; fixed a dep-less effect firing each keystroke; fire-and-forget `project.open()` (don't block navigation); coalesced the duplicate `listSources` fetch on workspace open.

## Backend latency
- Prompt/config JSON now mtime-cached (was re-read+parsed from disk on every AI call; self-invalidates on admin edit).
- User permissions fetched once per turn (was up to 7 identical DB queries).
- Active sources fetched once per turn (was twice).
- `get_project` writes `last_accessed` only when stale (>5 min) — removes a serial write RTT from the read path.

## Explicitly NOT changed (regression safety)
- Kept `get_messages`' chat-existence check — it enforces the chat→project boundary (the messages query is scoped only by chat_id), so removing it would be a cross-project access regression.

More deferred optimizations (chat virtualization, project-access TTL cache, scheduler worker-gating, get_chat_meta, sources column projection) are being added to this branch in follow-up commits.